### PR TITLE
[#143] Set the tag of the docker images to use

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -4,6 +4,8 @@ import org.testcontainers.containers.Db2Container;
 
 public class DB2Database {
 
+	public final static String IMAGE_NAME = "ibmcom/db2:11.5.0.0a";
+
 	/**
 	 * Holds configuration for the DB2 database contianer. If the build is run with <code>-Pdocker</code> then
 	 * Testcontianers+Docker will be used.
@@ -11,7 +13,7 @@ public class DB2Database {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	  static final Db2Container db2 = new Db2Container()
+	static final Db2Container db2 = new Db2Container( IMAGE_NAME )
 		      .withUsername(DatabaseConfiguration.USERNAME)
 		      .withPassword(DatabaseConfiguration.PASSWORD)
 		      .withDatabaseName(DatabaseConfiguration.DB_NAME)

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -2,6 +2,8 @@ package org.hibernate.reactive.containers;
 
 public class MySQLDatabase {
 
+	public final static String IMAGE_NAME = "mysql:8";
+
 	/**
 	 * Holds configuration for the MySQL database contianer. If the build is run with <code>-Pdocker</code> then
 	 * Testcontianers+Docker will be used.
@@ -9,7 +11,7 @@ public class MySQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final VertxMySqlContainer mysql = new VertxMySqlContainer()
+	public static final VertxMySqlContainer mysql = new VertxMySqlContainer( IMAGE_NAME )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -4,6 +4,8 @@ import org.testcontainers.containers.PostgreSQLContainer;
 
 public class PostgreSQLDatabase {
 
+	public final static String IMAGE_NAME = "postgres:12-alpine";
+
 	/**
 	 * Holds configuration for the PostgreSQL database contianer. If the build is run with <code>-Pdocker</code> then
 	 * Testcontianers+Docker will be used.
@@ -11,7 +13,7 @@ public class PostgreSQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>("postgres:12-alpine")
+	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>( IMAGE_NAME )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
@@ -21,8 +21,14 @@ import io.vertx.sqlclient.SqlConnection;
  * by default.
  */
 public class VertxMySqlContainer extends MySQLContainer<VertxMySqlContainer> {
-	
-    @Override
+
+	public final static String IMAGE_NAME = "mysql:8";
+
+	public VertxMySqlContainer(String dockerImageName) {
+		super( dockerImageName );
+	}
+
+	@Override
     protected void waitUntilContainerStarted() {
         logger().info( "Waiting for database connection to become available at {} using query '{}'", getVertxUrl(), getTestQueryString());
 

--- a/podman.md
+++ b/podman.md
@@ -16,7 +16,7 @@ These are the credentials used to connect to the dbs:
 
 * Server
 ```
-  sudo podman run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name HibernateTestingPGSQL -e POSTGRES_USER=hreact -e POSTGRES_PASSWORD=hreact -e POSTGRES_DB=hreact -p 5432:5432 postgres
+  sudo podman run --ulimit memlock=-1:-1 -it --rm=true --memory-swappiness=0 --name HibernateTestingPGSQL -e POSTGRES_USER=hreact -e POSTGRES_PASSWORD=hreact -e POSTGRES_DB=hreact -p 5432:5432 postgres:12
 ```
 
 * CLI
@@ -30,7 +30,7 @@ These are the credentials used to connect to the dbs:
 
 * Server
 ```
-  sudo podman run --rm -it --name HibernateTestingMariaDB -e MYSQL_ROOT_PASSWORD=hreact -e MYSQL_DATABASE=hreact -e MYSQL_USER=hreact -e MYSQL_PASSWORD=hreact -p 3306:3306 mysql
+  sudo podman run --rm -it --name HibernateTestingMariaDB -e MYSQL_ROOT_PASSWORD=hreact -e MYSQL_DATABASE=hreact -e MYSQL_USER=hreact -e MYSQL_PASSWORD=hreact -p 3306:3306 mysql:8
 ```
 
 * CLI
@@ -44,7 +44,7 @@ These are the credentials used to connect to the dbs:
 
 * Server
 ```
-sudo podman run --rm -it -e LICENSE=accept --privileged=true --name HibernateTestingDB2 -e DBNAME=hreact -e DB2INSTANCE=hreact -e DB2INST1_PASSWORD=hreact -p 50000:50000 ibmcom/db2
+sudo podman run --rm -it -e LICENSE=accept --privileged=true --name HibernateTestingDB2 -e DBNAME=hreact -e DB2INSTANCE=hreact -e DB2INST1_PASSWORD=hreact -p 50000:50000 ibmcom/db2:1.5.0.0a
 ```
 
 * CLI


### PR DESCRIPTION
  Otherwise we rely on whatever version TestContainer uses as default
  and it's not always the latest or could change between updates.

  I decided to use the family version where available but we might
  want to change this in the future and use the exact version to be
  extra safe.