### PR TITLE
add SessionFactory.createSession()

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -756,9 +756,25 @@ public interface Mutiny {
 	interface SessionFactory extends AutoCloseable {
 
 		/**
-		 * Obtain a new {@link Session reactive session}, the
-		 * main interaction point between the user's program and
-		 * Hibernate Reactive.
+		 * Obtain a new {@link Session reactive session}, the main
+		 * interaction point between the user's program and Hibernate
+		 * Reactive.
+		 *
+		 * The underlying database connection is obtained lazily
+		 * when the returned {@link Session} needs to access the
+		 * database.
+		 *
+		 * The client must close the session using {@link Session#close()}.
+		 */
+		Session createSession();
+
+		/**
+		 * Obtain a new {@link Session reactive session}, the main
+		 * interaction point between the user's program and Hibernate
+		 * Reactive.
+		 *
+		 * The underlying database connection is obtained before the
+		 * {@link Session} is returned via a {@link Uni}.
 		 *
 		 * The client must close the session using {@link Session#close()}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -32,6 +32,19 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory {
 	}
 
 	@Override
+	public Mutiny.Session createSession() {
+		ReactiveConnectionPool pool = delegate.getServiceRegistry()
+				.getService(ReactiveConnectionPool.class);
+		return new MutinySessionImpl(
+				new ReactiveSessionImpl(
+						delegate,
+						new SessionFactoryImpl.SessionBuilderImpl<>(delegate),
+						pool.getProxyConnection()
+				)
+		);
+	}
+
+	@Override
 	public Uni<Mutiny.Session> openSession() throws HibernateException {
 		ReactiveConnectionPool pool = delegate.getServiceRegistry()
 				.getService(ReactiveConnectionPool.class);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
@@ -31,8 +31,16 @@ import java.util.concurrent.CompletionStage;
 public interface ReactiveConnectionPool extends Service {
 
 	/**
-	 * Obtain a reactive connection.
+	 * Obtain a reactive connection, returning the connection
+	 * via a {@link CompletionStage}.
 	 */
 	CompletionStage<ReactiveConnection> getConnection();
+
+	/**
+	 * Obtain a lazily-initializing reactive connection. The
+	 * actual connection might be made when the returned
+	 * instance if {@link ReactiveConnection} is first used.
+	 */
+	ReactiveConnection getProxyConnection();
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -757,9 +757,25 @@ public interface Stage {
 	interface SessionFactory extends AutoCloseable {
 
 		/**
-		 * Obtain a new {@link Session reactive session}, the
-		 * main interaction point between the user's program and
-		 * Hibernate Reactive.
+		 * Obtain a new {@link Session reactive session}, the main
+		 * interaction point between the user's program and Hibernate
+		 * Reactive.
+		 *
+		 * The underlying database connection is obtained lazily
+		 * when the returned {@link Session} needs to access the
+		 * database.
+		 *
+		 * The client must close the session using {@link Session#close()}.
+		 */
+		Session createSession();
+
+		/**
+		 * Obtain a new {@link Session reactive session}, the main
+		 * interaction point between the user's program and Hibernate
+		 * Reactive.
+		 *
+		 * The underlying database connection is obtained before the
+		 * {@link Session} is returned via a {@link CompletionStage}.
 		 *
 		 * The client must close the session using {@link Session#close()}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
@@ -32,6 +32,19 @@ public class StageSessionFactoryImpl implements Stage.SessionFactory {
 	}
 
 	@Override
+	public Stage.Session createSession() {
+		ReactiveConnectionPool pool = delegate.getServiceRegistry()
+				.getService(ReactiveConnectionPool.class);
+		return new StageSessionImpl(
+				new ReactiveSessionImpl(
+						delegate,
+						new SessionFactoryImpl.SessionBuilderImpl<>(delegate),
+						pool.getProxyConnection()
+				)
+		);
+	}
+
+	@Override
 	public CompletionStage<Stage.Session> openSession() throws HibernateException {
 		ReactiveConnectionPool pool = delegate.getServiceRegistry()
 				.getService(ReactiveConnectionPool.class);

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -120,6 +120,14 @@ public abstract class BaseReactiveTest {
 		return sessionFactory.unwrap( Stage.SessionFactory.class );
 	}
 
+	protected Stage.Session createSession() {
+		if ( session != null && session.isOpen() ) {
+			session.close();
+		}
+		session = getSessionFactory().createSession();
+		return session;
+	}
+
 	protected CompletionStage<Stage.Session> openSession() {
 		if ( session != null && session.isOpen() ) {
 			session.close();


### PR DESCRIPTION
This is a request from @aguibert.

Currently `SessionFactory.openSession()` returns a `CompletionStage`. This would add an additional operation that gives you a `Session` with no `CompletionStage`, fetching the database connection lazily.

Would like some feedback on this issue.