### PR TITLE
support for parameters in native and criteria queries

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
@@ -139,7 +139,7 @@ public interface ReactiveLoader {
 				.thenApply( transformer );
 	}
 
-	default LimitHandler limitHandler(RowSelection selection, SessionImplementor session) {
+	default LimitHandler limitHandler(RowSelection selection, SharedSessionContractImplementor session) {
 		LimitHandler limitHandler = session.getJdbcServices().getDialect().getLimitHandler();
 		return LimitHelper.useLimit( limitHandler, selection ) ? limitHandler : NoopLimitHandler.INSTANCE;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/custom/impl/ReactiveCustomLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/custom/impl/ReactiveCustomLoader.java
@@ -21,11 +21,14 @@ import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+
+import static org.hibernate.reactive.sql.impl.Parameters.processParameters;
 
 /**
  * A reactive {@link org.hibernate.loader.Loader} for native SQL queries.
@@ -60,7 +63,8 @@ public class ReactiveCustomLoader extends CustomLoader implements CachingReactiv
 								QueryParameters queryParameters,
 								SessionFactoryImplementor factory,
 								List<AfterLoadAction> afterLoadActions) {
-		return super.preprocessSQL(sql, queryParameters, factory, afterLoadActions);
+		String processed = super.preprocessSQL(sql, queryParameters, factory, afterLoadActions);
+		return processParameters( processed, factory.getJdbcServices().getDialect() );
 	}
 
 	@Override
@@ -103,5 +107,11 @@ public class ReactiveCustomLoader extends CustomLoader implements CachingReactiv
 	@Override @SuppressWarnings("unchecked")
 	public List<Object> getResultList(List results, ResultTransformer resultTransformer) throws QueryException {
 		return super.getResultList(results, resultTransformer);
+	}
+
+	@Override
+	public int bindParameterValues(PreparedStatement statement, QueryParameters queryParameters, int startIndex,
+								   SharedSessionContractImplementor session) throws SQLException {
+		return super.bindParameterValues( statement, queryParameters, startIndex, session );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/hql/impl/ReactiveQueryLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/hql/impl/ReactiveQueryLoader.java
@@ -6,33 +6,33 @@
 package org.hibernate.reactive.loader.hql.impl;
 
 import org.hibernate.HibernateException;
-import org.hibernate.JDBCException;
-import org.hibernate.LockOptions;
 import org.hibernate.QueryException;
 import org.hibernate.cache.spi.QueryKey;
 import org.hibernate.cache.spi.QueryResultsCache;
-import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.pagination.LimitHandler;
 import org.hibernate.dialect.pagination.LimitHelper;
-import org.hibernate.engine.spi.*;
+import org.hibernate.engine.spi.QueryParameters;
+import org.hibernate.engine.spi.RowSelection;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.hql.internal.ast.QueryTranslatorImpl;
 import org.hibernate.hql.internal.ast.tree.SelectClause;
 import org.hibernate.loader.hql.QueryLoader;
 import org.hibernate.loader.spi.AfterLoadAction;
-import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
 import org.hibernate.reactive.loader.CachingReactiveLoader;
-import org.hibernate.reactive.sql.impl.Parameters;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
-import java.sql.CallableStatement;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
+
+import static org.hibernate.reactive.sql.impl.Parameters.processParameters;
 
 /**
  * A reactive {@link QueryLoader} for HQL queries.
@@ -109,10 +109,8 @@ public class ReactiveQueryLoader extends QueryLoader implements CachingReactiveL
 								QueryParameters queryParameters,
 								SessionFactoryImplementor factory,
 								List<AfterLoadAction> afterLoadActions) {
-		return Parameters.processParameters(
-				super.preprocessSQL(sql, queryParameters, factory, afterLoadActions),
-				factory.getDialect()
-		);
+		String processed = super.preprocessSQL(sql, queryParameters, factory, afterLoadActions);
+		return processParameters( processed, factory.getJdbcServices().getDialect() );
 	}
 
 	@Override
@@ -150,24 +148,6 @@ public class ReactiveQueryLoader extends QueryLoader implements CachingReactiveL
 		return super.getResultList(results, resultTransformer);
 	}
 
-	@Override
-	public Object[] toParameterArray(QueryParameters queryParameters, SharedSessionContractImplementor session) {
-		PreparedStatementAdaptor adaptor = new PreparedStatementAdaptor();
-		try {
-			bindPreparedStatement(
-					adaptor,
-					queryParameters,
-					getLimitHandler(queryParameters.getRowSelection()),
-					session
-			);
-			return adaptor.getParametersAsArray();
-		}
-		catch (SQLException e) {
-				//can never happen
-				throw new JDBCException("error binding parameters", e);
-		}
-	}
-
 	/**
 	 * This is based on private method,
 	 * {@link Loader#processResultSet(ResultSet, RowSelection, LimitHandler limitHandler, boolean, SharedSessionContractImplementor),
@@ -188,67 +168,9 @@ public class ReactiveQueryLoader extends QueryLoader implements CachingReactiveL
 		return resultSet;
 	}
 
-	/**
-	 * This is based on the code related to binding a PreparedStatement in {@link Loader#}prepareQueryStatement},
-	 * with modifications.
-	 */
-	private final PreparedStatement bindPreparedStatement(
-			final PreparedStatement st,
-			final QueryParameters queryParameters,
-			final LimitHandler limitHandler,
-			final SharedSessionContractImplementor session) throws SQLException, HibernateException {
-
-		final Dialect dialect = getFactory().getDialect();
-		final RowSelection selection = queryParameters.getRowSelection();
-		final boolean callable = queryParameters.isCallable();
-
-		int col = 1;
-		//TODO: can we limit stored procedures ?!
-		col += limitHandler.bindLimitParametersAtStartOfQuery( selection, st, col );
-
-		if ( callable ) {
-			col = dialect.registerResultSetOutParameter( (CallableStatement) st, col );
-		}
-
-		col += bindParameterValues( st, queryParameters, col, session );
-
-		col += limitHandler.bindLimitParametersAtEndOfQuery( selection, st, col );
-
-		limitHandler.setMaxRows( selection, st );
-
-		// no support for these options in Reactive
-//		if ( selection != null ) {
-//			if ( selection.getTimeout() != null ) {
-//				st.setQueryTimeout( selection.getTimeout() );
-//			}
-//			if ( selection.getFetchSize() != null ) {
-//				st.setFetchSize( selection.getFetchSize() );
-//			}
-//		}
-
-		// handle lock timeout...
-		LockOptions lockOptions = queryParameters.getLockOptions();
-		if ( lockOptions != null ) {
-			if ( lockOptions.getTimeOut() != LockOptions.WAIT_FOREVER ) {
-				if ( !dialect.supportsLockTimeouts() ) {
-					if ( LOG.isDebugEnabled() ) {
-						LOG.debugf(
-								"Lock timeout [%s] requested but dialect reported to not support lock timeouts",
-								lockOptions.getTimeOut()
-						);
-					}
-				}
-				else if ( dialect.isLockTimeoutParameterized() ) {
-					st.setInt( col++, lockOptions.getTimeOut() );
-				}
-			}
-		}
-
-		if ( LOG.isTraceEnabled() ) {
-			LOG.tracev( "Bound [{0}] parameters total", col );
-		}
-
-		return st;
+	@Override
+	public int bindParameterValues(PreparedStatement statement, QueryParameters queryParameters, int startIndex,
+								   SharedSessionContractImplementor session) throws SQLException {
+		return super.bindParameterValues( statement, queryParameters, startIndex, session );
 	}
-
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -18,6 +18,7 @@ import org.hibernate.proxy.HibernateProxy;
 import org.hibernate.reactive.session.ReactiveSession;
 
 import javax.persistence.EntityGraph;
+import javax.persistence.Parameter;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
@@ -50,9 +51,11 @@ public interface Mutiny {
 	 */
 	interface Query<R> {
 
-		Query<R> setParameter(int var1, Object var2);
+		Query<R> setParameter(int position, Object value);
 
-		Query<R> setParameter(String name, Object var2);
+		Query<R> setParameter(String name, Object value);
+
+		<T> Query<R> setParameter(Parameter<T> name, T value);
 
 		Query<R> setMaxResults(int maxResults);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -11,6 +11,7 @@ import org.hibernate.LockMode;
 import org.hibernate.reactive.session.ReactiveQuery;
 import org.hibernate.reactive.mutiny.Mutiny;
 
+import javax.persistence.Parameter;
 import java.util.List;
 
 /**
@@ -25,14 +26,20 @@ public class MutinyQueryImpl<R> implements Mutiny.Query<R> {
 	}
 
 	@Override
-	public Mutiny.Query<R> setParameter(int var1, Object var2) {
-		delegate.setParameter( var1, var2 );
+	public Mutiny.Query<R> setParameter(int position, Object value) {
+		delegate.setParameter( position, value );
 		return this;
 	}
 
 	@Override
-	public Mutiny.Query<R> setParameter(String name, Object var2) {
-		delegate.setParameter( name, var2 );
+	public Mutiny.Query<R> setParameter(String name, Object value) {
+		delegate.setParameter( name, value );
+		return this;
+	}
+
+	@Override
+	public <T> Mutiny.Query<R> setParameter(Parameter<T> name, T value) {
+		delegate.setParameter( name, value );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -33,7 +33,6 @@ import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
 import org.hibernate.reactive.loader.entity.impl.ReactiveDynamicBatchingEntityLoaderBuilder;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.session.ReactiveSession;
-import org.hibernate.reactive.sql.impl.Parameters;
 import org.hibernate.reactive.sql.impl.Update;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.sql.Delete;
@@ -975,10 +974,8 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 			throw new JDBCException("error binding parameters", e);
 		}
 
-		String sql = Parameters.processParameters(
-				delegate().getSQLSnapshotSelectString(),
-				getFactory().getJdbcServices().getDialect()
-		);
+		Dialect dialect = getFactory().getJdbcServices().getDialect();
+		String sql = processParameters( delegate().getSQLSnapshotSelectString(), dialect );
 
 		return getReactiveConnection( session )
 				.selectJdbc( sql, statement.getParametersAsArray() )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQuery.java
@@ -11,12 +11,14 @@ import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.TypeMismatchException;
 import org.hibernate.hql.internal.QueryExecutionRequestException;
+import org.hibernate.query.criteria.internal.compile.InterpretedParameterMetadata;
 import org.hibernate.query.internal.AbstractProducedQuery;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.transform.ResultTransformer;
 import org.hibernate.type.Type;
 
 import javax.persistence.NoResultException;
+import javax.persistence.Parameter;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
@@ -30,6 +32,8 @@ import java.util.concurrent.CompletionStage;
 @Incubating
 public interface ReactiveQuery<R> {
 
+	void setParameterMetadata(InterpretedParameterMetadata parameterMetadata);
+
 	CompletionStage<R> getReactiveSingleResult();
 
 	CompletionStage<List<R>> getReactiveResultList();
@@ -39,6 +43,8 @@ public interface ReactiveQuery<R> {
 	ReactiveQuery<R> setParameter(int position, Object value);
 
 	ReactiveQuery<R> setParameter(String name, Object value);
+
+	<T> ReactiveQuery<R> setParameter(Parameter<T> parameter, T value);
 
 	ReactiveQuery<R> setMaxResults(int maxResults);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveCriteriaQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveCriteriaQueryImpl.java
@@ -75,9 +75,10 @@ public class ReactiveCriteriaQueryImpl<T> extends CriteriaQueryImpl<T> implement
 
 //		return new CriteriaQueryTypeQueryAdapter(
 //				session,
-//				jpaqlQuery,
-//				parameterMetadata.explicitParameterInfoMap()
+//				query,
+//				context.explicitParameterInfoMap()
 //		);
+		query.setParameterMetadata( context );
 
 		return query;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeQueryImpl.java
@@ -12,11 +12,13 @@ import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
 import org.hibernate.engine.spi.NamedSQLQueryDefinition;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.ParameterMetadata;
+import org.hibernate.query.criteria.internal.compile.InterpretedParameterMetadata;
 import org.hibernate.query.internal.NativeQueryImpl;
 import org.hibernate.reactive.session.ReactiveNativeQuery;
 import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.transform.ResultTransformer;
 
+import javax.persistence.Parameter;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
@@ -44,6 +46,11 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R> implements Re
 			SharedSessionContractImplementor session,
 			ParameterMetadata sqlParameterMetadata) {
 		super( sqlString, callable, session, sqlParameterMetadata );
+	}
+
+	@Override
+	public void setParameterMetadata(InterpretedParameterMetadata parameterMetadata) {
+		throw new UnsupportedOperationException("not a JPA query");
 	}
 
 	@Override
@@ -114,6 +121,12 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R> implements Re
 	@Override
 	public ReactiveNativeQueryImpl<R> setParameter(String name, Object value) {
 		super.setParameter(name, value);
+		return this;
+	}
+
+	@Override
+	public <P> ReactiveNativeQueryImpl<R> setParameter(Parameter<P> parameter, P value) {
+		 super.setParameter(parameter, value);
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -18,6 +18,7 @@ import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import javax.persistence.EntityGraph;
+import javax.persistence.Parameter;
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaDelete;
 import javax.persistence.criteria.CriteriaQuery;
@@ -51,9 +52,11 @@ public interface Stage {
 	 */
 	interface Query<R> {
 
-		Query<R> setParameter(int var1, Object var2);
+		Query<R> setParameter(int position, Object value);
 
-		Query<R> setParameter(String name, Object var2);
+		Query<R> setParameter(String name, Object value);
+
+		<T> Query<R> setParameter(Parameter<T> name, T value);
 
 		Query<R> setMaxResults(int maxResults);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -5,13 +5,14 @@
  */
 package org.hibernate.reactive.stage.impl;
 
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-
 import org.hibernate.CacheMode;
 import org.hibernate.LockMode;
 import org.hibernate.reactive.session.ReactiveQuery;
 import org.hibernate.reactive.stage.Stage;
+
+import javax.persistence.Parameter;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
 
 /**
  * Implementation of {@link Stage.Query}.
@@ -25,14 +26,20 @@ public class StageQueryImpl<R> implements Stage.Query<R> {
 	}
 
 	@Override
-	public Stage.Query<R> setParameter(int var1, Object var2) {
-		delegate.setParameter( var1, var2 );
+	public Stage.Query<R> setParameter(int position, Object value) {
+		delegate.setParameter( position, value );
 		return this;
 	}
 
 	@Override
-	public Stage.Query<R> setParameter(String name, Object var2) {
-		delegate.setParameter( name, var2 );
+	public Stage.Query<R> setParameter(String name, Object value) {
+		delegate.setParameter( name, value );
+		return this;
+	}
+
+	@Override
+	public <T> Stage.Query<R> setParameter(Parameter<T> parameter, T value) {
+		delegate.setParameter( parameter, value );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
@@ -14,6 +14,7 @@ import org.hibernate.cfg.Configuration;
 
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -67,6 +68,25 @@ public class HQLUpdateQueryTest extends BaseReactiveTest {
 		);
 	}
 
+	@Test @Ignore("parameters in update queries not yet working")
+	public void testUpdateQueryWithParameters(TestContext context) {
+		String updatedDescription =  "Most rye breads use a mix of rye and wheat flours";
+		test(
+				context,
+				openSession()
+						.thenApply( s -> s.createQuery( "UPDATE Flour SET description = :updatedDescription WHERE id = :id" )
+								.setParameter("updatedDescription", updatedDescription)
+								.setParameter("id", rye.getId()) )
+						.thenCompose( qr -> {
+							context.assertNotNull( qr );
+							return qr.executeUpdate();
+						} )
+						.thenAccept( resultCount -> context.assertEquals( 1, resultCount ))
+						.thenCompose( v -> openSession() )
+						.thenCompose( s -> s.find( Flour.class, rye.getId() ) )
+						.thenAccept( result -> context.assertEquals( updatedDescription, result.getDescription() ) )
+		);
+	}
 
 	@Test
 	public void testInsertQuery(TestContext context) {


### PR DESCRIPTION
This patch extends @gbadner's work on query parameters by adding:

- positional + named parameters in native queries
- named + anonymous parameters in criteria queries

But for now I could not figure out how to add support for parameters in update/delete queries or criteria.