### PR TITLE
Fix #102 - publish artifacts to GitHub packages / Bintray

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,23 +61,5 @@ jobs:
         java-version: 1.8
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
-    - name: Detect the version of Hibernate Reactive
-      id: detect-version
-      run: |
-        ./gradlew hibernate-reactive-core:properties | grep '^version:' | sed -E 's/version: (.*)/::set-output name=version::\1/'
-    - name: Generate a unique version
-      id: generate-unique-version
-      env:
-        UNIQUE_VERSION: ${{ format( '{0}-{1}', steps.detect-version.outputs.version, github.sha ) }}
-      run: echo "::set-output name=version::$UNIQUE_VERSION"
     - name: Create maven package
-      env:
-        ORG_GRADLE_PROJECT_projectVersion: ${{ steps.generate-unique-version.outputs.version }}
       run: ./gradlew assemble publishToMavenLocal
-    - name: Publish to GitHub Packages (SNAPSHOT only, push only, PR excluded)
-      env:
-        ORG_GRADLE_PROJECT_projectVersion: ${{ steps.generate-unique-version.outputs.version }}
-        ORG_GRADLE_PROJECT_githubUser: ${{ github.actor }}
-        ORG_GRADLE_PROJECT_githubToken: ${{ github.token }}
-      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && github.event_name == 'push'
-      run: ./gradlew publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,15 +61,23 @@ jobs:
         java-version: 1.8
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
-    - name: Create maven package
-      run: ./gradlew assemble publishToMavenLocal
     - name: Detect the version of Hibernate Reactive
       id: detect-version
       run: |
         ./gradlew hibernate-reactive-core:properties | grep '^version:' | sed -E 's/version: (.*)/::set-output name=version::\1/'
-    - name: Publish to JBoss Nexus (SNAPSHOT only, push only, PR excluded)
+    - name: Generate a unique version
+      id: generate-unique-version
       env:
-        ORG_GRADLE_PROJECT_jbossNexusUser: ${{ secrets.jbossNexusUser }}
-        ORG_GRADLE_PROJECT_jbossNexusPassword: ${{ secrets.jbossNexusPassword }}
-      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && github.event_name == 'push' && env.ORG_GRADLE_PROJECT_jbossNexusUser
+        UNIQUE_VERSION: ${{ format( '{0}-{1}', steps.detect-version.outputs.version, github.sha ) }}
+      run: echo "::set-output name=version::$UNIQUE_VERSION"
+    - name: Create maven package
+      env:
+        ORG_GRADLE_PROJECT_projectVersion: ${{ steps.generate-unique-version.outputs.version }}
+      run: ./gradlew assemble publishToMavenLocal
+    - name: Publish to GitHub Packages (SNAPSHOT only, push only, PR excluded)
+      env:
+        ORG_GRADLE_PROJECT_projectVersion: ${{ steps.generate-unique-version.outputs.version }}
+        ORG_GRADLE_PROJECT_githubUser: ${{ github.actor }}
+        ORG_GRADLE_PROJECT_githubToken: ${{ github.token }}
+      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && github.event_name == 'push'
       run: ./gradlew publish

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,12 +62,14 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Create maven package
-      run: ./gradlew assemble publishToMavenLocal 
-
-    # The USERNAME and TOKEN need to correspond to the credentials environment variables used in
-    # the publishing section of your build.gradle
-    #- name: Publish to GitHub Packages
-    #  run: gradle publish
-    #  env:
-    #    USERNAME: ${{ github.actor }}
-    #    TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: ./gradlew assemble publishToMavenLocal
+    - name: Detect the version of Hibernate Reactive
+      id: detect-version
+      run: |
+        ./gradlew hibernate-reactive-core:properties | grep '^version:' | sed -E 's/version: (.*)/::set-output name=version::\1/'
+    - name: Publish to JBoss Nexus (SNAPSHOT only, push only, PR excluded)
+      env:
+        ORG_GRADLE_PROJECT_jbossNexusUser: ${{ secrets.jbossNexusUser }}
+        ORG_GRADLE_PROJECT_jbossNexusPassword: ${{ secrets.jbossNexusPassword }}
+      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && github.event_name == 'push' && env.ORG_GRADLE_PROJECT_jbossNexusUser
+      run: ./gradlew publish

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@
 */**/target
 /build
 */build
+*/src/main/generated
+*/src/test/generated
 
 # IntelliJ specific files/directories
 out

--- a/build.gradle
+++ b/build.gradle
@@ -6,11 +6,16 @@ plugins {
     id 'com.jfrog.bintray' version '1.8.5' apply false
 }
 
