### PR TITLE
120 query parameter support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
 
     repositories {
         // Only enable these for local development, never push it:
-        // mavenLocal()
+        mavenLocal()
         // jcenter()
         mavenCentral()
     }
@@ -30,7 +30,7 @@ subprojects {
 // ./gradlew clean build -PhibernateOrmVersion=5.4.9-SNAPSHOT
 
 ext {
-    hibernateOrmVersion = '5.4.16.Final'
+    hibernateOrmVersion = '5.5.0-SNAPSHOT'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ subprojects {
 
     repositories {
         // Only enable these for local development, never push it:
-        mavenLocal()
+        // mavenLocal()
         // jcenter()
         mavenCentral()
     }
@@ -30,7 +30,7 @@ subprojects {
 // ./gradlew clean build -PhibernateOrmVersion=5.4.9-SNAPSHOT
 
 ext {
-    hibernateOrmVersion = '5.5.0-SNAPSHOT'
+    hibernateOrmVersion = '5.4.16.Final'
 }
 
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
@@ -7,31 +7,53 @@ package org.hibernate.reactive.adaptor.impl;
 
 import org.hibernate.JDBCException;
 import org.hibernate.engine.spi.QueryParameters;
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.type.Type;
 
+import java.io.Serializable;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
 public class QueryParametersAdaptor {
 
-	public static Object[] toParameterArray(QueryParameters queryParameters, SessionImplementor session) {
-		PreparedStatementAdaptor adaptor = new PreparedStatementAdaptor();
-		Type[] types = queryParameters.getPositionalParameterTypes();
-		Object[] values = queryParameters.getPositionalParameterValues();
-		int n = 1;
-		for (int i = 0; i < types.length; i++) {
-			Type type = types[i];
-			Object value = values[i];
-			try {
-				type.nullSafeSet(adaptor, value, n, session);
-				n += type.getColumnSpan( session.getSessionFactory() );
-			}
-			catch (SQLException e) {
-				//can never happen
-				throw new JDBCException("error binding parameters", e);
-			}
-		}
-		return adaptor.getParametersAsArray();
+	public static Object[] toIdParameterArray(
+			final Serializable id,
+			final Type type,
+			final SharedSessionContractImplementor session) {
+		return toParameterArray( preparedStatement -> type.nullSafeSet( preparedStatement, id, 1, session ) );
 	}
 
+
+	public static Object[] toParameterArray(QueryParameters queryParameters, SharedSessionContractImplementor session) {
+
+		return toParameterArray(
+				preparedStatement -> {
+					Type[] types = queryParameters.getPositionalParameterTypes();
+					Object[] values = queryParameters.getPositionalParameterValues();
+					int n = 1;
+					for (int i = 0; i < types.length; i++) {
+						Type type = types[i];
+						Object value = values[i];
+							type.nullSafeSet(preparedStatement, value, n, session);
+							n += type.getColumnSpan(session.getFactory());
+					}
+				}
+		);
+	}
+
+	public static Object[] toParameterArray(Binder binder) {
+		PreparedStatementAdaptor adaptor = new PreparedStatementAdaptor();
+		try {
+			binder.bind( adaptor );
+			return adaptor.getParametersAsArray();
+		}
+		catch (SQLException e) {
+			//can never happen
+			throw new JDBCException("error binding parameters", e);
+		}
+	}
+
+	public interface Binder {
+		void bind(PreparedStatement preparedStatement) throws SQLException;
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
@@ -17,6 +17,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.spi.AfterLoadAction;
+import org.hibernate.reactive.adaptor.impl.QueryParametersAdaptor;
 import org.hibernate.reactive.engine.impl.ReactivePersistenceContextAdapter;
 import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.transform.ResultTransformer;
@@ -168,4 +169,7 @@ public interface ReactiveLoader {
 	 */
 	default void discoverTypes(QueryParameters queryParameters, ResultSet resultSet) {}
 
+	default Object[] toParameterArray(QueryParameters queryParameters, SharedSessionContractImplementor session) {
+		return QueryParametersAdaptor.toParameterArray( queryParameters, session );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/hql/impl/ReactiveQueryLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/hql/impl/ReactiveQueryLoader.java
@@ -6,21 +6,28 @@
 package org.hibernate.reactive.loader.hql.impl;
 
 import org.hibernate.HibernateException;
+import org.hibernate.JDBCException;
+import org.hibernate.LockOptions;
 import org.hibernate.QueryException;
 import org.hibernate.cache.spi.QueryKey;
 import org.hibernate.cache.spi.QueryResultsCache;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.pagination.LimitHandler;
+import org.hibernate.dialect.pagination.LimitHelper;
 import org.hibernate.engine.spi.*;
 import org.hibernate.hql.internal.ast.QueryTranslatorImpl;
 import org.hibernate.hql.internal.ast.tree.SelectClause;
 import org.hibernate.loader.hql.QueryLoader;
 import org.hibernate.loader.spi.AfterLoadAction;
-import org.hibernate.reactive.adaptor.impl.QueryParametersAdaptor;
+import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
 import org.hibernate.reactive.loader.CachingReactiveLoader;
 import org.hibernate.reactive.sql.impl.Parameters;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
@@ -91,9 +98,7 @@ public class ReactiveQueryLoader extends QueryLoader implements CachingReactiveL
 		final ResultSet resultSetPreprocessed = preprocessResultSet(
 				rs,
 				rowSelection,
-				getLimitHandler( rowSelection ),
-				queryParameters.hasAutoDiscoverScalarTypes(),
-				session
+				getLimitHandler( rowSelection )
 		);
 		return super.processResultSet(resultSetPreprocessed, queryParameters, session, returnProxies,
 				forcedResultTransformer, maxRows, afterLoadActions);
@@ -147,13 +152,103 @@ public class ReactiveQueryLoader extends QueryLoader implements CachingReactiveL
 
 	@Override
 	public Object[] toParameterArray(QueryParameters queryParameters, SharedSessionContractImplementor session) {
-		return QueryParametersAdaptor.toParameterArray( preparedStatement ->
-				bindPreparedStatement(
-						preparedStatement,
-						queryParameters,
-						getLimitHandler(queryParameters.getRowSelection()),
-						session
-				)
-		);
+		PreparedStatementAdaptor adaptor = new PreparedStatementAdaptor();
+		try {
+			bindPreparedStatement(
+					adaptor,
+					queryParameters,
+					getLimitHandler(queryParameters.getRowSelection()),
+					session
+			);
+			return adaptor.getParametersAsArray();
+		}
+		catch (SQLException e) {
+				//can never happen
+				throw new JDBCException("error binding parameters", e);
+		}
 	}
+
+	/**
+	 * This is based on private method,
+	 * {@link Loader#processResultSet(ResultSet, RowSelection, LimitHandler limitHandler, boolean, SharedSessionContractImplementor),
+	 */
+	private ResultSet preprocessResultSet(
+			ResultSet resultSet,
+			final RowSelection selection,
+			final LimitHandler limitHandler
+	) throws SQLException, HibernateException {
+		if ( !limitHandler.supportsLimitOffset()
+				|| !LimitHelper.useLimit( limitHandler, selection ) ) {
+			for (int i = 0,
+				 firstRow = LimitHelper.getFirstRow(selection);
+				 i < firstRow; i++ ) {
+				resultSet.next();
+			}
+		}
+		return resultSet;
+	}
+
+	/**
+	 * This is based on the code related to binding a PreparedStatement in {@link Loader#}prepareQueryStatement},
+	 * with modifications.
+	 */
+	private final PreparedStatement bindPreparedStatement(
+			final PreparedStatement st,
+			final QueryParameters queryParameters,
+			final LimitHandler limitHandler,
+			final SharedSessionContractImplementor session) throws SQLException, HibernateException {
+
+		final Dialect dialect = getFactory().getDialect();
+		final RowSelection selection = queryParameters.getRowSelection();
+		final boolean callable = queryParameters.isCallable();
+
+		int col = 1;
+		//TODO: can we limit stored procedures ?!
+		col += limitHandler.bindLimitParametersAtStartOfQuery( selection, st, col );
+
+		if ( callable ) {
+			col = dialect.registerResultSetOutParameter( (CallableStatement) st, col );
+		}
+
+		col += bindParameterValues( st, queryParameters, col, session );
+
+		col += limitHandler.bindLimitParametersAtEndOfQuery( selection, st, col );
+
+		limitHandler.setMaxRows( selection, st );
+
+		// no support for these options in Reactive
+//		if ( selection != null ) {
+//			if ( selection.getTimeout() != null ) {
+//				st.setQueryTimeout( selection.getTimeout() );
+//			}
+//			if ( selection.getFetchSize() != null ) {
+//				st.setFetchSize( selection.getFetchSize() );
+//			}
+//		}
+
+		// handle lock timeout...
+		LockOptions lockOptions = queryParameters.getLockOptions();
+		if ( lockOptions != null ) {
+			if ( lockOptions.getTimeOut() != LockOptions.WAIT_FOREVER ) {
+				if ( !dialect.supportsLockTimeouts() ) {
+					if ( LOG.isDebugEnabled() ) {
+						LOG.debugf(
+								"Lock timeout [%s] requested but dialect reported to not support lock timeouts",
+								lockOptions.getTimeOut()
+						);
+					}
+				}
+				else if ( dialect.isLockTimeoutParameterized() ) {
+					st.setInt( col++, lockOptions.getTimeOut() );
+				}
+			}
+		}
+
+		if ( LOG.isTraceEnabled() ) {
+			LOG.tracev( "Bound [{0}] parameters total", col );
+		}
+
+		return st;
+	}
+
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -52,6 +52,8 @@ public interface Mutiny {
 
 		Query<R> setParameter(int var1, Object var2);
 
+		Query<R> setParameter(String name, Object var2);
+
 		Query<R> setMaxResults(int maxResults);
 
 		Query<R> setFirstResult(int firstResult);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -31,6 +31,12 @@ public class MutinyQueryImpl<R> implements Mutiny.Query<R> {
 	}
 
 	@Override
+	public Mutiny.Query<R> setParameter(String name, Object var2) {
+		delegate.setParameter( name, var2 );
+		return this;
+	}
+
+	@Override
 	public Mutiny.Query<R> setMaxResults(int maxResults) {
 		delegate.setMaxResults( maxResults );
 		return this;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -18,7 +18,6 @@ import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -51,8 +50,8 @@ import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import static org.hibernate.pretty.MessageHelper.infoString;
-import static org.hibernate.reactive.adaptor.impl.QueryParametersAdaptor.toParameterArray;
 import static org.hibernate.reactive.sql.impl.Parameters.createDialectParameterGenerator;
+import static org.hibernate.reactive.adaptor.impl.QueryParametersAdaptor.toIdParameterArray;
 import static org.hibernate.reactive.sql.impl.Parameters.processParameters;
 
 /**
@@ -958,7 +957,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 				session.getFactory().getJdbcServices().getDialect()
 		);
 		Serializable id = delegate().getIdentifier( entity, session );
-		Object[] params = toParameterArray( new QueryParameters( getIdentifierType(), id ), session );
+		Object[] params = toIdParameterArray( id, getIdentifierType(), session );
 		return getReactiveConnection(session).select( sql, params )
 				.thenApply( resultSet -> !resultSet.hasNext() );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQuery.java
@@ -32,6 +32,8 @@ public interface ReactiveQuery<R> {
 
 	ReactiveQuery<R> setParameter(int position, Object value);
 
+	ReactiveQuery<R> setParameter(String name, Object value);
+
 	ReactiveQuery<R> setMaxResults(int maxResults);
 
 	ReactiveQuery<R> setFirstResult(int firstResult);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
@@ -141,6 +141,12 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R> implements Re
 	}
 
 	@Override
+	public ReactiveNativeQueryImpl<R> setParameter(String name, Object value) {
+		super.setParameter(name, value);
+		return this;
+	}
+
+	@Override
 	public ReactiveNativeQueryImpl<R> setMaxResults(int maxResults) {
 		super.setMaxResults(maxResults);
 		return this;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveQueryImpl.java
@@ -159,6 +159,12 @@ public class ReactiveQueryImpl<R> extends QueryImpl<R> implements ReactiveQuery<
 	}
 
 	@Override
+	public ReactiveQueryImpl<R> setParameter(String name, Object value) {
+		super.setParameter(name, value);
+		return this;
+	}
+
+	@Override
 	public ReactiveQueryImpl<R> setMaxResults(int maxResults) {
 		super.setMaxResults(maxResults);
 		return this;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/impl/Parameters.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/impl/Parameters.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive.sql.impl;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQL81Dialect;
 
+import java.util.StringTokenizer;
 import java.util.function.Supplier;
 
 public class Parameters {
@@ -31,7 +32,29 @@ public class Parameters {
 	 * Better to not use this approach.
 	 */
 	public static String processParameters(String sql, Dialect dialect) {
-		Supplier<String> generator = createDialectParameterGenerator(dialect);
+		final Supplier<String> generator = createDialectParameterGenerator( dialect );
+		final StringTokenizer quoteTokenizer = new StringTokenizer( sql, "'", true );
+		final StringBuilder sb = new StringBuilder();
+		int quoteCount = 0;
+		while ( quoteTokenizer.hasMoreTokens() ) {
+			final String token = quoteTokenizer.nextToken();
+				if ( token.charAt( 0 ) == '\'' ) {
+					quoteCount++;
+					sb.append( token );
+				}
+				else if ( quoteCount % 2 == 0) {
+					// if quoteCount is even, that means the token is not in a quoted string
+					sb.append( processParameters( token, generator ) );
+				}
+				else {
+					// quoteCount is odd, so token is in a quoted string.
+					sb.append( token );
+				}
+			}
+		return sb.toString();
+	}
+
+	private static String processParameters(String sql, Supplier<String> generator) {
 		for ( int i = sql.indexOf('?'); i>=0; i = sql.indexOf('?', i+1) ) {
 			sql = sql.substring(0, i) + generator.get() + sql.substring(i+1);
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -53,6 +53,8 @@ public interface Stage {
 
 		Query<R> setParameter(int var1, Object var2);
 
+		Query<R> setParameter(String name, Object var2);
+
 		Query<R> setMaxResults(int maxResults);
 
 		Query<R> setFirstResult(int firstResult);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -31,6 +31,12 @@ public class StageQueryImpl<R> implements Stage.Query<R> {
 	}
 
 	@Override
+	public Stage.Query<R> setParameter(String name, Object var2) {
+		delegate.setParameter( name, var2 );
+		return this;
+	}
+
+	@Override
 	public Stage.Query<R> setMaxResults(int maxResults) {
 		delegate.setMaxResults( maxResults );
 		return this;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
@@ -1,0 +1,246 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+/**
+ * Tests queries using named parameters like ":name",
+ * as defined by the JPA specification, along with limit parameters
+ */
+public class HQLQueryParameterNamedLimitTest extends BaseReactiveTest {
+
+	Flour spelt = new Flour( 1, "Spelt", "An ancient grain, is a hexaploid species of wheat.", "Wheat flour" );
+	Flour rye = new Flour( 2, "Rye", "Used to bake the traditional sourdough breads of Germany.", "Wheat flour" );
+	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Flour.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.persist( spelt ) )
+				.thenCompose( s -> s.persist( rye ) )
+				.thenCompose( s -> s.persist( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.remove( spelt ) )
+				.thenCompose( s -> s.remove( rye ) )
+				.thenCompose( s -> s.remove( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@Test
+	public void testNoResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour where id = :id" ).setMaxResults( 0 )
+										.setParameter( "id", rye.getId() )
+										.getResultList()
+										.thenAccept( list -> context.assertEquals( 0, list.size() ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultNoResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour" )
+										.setMaxResults( 0 )
+										.setFirstResult( 1 )
+										.getResultList()
+										.thenAccept( list -> context.assertEquals( 0, list.size() ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultSingleResult(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour where name != :name order by id" )
+										.setParameter( "name", spelt.getName() )
+										.setFirstResult( 1 )
+										.getSingleResult()
+										.thenAccept( result -> context.assertEquals( almond, result ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMultipleResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsSingleResult(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 1 )
+										.getSingleResult()
+										.thenAccept( result -> {
+											context.assertEquals( rye, result );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsMultipleResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 2 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsExtra(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 3 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Entity(name = "Flour")
+	@Table(name = "Flour")
+	public static class Flour {
+		@Id
+		private Integer id;
+		private String name;
+		private String description;
+		private String type;
+
+		public Flour() {
+		}
+
+		public Flour(Integer id, String name, String description, String type) {
+			this.id = id;
+			this.name = name;
+			this.description = description;
+			this.type = type;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Flour flour = (Flour) o;
+			return Objects.equals( name, flour.name ) &&
+					Objects.equals( description, flour.description ) &&
+					Objects.equals( type, flour.type );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name, description, type );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
@@ -1,0 +1,307 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+/**
+ * Tests queries using named parameters like ":name",
+ * as defined by the JPA specification.
+ */
+public class HQLQueryParameterNamedTest extends BaseReactiveTest {
+
+	Flour spelt = new Flour( 1, "Spelt", "An ancient grain, is a hexaploid species of wheat.", "Wheat flour" );
+	Flour rye = new Flour( 2, "Rye", "Used to bake the traditional sourdough breads of Germany.", "Wheat flour" );
+	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Flour.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.persist( spelt ) )
+				.thenCompose( s -> s.persist( rye ) )
+				.thenCompose( s -> s.persist( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.remove( spelt ) )
+				.thenCompose( s -> s.remove( rye ) )
+				.thenCompose( s -> s.remove( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@Test
+	public void testAutoFlushOnSingleResult(TestContext context) {
+		Flour semolina = new Flour( 678, "Semoline", "the coarse, purified wheat middlings of durum wheat used in making pasta.", "Wheat flour" );
+		test(
+				context,
+				openSession()
+						.thenCompose( s -> s.persist( semolina ) )
+						.thenCompose( s ->
+								s.createQuery( "from Flour where id = :id" )
+										.setParameter( "id", semolina.getId())
+										.getSingleResult()
+										.thenAccept( found -> context.assertEquals( semolina, found ) )
+										.thenCompose( v -> s.remove( semolina ) )
+										.thenAccept( ss -> ss.flush() )
+						)
+		);
+	}
+
+	@Test
+	public void testSelectScalarValues(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s ->
+								s.createQuery( "SELECT 'Prova' FROM Flour WHERE id = :id" )
+										.setParameter( "id", rye.getId() ) )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( found -> context.assertEquals( "Prova", found ) )
+		);
+	}
+
+	@Test
+	public void testSelectWithMultipleScalarValues(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s ->
+								s.createQuery( "SELECT 'Prova', f.id FROM Flour f WHERE f.id = :id" )
+										.setParameter("id", rye.getId() ))
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( found -> {
+							context.assertTrue( found instanceof Object[] );
+							context.assertEquals( "Prova", ( (Object[]) found )[0] );
+							context.assertEquals( rye.getId(), ( (Object[]) found )[1] );
+						} )
+		);
+	}
+
+	@Test
+	public void testSingleResultQueryOnId(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE id = :id" ).setParameter( "id", 1) )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( spelt, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultQueryOnName(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = :name" ).setParameter( "name", "Almond") )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParameters(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = :name and description = :desc" )
+								.setParameter( "name", almond.getName() )
+								.setParameter( "desc", almond.getDescription() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParametersReversed(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = :name and description = :desc" )
+								.setParameter( "desc", almond.getDescription() )
+								.setParameter( "name", almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParametersReused(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = :name or cast(:name as string) is null" )
+								.setParameter( "name", almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testPlaceHolderInString(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "select ':', ':name', f FROM Flour f WHERE f.name = :name" )
+								.setParameter( "name", almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( result -> {
+							context.assertEquals( Object[].class, result.getClass() );
+							final Object[] objects = (Object[]) result;
+							context.assertEquals( 3, objects.length );
+							context.assertEquals( ":", objects[0] );
+							context.assertEquals( ":name", objects[1] );
+							context.assertEquals( almond, objects[2] );
+						})
+		);
+	}
+
+	@Test
+	public void testPlaceHolderAndSingleQuoteInString(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery("select ''':', ''':name''', f FROM Flour f WHERE f.name = :name")
+								.setParameter( "name", almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( result -> {
+							context.assertEquals( Object[].class, result.getClass() );
+							final Object[] objects = (Object[]) result;
+							context.assertEquals( 3, objects.length );
+							context.assertEquals( "':", objects[0] );
+							context.assertEquals( "':name'", objects[1] );
+							context.assertEquals( almond, objects[2] );
+						})
+		);
+	}
+
+	@Entity(name = "Flour")
+	@Table(name = "Flour")
+	public static class Flour {
+		@Id
+		private Integer id;
+		private String name;
+		private String description;
+		private String type;
+
+		public Flour() {
+		}
+
+		public Flour(Integer id, String name, String description, String type) {
+			this.id = id;
+			this.name = name;
+			this.description = description;
+			this.type = type;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Flour flour = (Flour) o;
+			return Objects.equals( name, flour.name ) &&
+					Objects.equals( description, flour.description ) &&
+					Objects.equals( type, flour.type );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name, description, type );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
@@ -1,0 +1,249 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+/**
+ * Tests queries using positional parameters like "?1, ?2, ...",
+ * as defined by the JPA specification, along with limit parameters.
+ *
+ * Note that ORM treats such parameters as "named", not "positional";
+ * that should be considered an internal implementation detail.
+ */
+public class HQLQueryParameterPositionalLimitTest extends BaseReactiveTest {
+
+	Flour spelt = new Flour( 1, "Spelt", "An ancient grain, is a hexaploid species of wheat.", "Wheat flour" );
+	Flour rye = new Flour( 2, "Rye", "Used to bake the traditional sourdough breads of Germany.", "Wheat flour" );
+	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Flour.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.persist( spelt ) )
+				.thenCompose( s -> s.persist( rye ) )
+				.thenCompose( s -> s.persist( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.remove( spelt ) )
+				.thenCompose( s -> s.remove( rye ) )
+				.thenCompose( s -> s.remove( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@Test
+	public void testNoResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour where id = ?1" ).setMaxResults( 0 )
+										.setParameter( 1, rye.getId() )
+										.getResultList()
+										.thenAccept( list -> context.assertEquals( 0, list.size() ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultNoResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour" )
+										.setMaxResults( 0 )
+										.setFirstResult( 1 )
+										.getResultList()
+										.thenAccept( list -> context.assertEquals( 0, list.size() ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultSingleResult(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour where name != ?1 order by id" )
+										.setParameter( 1, spelt.getName() )
+										.setFirstResult( 1 )
+										.getSingleResult()
+										.thenAccept( result -> context.assertEquals( almond, result ) )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMultipleResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsSingleResult(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 1 )
+										.getSingleResult()
+										.thenAccept( result -> {
+											context.assertEquals( rye, result );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsMultipleResults(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 2 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Test
+	public void testFirstResultMaxResultsExtra(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenCompose( s ->
+								s.createQuery( "from Flour order by id" )
+										.setFirstResult( 1 )
+										.setMaxResults( 3 )
+										.getResultList()
+										.thenAccept( results -> {
+											context.assertEquals( 2, results.size() );
+											context.assertEquals( rye, results.get( 0 ) );
+											context.assertEquals( almond, results.get( 1 ) );
+										} )
+						)
+		);
+	}
+
+	@Entity(name = "Flour")
+	@Table(name = "Flour")
+	public static class Flour {
+		@Id
+		private Integer id;
+		private String name;
+		private String description;
+		private String type;
+
+		public Flour() {
+		}
+
+		public Flour(Integer id, String name, String description, String type) {
+			this.id = id;
+			this.name = name;
+			this.description = description;
+			this.type = type;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Flour flour = (Flour) o;
+			return Objects.equals( name, flour.name ) &&
+					Objects.equals( description, flour.description ) &&
+					Objects.equals( type, flour.type );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name, description, type );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
@@ -1,0 +1,312 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.Configuration;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import java.util.Objects;
+
+/**
+ * Tests queries using positional parameters like "?1, ?2, ...",
+ * as defined by the JPA specification.
+ *
+ * Note that ORM treats such parameters as "named", not "positional";
+ * that should be considered an internal implementation detail.
+ */
+public class HQLQueryParameterPositionalTest extends BaseReactiveTest {
+
+	Flour spelt = new Flour( 1, "Spelt", "An ancient grain, is a hexaploid species of wheat.", "Wheat flour" );
+	Flour rye = new Flour( 2, "Rye", "Used to bake the traditional sourdough breads of Germany.", "Wheat flour" );
+	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Flour.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.persist( spelt ) )
+				.thenCompose( s -> s.persist( rye ) )
+				.thenCompose( s -> s.persist( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, openSession()
+				.thenCompose( s -> s.remove( spelt ) )
+				.thenCompose( s -> s.remove( rye ) )
+				.thenCompose( s -> s.remove( almond ) )
+				.thenCompose( s -> s.flush() ) );
+	}
+
+	@Test
+	public void testAutoFlushOnSingleResult(TestContext context) {
+		Flour semolina = new Flour( 678, "Semoline", "the coarse, purified wheat middlings of durum wheat used in making pasta.", "Wheat flour" );
+		test(
+				context,
+				openSession()
+						.thenCompose( s -> s.persist( semolina ) )
+						.thenCompose( s ->
+								s.createQuery( "from Flour where id = ?1" )
+										.setParameter( 1, semolina.getId())
+										.getSingleResult()
+										.thenAccept( found -> context.assertEquals( semolina, found ) )
+										.thenCompose( v -> s.remove( semolina ) )
+										.thenAccept( ss -> ss.flush() )
+						)
+		);
+	}
+
+	@Test
+	public void testSelectScalarValues(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s ->
+								s.createQuery( "SELECT 'Prova' FROM Flour WHERE id = ?1" )
+										.setParameter( 1, rye.getId() ) )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( found -> context.assertEquals( "Prova", found ) )
+		);
+	}
+
+	@Test
+	public void testSelectWithMultipleScalarValues(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s ->
+								s.createQuery( "SELECT 'Prova', f.id FROM Flour f WHERE f.id = ?1" )
+										.setParameter(1, rye.getId() ))
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( found -> {
+							context.assertTrue( found instanceof Object[] );
+							context.assertEquals( "Prova", ( (Object[]) found )[0] );
+							context.assertEquals( rye.getId(), ( (Object[]) found )[1] );
+						} )
+		);
+	}
+
+	@Test
+	public void testSingleResultQueryOnId(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE id = ?1" ).setParameter( 1, 1) )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( spelt, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultQueryOnName(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = ?1" ).setParameter( 1, "Almond") )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParameters(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = ?1 and description = ?2" )
+								.setParameter( 1, almond.getName() )
+								.setParameter( 2, almond.getDescription() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParametersReversed(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = ?2 and description = ?1" )
+								.setParameter( 2, almond.getName() )
+								.setParameter( 1, almond.getDescription() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testSingleResultMultipleParametersReused(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "FROM Flour WHERE name = ?1 or cast(?1 as string) is null" )
+								.setParameter( 1, almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( flour -> context.assertEquals( almond, flour ) )
+		);
+	}
+
+	@Test
+	public void testPlaceHolderInString(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "select '?', '?1', f FROM Flour f WHERE f.name = ?1" )
+								.setParameter( 1, almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( result -> {
+							context.assertEquals( Object[].class, result.getClass() );
+							final Object[] objects = (Object[]) result;
+							context.assertEquals( 3, objects.length );
+							context.assertEquals( "?", objects[0] );
+							context.assertEquals( "?1", objects[1] );
+							context.assertEquals( almond, objects[2] );
+						})
+		);
+	}
+
+	@Test
+	public void testPlaceHolderAndSingleQuoteInString(TestContext context) {
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery("select '''?', '''?1''', f FROM Flour f WHERE f.name = ?1")
+								.setParameter( 1, almond.getName() )
+						)
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.getSingleResult();
+						} )
+						.thenAccept( result -> {
+							context.assertEquals( Object[].class, result.getClass() );
+							final Object[] objects = (Object[]) result;
+							context.assertEquals( 3, objects.length );
+							context.assertEquals( "'?", objects[0] );
+							context.assertEquals( "'?1'", objects[1] );
+							context.assertEquals( almond, objects[2] );
+						})
+		);
+	}
+
+
+
+	@Entity(name = "Flour")
+	@Table(name = "Flour")
+	public static class Flour {
+		@Id
+		private Integer id;
+		private String name;
+		private String description;
+		private String type;
+
+		public Flour() {
+		}
+
+		public Flour(Integer id, String name, String description, String type) {
+			this.id = id;
+			this.name = name;
+			this.description = description;
+			this.type = type;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public String getDescription() {
+			return description;
+		}
+
+		public void setDescription(String description) {
+			this.description = description;
+		}
+
+		public String getType() {
+			return type;
+		}
+
+		public void setType(String type) {
+			this.type = type;
+		}
+
+		@Override
+		public String toString() {
+			return name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Flour flour = (Flour) o;
+			return Objects.equals( name, flour.name ) &&
+					Objects.equals( description, flour.description ) &&
+					Objects.equals( type, flour.type );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name, description, type );
+		}
+	}
+}


### PR DESCRIPTION
hibernate/hibernate-reactive#120

After force-pushing, this branch no longer requires https://github.com/hibernate/hibernate-orm/pull/3420.

This works for HQL queries. Some similar changes still need to be made for native queries.

More tests are needed for native queries, filters, and criteria queries.