### PR TITLE
#163 Gradle testall task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,8 +8,8 @@ on:
     branches: master
 
 jobs:
-  test_postgresql:
-    name: Test with PostgreSQL
+  test_dbs:
+    name: Test available databases
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -20,36 +20,8 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build and Test with PostgreSQL
-      run: ./gradlew build -Pdocker -Pdb=pg
+      run: ./gradlew testAll -Pdocker
 
-  test_mysql:      
-    name: Test with MySQL
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
-    - name: Build and Test with MySQL
-      run: ./gradlew build -Pdocker -Pdb=mysql
-
-  test_db2:      
-    name: Test with DB2
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
-    - name: Build and Test with DB2
-      run: ./gradlew build -Pdocker -Pdb=db2
-      
   build_package:      
     name: Build and create maven package
     runs-on: ubuntu-latest

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -40,6 +40,15 @@ dependencies {
 def dbs = ['MySQL', 'PostgreSQL', 'DB2']
 def testTasks = []
 
+// Print a summary of the results of the tests (number of failures, successes and skipped)
+def loggingSummary(db, result, desc) {
+    if ( !desc.parent ) { // will match the outermost suite
+        def output = "${db} results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+        def repeatLength = output.length() + 1
+        println '\n' + ('-' * repeatLength) + '\n' + output + '\n' + ('-' * repeatLength)
+    }
+}
+
 // For each database create a dynamic test task
 dbs.each { db ->
     testTasks.add( "test_${db.toLowerCase()}" )
@@ -51,6 +60,9 @@ dbs.each { db ->
             showStackTraces = true
             exceptionFormat = 'full'
             events 'PASSED', 'FAILED', 'SKIPPED'
+            afterSuite { desc, result ->
+                loggingSummary( db, result, desc )
+            }
         }
         systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
         doFirst() {
@@ -63,6 +75,7 @@ task testAll( dependsOn: testTasks ) {
 }
 
 test {
+  def selectedDb = project.hasProperty( 'db' ) ? project.getProperty( 'db' ) : 'PostgreSQL'
   defaultCharacterEncoding = "UTF-8"
   testLogging {
       displayGranularity 1
@@ -70,9 +83,12 @@ test {
       showStackTraces = true
       exceptionFormat = 'full'
       events 'PASSED', 'FAILED', 'SKIPPED'
+      afterSuite { desc, result ->
+          loggingSummary( selectedDb, result, desc )
+      }
   }
-  systemProperty 'docker', project.hasProperty('docker') ? 'true' : 'false'
-  systemProperty 'db', project.hasProperty('db') ? project.getProperty('db') : 'postgresql'
+  systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
+  systemProperty 'db', selectedDb
 }
 
 spotless {

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -36,6 +36,32 @@ dependencies {
     testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
 }
 
+// Is there a way to read this from org.hibernate.reactive.containers.DatabaseConfiguration?
+def dbs = ['MySQL', 'PostgreSQL', 'DB2']
+def testTasks = []
+
+// For each database create a dynamic test task
+dbs.each { db ->
+    testTasks.add( "test_${db.toLowerCase()}" )
+    task "test_${db.toLowerCase()}"( type: Test ) {
+        defaultCharacterEncoding = "UTF-8"
+        testLogging {
+            displayGranularity 1
+            showStandardStreams = false
+            showStackTraces = true
+            exceptionFormat = 'full'
+            events 'PASSED', 'FAILED', 'SKIPPED'
+        }
+        systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
+        doFirst() {
+            systemProperty 'db', db
+        }
+    }
+}
+
+task testAll( dependsOn: testTasks ) {
+}
+
 test {
   defaultCharacterEncoding = "UTF-8"
   testLogging {


### PR DESCRIPTION
This adds a task `testAll`  to test all the selected dbs. Right now the list of available databases is in an array.

I've updated the workflow on github so that it calls the new task, but I suppose there is a trade off   with speed (test are not running in parallel like before). I don't think it makes much difference now  with 3 dbs. It's nice not having to think about the wrorkflow when we add a new db.

I haven't changed the default behaviour so it shouldn't change anything for developers. The code is not great but my knowledge with groovy and gradle is limited.