+ext {
+    // Needs to be overridden when publishing SNAPSHOT versions to GitHub Packages
+    projectVersion = '1.0.0-SNAPSHOT'
+}
+
 subprojects {
     apply plugin: 'java-library'
     apply plugin: 'com.diffplug.gradle.spotless'
     group = 'org.hibernate.reactive'
-    version = '1.0.0-SNAPSHOT'
+    version = projectVersion
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
     compileJava.options.encoding = 'UTF-8'

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java-library'
     id 'maven-publish'
     id 'com.diffplug.gradle.spotless' version '4.0.1'
+    id 'nu.studer.credentials' version '2.1' apply false
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,7 @@ plugins {
     id 'maven-publish'
     id 'com.diffplug.gradle.spotless' version '4.0.1'
     id 'nu.studer.credentials' version '2.1' apply false
+    id 'com.jfrog.bintray' version '1.8.5' apply false
 }
 
 subprojects {

--- a/publish.gradle
+++ b/publish.gradle
@@ -91,12 +91,12 @@ publishing {
                 url = 'https://github.com/hibernate/hibernate-reactive'
                 organization {
                     name = 'Hibernate.org'
-                    url = 'http://hibernate.org'
+                    url = 'https://hibernate.org'
                 }
                 licenses {
                     license {
                         name = 'GNU Library General Public License v2.1 or later'
-                        url = 'http://www.opensource.org/licenses/LGPL-2.1'
+                        url = 'https://opensource.org/licenses/LGPL-2.1'
                         comments = 'See discussion at http://hibernate.org/community/license/ for more details.'
                         distribution = 'repo'
                     }
@@ -115,7 +115,7 @@ publishing {
                         id = 'hibernate-team'
                         name = 'The Hibernate Development Team'
                         organization = 'Hibernate.org'
-                        organizationUrl = 'http://hibernate.org'
+                        organizationUrl = 'https://hibernate.org'
                     }
                 }
             }

--- a/publish.gradle
+++ b/publish.gradle
@@ -10,6 +10,29 @@ task javadocJar(type: Jar) {
     archiveClassifier = 'javadoc'
 }
 
+jar {
+    manifest {
+        attributes(
+                // Basic JAR manifest attributes
+                'Specification-Title': project.name,
+                'Specification-Version': project.version,
+                'Specification-Vendor': 'Hibernate.org',
+                'Implementation-Title': project.name,
+                'Implementation-Version': project.version,
+                'Implementation-Vendor': 'Hibernate.org',
+                'Implementation-Vendor-Id': 'org.hibernate',
+                'Implementation-Url': 'http://hibernate.org/reactive',
+        )
+    }
+}
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+    options.addStringOption('Xdoclint:none', '-quiet')
+}
+
 publishing {
     repositories {
         mavenLocal()
@@ -57,27 +80,4 @@ publishing {
             }
         }
     }
-}
-
-jar {
-    manifest {
-        attributes(
-                // Basic JAR manifest attributes
-                'Specification-Title': project.name,
-                'Specification-Version': project.version,
-                'Specification-Vendor': 'Hibernate.org',
-                'Implementation-Title': project.name,
-                'Implementation-Version': project.version,
-                'Implementation-Vendor': 'Hibernate.org',
-                'Implementation-Vendor-Id': 'org.hibernate',
-                'Implementation-Url': 'http://hibernate.org/reactive',
-        )
-    }
-}
-
-javadoc {
-    if(JavaVersion.current().isJava9Compatible()) {
-        options.addBooleanOption('html5', true)
-    }
-    options.addStringOption('Xdoclint:none', '-quiet')
 }

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,4 +1,21 @@
 apply plugin: 'maven-publish'
