### PR TITLE
Support parameters for update/delete queries

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
@@ -8,10 +8,12 @@ package org.hibernate.reactive.adaptor.impl;
 import org.hibernate.JDBCException;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.param.ParameterSpecification;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
 import java.sql.SQLException;
+import java.util.List;
 
 public class QueryParametersAdaptor {
 
@@ -43,6 +45,24 @@ public class QueryParametersAdaptor {
 				Object value = values[i];
 				type.nullSafeSet(adaptor, value, n, session);
 				n += type.getColumnSpan(session.getFactory());
+			}
+			return adaptor.getParametersAsArray();
+		}
+		catch (SQLException e) {
+			//can never happen
+			throw new JDBCException("error binding parameters", e);
+		}
+	}
+
+	public static Object[] toParameterArray(
+			QueryParameters queryParameters,
+			List<ParameterSpecification> parameterSpecifications,
+			SharedSessionContractImplementor session) {
+		final PreparedStatementAdaptor adaptor = new PreparedStatementAdaptor();
+		try {
+			int pos = 1;
+			for (ParameterSpecification parameterSpecification : parameterSpecifications) {
+				pos += parameterSpecification.bind(adaptor, queryParameters, session, pos);
 			}
 			return adaptor.getParametersAsArray();
 		}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
@@ -14,7 +14,6 @@ import org.hibernate.cfg.Configuration;
 
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -68,7 +67,7 @@ public class HQLUpdateQueryTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test @Ignore("parameters in update queries not yet working")
+	@Test
 	public void testUpdateQueryWithParameters(TestContext context) {
 		String updatedDescription =  "Most rye breads use a mix of rye and wheat flours";
 		test(


### PR DESCRIPTION
See #220

Currently, multi-table updates and deletes are not supported.

This fix makes `HQLUpdateQueryTest#testUpdateQuery` pass. I have not tried other tests yet.

I suspect we would be better off using something like `BasicExecutor` instead. I'll look into this further next week,

