### PR TITLE
Automated release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,8 +18,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build and Test with PostgreSQL
       run: ./gradlew build -Pdocker -Pdb=pg
 
@@ -32,8 +30,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build and Test with MySQL
       run: ./gradlew build -Pdocker -Pdb=mysql
 
@@ -46,8 +42,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build and Test with DB2
       run: ./gradlew build -Pdocker -Pdb=db2
 
@@ -85,8 +79,6 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Create maven package
       run: ./gradlew assemble
     - name: Publish release to Bintray

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,7 +72,6 @@ jobs:
     name: Release
     if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
     runs-on: ubuntu-latest
-    needs: [test_postgresql, test_mysql, test_db2]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+    tags: '*'
   pull_request:
     branches: master
 
@@ -50,9 +51,11 @@ jobs:
     - name: Build and Test with DB2
       run: ./gradlew build -Pdocker -Pdb=db2
       
-  build_package:      
-    name: Build and create maven package
+  release:
+    name: Release
+    if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )
     runs-on: ubuntu-latest
+    needs: [test_postgresql, test_mysql, test_db2]
     steps:
     - uses: actions/checkout@v2
     - name: Set up JDK 1.8
@@ -62,4 +65,9 @@ jobs:
         server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Create maven package
-      run: ./gradlew assemble publishToMavenLocal
+      run: ./gradlew assemble
+    - name: Publish release to Bintray
+      env:
+        ORG_GRADLE_PROJECT_bintrayUser: ${{ secrets.bintrayUser }}
+        ORG_GRADLE_PROJECT_bintrayKey: ${{ secrets.bintrayKey }}
+      run: ./gradlew bintrayUpload

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,29 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
     - name: Build and Test with DB2
       run: ./gradlew build -Pdocker -Pdb=db2
+
+  snapshot:
+    name: Create snapshot
+    if: github.event_name == 'push' && startsWith( github.ref, 'refs/heads/' )
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Create maven package
+      run: ./gradlew assemble
+    - name: Detect the version of Hibernate Reactive
+      id: detect-version
+      run: |
+        sed -E 's/^projectVersion( *= *| +)([^ ]+)/::set-output name=version::\2/g' gradle/version.properties
+    - name: Publish snapshot to JBoss Nexus (experimental, Nexus rejects some binaries)
+      env:
+        ORG_GRADLE_PROJECT_jbossNexusUser: ${{ secrets.jbossNexusUser }}
+        ORG_GRADLE_PROJECT_jbossNexusPassword: ${{ secrets.jbossNexusPassword }}
+      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && env.ORG_GRADLE_PROJECT_jbossNexusUser
+      run: ./gradlew publish
       
   release:
     name: Release