+apply plugin: 'nu.studer.credentials'
+
+// To publish snapshots:
+//  ./gradlew publish -PjbossNexusUser="<YOUR USERNAME>" -PjbossNexusPassword="<YOUR PASSWORD>"
+
+ext {
+    // Credentials can be specified on the command-line using project properties,
+    // or stored locally using the gradle-credentials-plugin.
+    // See below for the name of project properties.
+    // See https://github.com/etiennestuder/gradle-credentials-plugin to store credentials locally.
+    if (!project.hasProperty('jbossNexusUser')) {
+        jbossNexusUser = credentials.jbossNexusUser
+    }
+    if (!project.hasProperty('jbossNexusPassword')) {
+        jbossNexusPassword = credentials.jbossNexusPassword
+    }
+}
 
 task sourcesJar(type: Jar) {
     from sourceSets.main.allJava
@@ -36,6 +53,14 @@ javadoc {
 publishing {
     repositories {
         mavenLocal()
+        maven {
+            name 'jboss-snapshots-repository'
+            url 'https://repository.jboss.org/nexus/content/repositories/snapshots'
+            credentials {
+                username project.jbossNexusUser
+                password project.jbossNexusPassword
+            }
+        }
     }
     publications {
         publishedArtifacts(MavenPublication) {

--- a/publish.gradle
+++ b/publish.gradle
@@ -38,7 +38,7 @@ publishing {
         mavenLocal()
     }
     publications {
-        mavenJava(MavenPublication) {
+        publishedArtifacts(MavenPublication) {
             groupId = project.group
             version = project.version
             from components.java

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,7 @@ apply plugin: 'nu.studer.credentials'
 apply plugin: 'com.jfrog.bintray'
 
 // To publish snapshots:
-//  ./gradlew publish -PjbossNexusUser="<YOUR USERNAME>" -PjbossNexusPassword="<YOUR PASSWORD>"
+//  ./gradlew publish -PgithubUser="<YOUR USERNAME>" -PgithubToken="<YOUR TOKEN>"
 // To release:
 //  1. Update the version, changelog, etc.
 //  2. Commit.
@@ -19,11 +19,11 @@ ext {
     // or stored locally using the gradle-credentials-plugin.
     // See below for the name of project properties.
     // See https://github.com/etiennestuder/gradle-credentials-plugin to store credentials locally.
-    if (!project.hasProperty('jbossNexusUser')) {
-        jbossNexusUser = credentials.jbossNexusUser
+    if (!project.hasProperty('githubUser')) {
+        githubUser = credentials.githubUser
     }
-    if (!project.hasProperty('jbossNexusPassword')) {
-        jbossNexusPassword = credentials.jbossNexusPassword
+    if (!project.hasProperty('githubToken')) {
+        githubToken = credentials.githubToken
     }
     if (!project.hasProperty('bintrayUser')) {
         bintrayUser = credentials.bintrayUser
@@ -70,11 +70,11 @@ publishing {
     repositories {
         mavenLocal()
         maven {
-            name 'jboss-snapshots-repository'
-            url 'https://repository.jboss.org/nexus/content/repositories/snapshots'
+            name 'github-packages-repository'
+            url 'https://maven.pkg.github.com/hibernate/hibernate-reactive'
             credentials {
-                username project.jbossNexusUser
-                password project.jbossNexusPassword
+                username project.githubUser
+                password project.githubToken
             }
         }
     }

--- a/publish.gradle
+++ b/publish.gradle
@@ -1,8 +1,18 @@
 apply plugin: 'maven-publish'
 apply plugin: 'nu.studer.credentials'
+apply plugin: 'com.jfrog.bintray'
 
 // To publish snapshots:
 //  ./gradlew publish -PjbossNexusUser="<YOUR USERNAME>" -PjbossNexusPassword="<YOUR PASSWORD>"
+// To release:
+//  1. Update the version, changelog, etc.
+//  2. Commit.
+//  3. Tag the release.
+//     > git tag -a -m "Release $RELEASE_VERSION" "$RELEASE_VERSION"
+//  4. Push the tag to the repository.
+//     > git push <REMOTE> "$RELEASE_VERSION"
+//  5. Publish:
+//     > ./gradlew bintrayUpload -PbintrayUser="<YOUR USERNAME>" -PbintrayKey="<YOUR API KEY>"
 
 ext {
     // Credentials can be specified on the command-line using project properties,
@@ -14,6 +24,12 @@ ext {
     }
     if (!project.hasProperty('jbossNexusPassword')) {
         jbossNexusPassword = credentials.jbossNexusPassword
+    }
+    if (!project.hasProperty('bintrayUser')) {
+        bintrayUser = credentials.bintrayUser
+    }
+    if (!project.hasProperty('bintrayKey')) {
+        bintrayKey = credentials.bintrayKey
     }
 }
 
@@ -102,6 +118,33 @@ publishing {
                         organizationUrl = 'http://hibernate.org'
                     }
                 }
+            }
+        }
+    }
+}
+
+bintray {
+    user = project.bintrayUser
+    key = project.bintrayKey
+
+    publications = ['publishedArtifacts']
+
+    pkg {
+        userOrg = 'hibernate'
+        repo = 'artifacts'
+        name = 'hibernate-reactive'
+
+        publish = true
+
+        version {
+            name = project.version
+            released = new Date()
+            vcsTag = project.version
+            gpg {
+                sign = true
+            }
+            mavenCentralSync {
+                sync = true
             }
         }
     }


### PR DESCRIPTION
This adds support for:

* Publishing actual releases to Bintray
* Publishing snapshots to GitHub Packages
* Publishing snapshots after every build on master

Bintray doesn't accept snapshot artifacts, so even if it's our platform of choice for artifacts that need to be synced to Maven Central, we need another one for snapshots.

You can find an example of what Bintray releases look like here: https://bintray.com/yrodiere/hibernate-release-testing/hibernate-reactive/0.0.1
I included instructions for releasing in the file `publish.gradle`.

I decided not to publish snpashots to JBoss Nexus, because it silently rejects some artifacts (accepts the upload, but does not display them in the repository afterwards). I didn't find a way to debug this: there's absolutely no feedback from the Nexus server and no way to know what the rules for rejecting artifacts are.

GitHub Packages accepts snapshot artifacts, but:

1. They are not kept separate from actual releases in the web interface, and there's apparently no way to do so.
2. They need to have a unique version number and they cannot be deleted, ever. So reusing "1.0.0-SNAPSHOT" for every snapshot cannot work, we need to assign a unique version number (based on the commit SHA) to every snapshot artifact.

You can find an example of what GitHub Packages releases look like here: https://github.com/yrodiere/hibernate-reactive/packages/244270?version=1.0.0-SNAPSHOT-e822255088ce1382cb103123f114404dbe26547e
I included instructions for publishing snapshots in the file `publish.gradle`.

