### PR TITLE
use static methods for more robust exception handling

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveAutoFlushEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveAutoFlushEventListener.java
@@ -69,7 +69,7 @@ public class DefaultReactiveAutoFlushEventListener extends AbstractReactiveFlush
 		}
 		autoFlushStage.whenComplete( (v, x) -> {
 			source.getEventListenerManager().flushEnd( event.getNumberOfEntitiesProcessed(), event.getNumberOfCollectionsProcessed() );
-			CompletionStages.rethrowIfNotNull( x );
+			CompletionStages.returnNullorRethrow( x );
 		} );
 
 		return autoFlushStage;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
@@ -139,7 +139,7 @@ public class DefaultReactiveLoadEventListener implements LoadEventListener, Reac
 							if ( x instanceof HibernateException ) {
 								LOG.unableToLoadCommand( (HibernateException) x );
 							}
-							CompletionStages.rethrowIfNotNull( x );
+							CompletionStages.returnNullorRethrow( x );
 
 							if ( event.getResult() instanceof CompletionStage ) {
 								throw new AssertionFailure( "Unexpected CompletionStage" );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
@@ -88,23 +88,25 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R> implements Re
 		getProducer().checkTransactionNeededForUpdateOperation( "Executing an update/delete query" );
 
 		beforeQuery();
-		return doExecuteReactiveUpdate()
-				.handle( (count, e) -> {
-					afterQuery();
-					if ( e instanceof QueryExecutionRequestException ) {
-						CompletionStages.rethrow( new IllegalStateException( e ) );
-					}
-					if ( e instanceof TypeMismatchException ) {
-						CompletionStages.rethrow( new IllegalStateException( e ) );
-					}
-					if ( e instanceof HibernateException ) {
-						CompletionStages.rethrow( getExceptionConverter().convert( (HibernateException) e ) );
-					}
-					CompletionStages.rethrowIfNotNull( e );
-					return count;
-				} );
+		return doExecuteReactiveUpdate().handle(this::afterQuery);
 	}
 
+	//copy pasted between here and ReactiveQueryImpl
+	private Integer afterQuery(Integer count, Throwable e) {
+		afterQuery();
+		if ( e instanceof QueryExecutionRequestException) {
+			CompletionStages.rethrow( new IllegalStateException( e ) );
+		}
+		if ( e instanceof TypeMismatchException) {
+			CompletionStages.rethrow( new IllegalStateException( e ) );
+		}
+		if ( e instanceof HibernateException) {
+			CompletionStages.rethrow( getExceptionConverter().convert( (HibernateException) e ) );
+		}
+		return CompletionStages.returnOrRethrow( e, count );
+	}
+
+	//copy pasted between here and ReactiveQueryImpl
 	private CompletionStage<Integer> doExecuteReactiveUpdate() {
 		final String expandedQuery = getQueryParameterBindings().expandListValuedParameters( getQueryString(), getProducer() );
 		return reactiveProducer().executeReactiveUpdate( expandedQuery, makeQueryParametersForExecution( expandedQuery ) );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -290,10 +290,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					else if ( e instanceof RuntimeException ) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if ( e != null ) {
-						return CompletionStages.rethrow( e );
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				} );
 	}
 
@@ -538,10 +535,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					else if (e instanceof RuntimeException) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -559,10 +553,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					else if (e instanceof RuntimeException) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null){
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -629,10 +620,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						//including HibernateException
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -654,10 +642,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						//including HibernateException
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -694,10 +679,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						//including HibernateException
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e !=null) {
-						return CompletionStages.rethrow(e);
-					}
-					return (T) event.getResult();
+					return CompletionStages.returnOrRethrow( e, (T) event.getResult() );
 				});
 	}
 
@@ -719,10 +701,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						//including HibernateException
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e !=null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 
 	}
@@ -756,10 +735,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					if ( e instanceof RuntimeException ) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow( e );
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				} );
 	}
 
@@ -804,10 +780,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						//including HibernateException
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -822,10 +795,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					if (e instanceof RuntimeException) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 
@@ -845,10 +815,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					if (e instanceof RuntimeException) {
 						throw getExceptionConverter().convert( (RuntimeException) e );
 					}
-					else if (e != null) {
-						return CompletionStages.rethrow(e);
-					}
-					return v;
+					return CompletionStages.returnNullorRethrow( e );
 				});
 	}
 


### PR DESCRIPTION
I've tried to clean up the `handle()` methods a bit.

I also ran across some exception-handling stuff that can't possibly be right and fixed it.