--- a/build.gradle
+++ b/build.gradle
@@ -7,8 +7,8 @@ plugins {
 }
 
 ext {
-    // Needs to be overridden when publishing SNAPSHOT versions to GitHub Packages
-    projectVersion = '1.0.0-SNAPSHOT'
+    projectVersionFile = file( "${rootProject.projectDir}/gradle/version.properties" )
+    projectVersion = readVersionFromProperties( projectVersionFile )
 }
 
 subprojects {
@@ -40,5 +40,13 @@ ext {
     hibernateOrmVersion = '5.4.17.Final'
 }
 
-
-
+private static String readVersionFromProperties(File file) {
+    if ( !file.exists() ) {
+        throw new GradleException( "Version file $file.canonicalPath does not exists" )
+    }
+    Properties versionProperties = new Properties()
+    file.withInputStream {
+        stream -> versionProperties.load( stream )
+    }
+    return versionProperties.projectVersion
+}

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,5 @@
+import java.util.regex.Pattern
+
 plugins {
     id 'java-library'
     id 'maven-publish'
@@ -8,7 +10,14 @@ plugins {
 
 ext {
     projectVersionFile = file( "${rootProject.projectDir}/gradle/version.properties" )
-    projectVersion = readVersionFromProperties( projectVersionFile )
+    projectVersion = Version.parseProjectVersion( readVersionFromProperties( projectVersionFile ) )
+
+    if ( project.hasProperty('releaseVersion') ) {
+        releaseVersion = Version.parseReleaseVersion( project.releaseVersion )
+    }
+    if ( project.hasProperty('developmentVersion') ) {
+        developmentVersion = Version.parseDevelopmentVersion( project.developmentVersion )
+    }
 }
 
 subprojects {
@@ -49,4 +58,70 @@ private static String readVersionFromProperties(File file) {
         stream -> versionProperties.load( stream )
     }
     return versionProperties.projectVersion
+}
+
+class Version {
+
+    private static final Pattern RELEASE_VERSION_PATTERN = ~/^(\d+)\.(\d+)\.(\d+)\.((?<=\.0\.)(?:Alpha\d+|Beta\d+|CR\d+)|Final)$/
+
+    private static final Pattern DEVELOPMENT_VERSION_PATTERN = ~/^(\d+)\.(\d+)\.(\d+)-SNAPSHOT$/
+
+    static Version parseReleaseVersion(String versionString) {
+        def matcher = (versionString =~ RELEASE_VERSION_PATTERN)
+        if ( !matcher.matches() ) {
+            throw new IllegalArgumentException(
+                    "Invalid version number: '$versionString'." +
+                            " Release version numbers must match /$RELEASE_VERSION_PATTERN/."
+            )
+        }
+        return new Version( matcher.group(1), matcher.group(2), matcher.group(3), matcher.group(4), false )
+    }
+
+    static Version parseDevelopmentVersion(String versionString) {
+        def matcher = (versionString =~ DEVELOPMENT_VERSION_PATTERN)
+        if ( !matcher.matches() ) {
+            throw new IllegalArgumentException(
+                    "Invalid version number: '$versionString'." +
+                            " Development version numbers must match /$DEVELOPMENT_VERSION_PATTERN/."
+            )
+        }
+
+        return new Version( matcher.group(1), matcher.group(2), matcher.group(3), null, true )
+    }
+
+    static Version parseProjectVersion(String versionString) {
+        if ( (versionString =~ RELEASE_VERSION_PATTERN).matches() ) {
+            return parseReleaseVersion( versionString )
+        }
+        if ( (versionString =~ DEVELOPMENT_VERSION_PATTERN).matches() ) {
+            return parseDevelopmentVersion( versionString )
+        }
+        throw new IllegalArgumentException(
+                "Invalid version number: '$versionString'." +
+                        " Project version numbers must match either /$RELEASE_VERSION_PATTERN/ or /$DEVELOPMENT_VERSION_PATTERN/."
+        )
+    }
+
+    final String major
+    final String minor
+    final String micro
+    final String qualifier
+    final boolean snapshot
+
+    Version(String major, String minor, String micro, String qualifier, boolean snapshot) {
+        this.major = major
+        this.minor = minor
+        this.micro = micro
+        this.qualifier = qualifier
+        this.snapshot = snapshot
+    }
+
+    @Override
+    String toString() {
+        [major, minor, micro, qualifier].findAll({ it != null }).join('.') + (snapshot ? '-SNAPSHOT' : '')
+    }
+
+    String getFamily() {
+        "$major.$minor"
+    }
 }

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,0 +1,1 @@
+projectVersion=1.0.0-SNAPSHOT

--- a/publish.gradle
+++ b/publish.gradle
@@ -3,7 +3,7 @@ apply plugin: 'nu.studer.credentials'
 apply plugin: 'com.jfrog.bintray'
 
 // To publish snapshots:
-//  ./gradlew publish -PgithubUser="<YOUR USERNAME>" -PgithubToken="<YOUR TOKEN>"
+//  ./gradlew publish -PjbossNexusUser="<YOUR USERNAME>" -PjbossNexusPassword="<YOUR PASSWORD>"
 // To release:
 //  1. Update the version, changelog, etc.
 //  2. Commit.
@@ -19,11 +19,11 @@ ext {
     // or stored locally using the gradle-credentials-plugin.
     // See below for the name of project properties.
     // See https://github.com/etiennestuder/gradle-credentials-plugin to store credentials locally.
-    if (!project.hasProperty('githubUser')) {
-        githubUser = credentials.githubUser
+    if (!project.hasProperty('jbossNexusUser')) {
+        jbossNexusUser = credentials.jbossNexusUser
     }
-    if (!project.hasProperty('githubToken')) {
-        githubToken = credentials.githubToken
+    if (!project.hasProperty('jbossNexusPassword')) {
+        jbossNexusPassword = credentials.jbossNexusPassword
     }
     if (!project.hasProperty('bintrayUser')) {
         bintrayUser = credentials.bintrayUser
@@ -70,11 +70,11 @@ publishing {
     repositories {
         mavenLocal()
         maven {
-            name 'github-packages-repository'
-            url 'https://maven.pkg.github.com/hibernate/hibernate-reactive'
+            name 'jboss-snapshots-repository'
+            url 'https://repository.jboss.org/nexus/content/repositories/snapshots'
             credentials {
-                username project.githubUser
-                password project.githubToken
+                username project.jbossNexusUser
+                password project.jbossNexusPassword
             }
         }
     }

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -2,15 +2,17 @@ import java.nio.charset.StandardCharsets
 
 description = 'Release module'
 
-// Usage: ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin
+// Usage: ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin -PgitBranch=master
 task ciRelease {
     group = "Release"
     description = "Triggers the release on CI: creates commits to change the version (release, then development), creates a tag, pushes everything. Then CI will take over and perform the release."
 
     doFirst {
-        if (!project.hasProperty('releaseVersion') || !project.hasProperty('developmentVersion') || !project.hasProperty('gitRemote')) {
+        if (!project.hasProperty('releaseVersion') || !project.hasProperty('developmentVersion')
+                || !project.hasProperty('gitRemote') ||!project.hasProperty('gitBranch')) {
             throw new GradleException(
-                    "The ciRelease task requires the 'releaseVersion', 'developmentVersion' and 'gitRemote' parameters."
+                    "Task 'ciRelease' requires all of the following properties to be set:"
+                            + "'releaseVersion', 'developmentVersion', 'gitRemote' and 'gitBranch'."
             )
         }
     }
@@ -25,6 +27,9 @@ task ciRelease {
                             + "\nUncommitted files:\n" + uncommittedFiles
             );
         }
+
+        println("Switching to branch '${project.gitBranch}'...")
+        executeGitCommand('switch', project.gitBranch)
 
         println("Checking that all commits are pushed...")
         String diffWithUpstream = executeGitCommand('diff', '@{u}')

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -57,11 +57,8 @@ task ciRelease {
         executeGitCommand('add', '.')
         executeGitCommand('commit', '-m', project.developmentVersion)
 
-        println("Pushing branch to remote '${project.gitRemote}'...")
-        executeGitCommand('push', project.gitRemote)
-
-        println("Pushing tag '${tag}' to remote '${project.gitRemote}'...")
-        executeGitCommand('push', project.gitRemote, tag)
+        println("Pushing branch and tag to remote '${project.gitRemote}'...")
+        executeGitCommand('push', '--atomic', project.gitRemote, project.gitBranch, tag)
 
         println("Done!")
 

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -16,6 +16,25 @@ task ciRelease {
     }
 
     doLast {
+        println("Checking that the working tree is clean...")
+        String uncommittedFiles = executeGitCommand('status', '--porcelain')
+        if ( !uncommittedFiles.isEmpty() ) {
+            throw new GradleException(
+                    "Cannot release because there are uncommitted or untracked files in the working tree."
+                            + "\nCommit or stash your changes first."
+                            + "\nUncommitted files:\n" + uncommittedFiles
+            );
+        }
+
+        println("Checking that all commits are pushed...")
+        String diffWithUpstream = executeGitCommand('diff', '@{u}')
+        if ( !diffWithUpstream.isEmpty() ) {
+            throw new GradleException(
+                    "Cannot release because there are commits on the branch to release that haven't been pushed yet."
+                            + "\nPush your commits to the branch to release first."
+            );
+        }
+
         println("Adding commit to update version to '${project.releaseVersion}'...")
         project.projectVersionFile.text = "projectVersion=${project.releaseVersion}"
         executeGitCommand('add', '.')
@@ -26,7 +45,7 @@ task ciRelease {
         }
 
         println("Tagging '${tag}'...")
-        executeGitCommand('tag', tag)
+        executeGitCommand('tag', '-a', '-m', "Release ${project.releaseVersion}", tag)
 
         println("Adding commit to update version to '${project.developmentVersion}'...")
         project.projectVersionFile.text = "projectVersion=${project.developmentVersion}"
@@ -45,7 +64,7 @@ task ciRelease {
     }
 }
 
-static void executeGitCommand(Object ... subcommand){
+static String executeGitCommand(Object ... subcommand){
     List<Object> command = ['git']
     Collections.addAll( command, subcommand )
     def proc = command.execute()
@@ -55,6 +74,7 @@ static void executeGitCommand(Object ... subcommand){
     if ( code != 0 ) {
         throw new GradleException( "An error occurred while executing " + command + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
     }
+    return stdout
 }
 
 static String inputStreamToString(InputStream inputStream) {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -1,0 +1,73 @@
+import java.nio.charset.StandardCharsets
+
+description = 'Release module'
+
+// Usage: ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin
+task ciRelease {
+    group = "Release"
+    description = "Triggers the release on CI: creates commits to change the version (release, then development), creates a tag, pushes everything. Then CI will take over and perform the release."
+
+    doFirst {
+        if (!project.hasProperty('releaseVersion') || !project.hasProperty('developmentVersion') || !project.hasProperty('gitRemote')) {
+            throw new GradleException(
+                    "The ciRelease task requires the 'releaseVersion', 'developmentVersion' and 'gitRemote' parameters."
+            )
+        }
+    }
+
+    doLast {
+        println("Adding commit to update version to '${project.releaseVersion}'...")
+        project.projectVersionFile.text = "projectVersion=${project.releaseVersion}"
+        executeGitCommand('add', '.')
+        executeGitCommand('commit', '-m', project.releaseVersion)
+        String tag = project.releaseVersion
+        if ( tag.endsWith( ".Final" ) ) {
+            tag = tag.replace( ".Final", "" )
+        }
+
+        println("Tagging '${tag}'...")
+        executeGitCommand('tag', tag)
+
+        println("Adding commit to update version to '${project.developmentVersion}'...")
+        project.projectVersionFile.text = "projectVersion=${project.developmentVersion}"
+        executeGitCommand('add', '.')
+        executeGitCommand('commit', '-m', project.developmentVersion)
+
+        println("Pushing branch to remote '${project.gitRemote}'...")
+        executeGitCommand('push', project.gitRemote)
+
+        println("Pushing tag '${tag}' to remote '${project.gitRemote}'...")
+        executeGitCommand('push', project.gitRemote, tag)
+
+        println("Done!")
+
+        println("Go to https://github.com/hibernate/hibernate-reactive/actions?query=branch%3A${tag} to check the progress of the automated release.")
+    }
+}
+
+static void executeGitCommand(Object ... subcommand){
+    List<Object> command = ['git']
+    Collections.addAll( command, subcommand )
+    def proc = command.execute()
+    def code = proc.waitFor()
+    def stdout = inputStreamToString( proc.getInputStream() )
+    def stderr = inputStreamToString( proc.getErrorStream() )
+    if ( code != 0 ) {
+        throw new GradleException( "An error occurred while executing " + command + "\n\nstdout:\n" + stdout + "\n\nstderr:\n" + stderr )
+    }
+}
+
+static String inputStreamToString(InputStream inputStream) {
+    inputStream.withCloseable { ins ->
+        new BufferedInputStream(ins).withCloseable { bis ->
+            new ByteArrayOutputStream().withCloseable { buf ->
+                int result = bis.read();
+                while (result != -1) {
+                    buf.write((byte) result);
+                    result = bis.read();
+                }
+                return buf.toString(StandardCharsets.UTF_8.name());
+            }
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,4 +11,5 @@ rootProject.name = 'hibernate-reactive'
 
 include 'hibernate-reactive-core'
 include 'example'
+include 'release'
 


### PR DESCRIPTION
Follows up on #122 

To release, just run this from your clone of the repo:

```
./gradlew ciRelease -PreleaseVersion=0.0.1.Alpha1 -PdevelopmentVersion=1.0.0-SNAPSHOT -PgitRemote=upstream -PgitBranch=master
```

This will switch to your local copy of the branch `master`, create a commit that changes the version to `0.0.1.Alpha1` and tag it as `0.0.1.Alpha1`, then create another commit that changes the version to `1.0.0-SNAPSHOT`, then push those commits to branch `master` on remote `upstream` along with the tag.

Then GitHub actions will run tests, and finally create the packages and publish them to bintray, here: https://bintray.com/beta/#/hibernate/artifacts/hibernate-reactive?tab=overview

I'll submit another PR later to also push the javadoc to jboss.org.