### PR TITLE
Add a reference documentation module and publish documentation (reference + javadoc) upon release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,6 +80,18 @@ jobs:
         java-version: 1.8
     - name: Create maven package
       run: ./gradlew assemble
+    - name: Install SSH key
+      uses: shimataro/ssh-key-action@v2
+      with:
+        name: jboss_filemgmt
+        key: ${{ secrets.JBOSS_FILEMGMT_SSH_KEY }}
+        known_hosts: ${{ secrets.JBOSS_FILEMGMT_SSH_KNOWN_HOSTS }}
+        config: |
+          Host filemgmt.jboss.org
+            User hibernate
+            IdentityFile ~/.ssh/jboss_filemgmt
+    - name: Publish documentation to jboss.org
+      run: ./gradlew uploadDocumentation
     - name: Publish release to Bintray
       env:
         ORG_GRADLE_PROJECT_bintrayUser: ${{ secrets.BINTRAY_USER }}

--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,7 @@ plugins {
     id 'com.diffplug.gradle.spotless' version '4.0.1'
     id 'nu.studer.credentials' version '2.1' apply false
     id 'com.jfrog.bintray' version '1.8.5' apply false
+    id 'org.asciidoctor.convert' version '1.5.7' apply false
 }
 
 ext {
@@ -18,6 +19,20 @@ ext {
     if ( project.hasProperty('developmentVersion') ) {
         developmentVersion = Version.parseDevelopmentVersion( project.developmentVersion )
     }
+}
+
+// Versions which need to be aligned across modules; this also
+// allows overriding the build using a parameter, which can be
+// useful to monitor compatibility for upcoming versions on CI:
+//
+// ./gradlew clean build -PhibernateOrmVersion=5.4.9-SNAPSHOT
+
+ext {
+    if ( !project.hasProperty('hibernateOrmVersion') ) {
+        hibernateOrmVersion = '5.4.17.Final'
+    }
+    // For ORM, we need a parsed version (to get the family, ...)
+    hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
 }
 
 subprojects {
@@ -37,16 +52,6 @@ subprojects {
     }
     
     ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'
-}
-
-// Versions which need to be aligned across modules; this also
-// allows overriding the build using a parameter, which can be
-// useful to monitor compatibility for upcoming versions on CI:
-//
-// ./gradlew clean build -PhibernateOrmVersion=5.4.9-SNAPSHOT
-
-ext {
-    hibernateOrmVersion = '5.4.17.Final'
 }
 
 private static String readVersionFromProperties(File file) {

--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -1,0 +1,123 @@
+import org.asciidoctor.gradle.AsciidoctorTask
+
+import java.time.Year
+
+apply plugin: 'org.asciidoctor.convert'
+
+ext {
+	projectsToSkipWhenAggregatingJavadocs = [
+			'example',
+			'release',
+			'documentation'
+	]
+}
+
+rootProject.subprojects { subproject ->
+	if ( !this.projectsToSkipWhenAggregatingJavadocs.contains( subproject.name ) ) {
+		this.evaluationDependsOn( subproject.path )
+	}
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Aggregated JavaDoc
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+final File javadocDir = mkdir( new File( (File) project.buildDir, 'javadocs' ) )
+
+/**
+ * Builds the JavaDocs aggregated (unified) across all the sub-projects
+ */
+task aggregateJavadocs(type: Javadoc, group: 'Documentation') {
+    description = 'Builds the aggregated (unified) JavaDocs across all sub-projects'
+
+	final int inceptionYear = 2020
+    final int currentYear = Year.now().getValue()
+
+    // exclude any generated sources and internal packages
+    exclude( '**/generated-src/**' )
+	exclude( '**/src/main/generated/**' )
+    exclude( '**/internal/**' )
+	exclude( '**/impl/**' )
+
+	// apply standard config
+	maxMemory = '512m'
+	destinationDir = javadocDir
+	configure( options ) {
+		windowTitle = 'Hibernate Reactive JavaDoc'
+		docTitle = "Hibernate Reactive JavaDoc ($project.version)"
+		bottom = "Copyright &copy; $inceptionYear-$currentYear <a href=\"http://redhat.com\">Red Hat, Inc</a>. All Rights Reserved."
+		use = true
+		options.encoding = 'UTF-8'
+
+		links = [
+				'https://docs.oracle.com/javase/8/docs/api/',
+				'http://docs.jboss.org/hibernate/beanvalidation/spec/2.0/api/',
+				'https://javaee.github.io/javaee-spec/javadocs/',
+				// Need toString() to avoid ClassCastException from GStringImpl to String (!?)
+				"https://docs.jboss.org/hibernate/orm/${hibernateOrmVersion.family}/javadocs/".toString()
+		]
+		
+		if ( JavaVersion.current().isJava11Compatible() ) {
+			//The need to set `--source 1.8` applies to all JVMs after 11, and also to 11
+			// but after excluding the first two builds; see also specific comments on
+			// https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762
+			// For now, let's be compatible with JDK 11.0.3+. We can improve on it if people
+			// complain they cannot build with JDK 11.0.0, 11.0.1 and 11.0.2.
+			System.out.println("Forcing Javadoc in Java 8 compatible mode");
+			options.source = project.baselineJavaVersion
+		}
+
+		options.addStringOption( 'Xdoclint:none', '-quiet' )
+	}
+
+    // process each project, building up:
+    //      1) appropriate sources
+    //      2) classpath
+    parent.subprojects.each { Project subProject->
+        // skip certain sub-projects
+		if ( ! project.projectsToSkipWhenAggregatingJavadocs.contains( subProject.name ) ) {
+			// we only care about the main SourceSet...
+			source subProject.sourceSets.main.java
+
+			classpath += subProject.sourceSets.main.output + subProject.sourceSets.main.compileClasspath
+		}
+    }
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// Asciidoc
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+asciidoctor {
+	// we do not want it creating its "default task"
+	enabled = false
+}
+
+task renderReferenceDocumentation(type: AsciidoctorTask, group: 'Documentation') {
+    description = 'Renders the Reference Documentation in HTML format using Asciidoctor.'
+    sourceDir = file( 'src/main/asciidoc/reference' )
+    sources {
+        include 'index.adoc'
+    }
+    outputDir = new File("$buildDir/asciidoc/reference/html_single")
+    backends "html5"
+    separateOutputDirs false
+    options logDocuments: true
+	attributes icons: 'font', experimental: true,
+			   'source-highlighter': 'prettify',
+			   linkcss: true,
+			   majorMinorVersion: project.version.family,
+			   fullVersion: project.version.toString(),
+			   docinfo: 'private'
+}
+
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+// All
+// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+task assembleDocumentation(dependsOn: [aggregateJavadocs, renderReferenceDocumentation]) {
+	group 'Documentation'
+	description 'Grouping task for performing all documentation building tasks'
+}
+
+assemble.dependsOn assembleDocumentation

--- a/documentation/src/main/asciidoc/reference/getting-started.adoc
+++ b/documentation/src/main/asciidoc/reference/getting-started.adoc
@@ -1,0 +1,4 @@
+[[getting-started]]
+= Getting started
+
+NOTE: This section is still incomplete.

--- a/documentation/src/main/asciidoc/reference/index.adoc
+++ b/documentation/src/main/asciidoc/reference/index.adoc
@@ -1,0 +1,16 @@
+= Hibernate Reactive {fullVersion} Reference Documentation
+AUTHOR 1, AUTHOR 2
+:toc2:
+:toclevels: 3
+:sectanchors:
+
+:leveloffset: +1
+
+include::preface.adoc[]
+
+:numbered:
+
+include::getting-started.adoc[]
+
+:leveloffset: -1
+

--- a/documentation/src/main/asciidoc/reference/preface.adoc
+++ b/documentation/src/main/asciidoc/reference/preface.adoc
@@ -1,0 +1,4 @@
+[[preface]]
+= Preface
+
+NOTE: This section is still incomplete.

--- a/documentation/src/main/javadoc/overview.html
+++ b/documentation/src/main/javadoc/overview.html
@@ -1,0 +1,67 @@
+<!--
+  ~ Hibernate, Relational Persistence for Idiomatic Java
+  ~
+  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later.
+  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<body>
+
+<h2>Hibernate O/RM Aggregated JavaDocs</h2>
+
+Hibernate provides both<ul>
+    <li>
+        a native API comprised centrally around {@link org.hibernate.SessionFactory} and {@link org.hibernate.Session}
+    </li>
+    <li>
+        an implementation of the Java Persistence API (JPA).
+        See the latest <a href="http://jcp.org/en/jsr/detail?id=338">JPA JSR</a> for details.
+    </li>
+</ul>
+<p></p>
+
+<h3>Native API</h3>
+In addition to SessionFactory and Session, applications using the native API will often utilize the following
+interfaces:<ul>
+    <li>{@link org.hibernate.cfg.Configuration}</li>
+    <li>{@link org.hibernate.Transaction}</li>
+    <li>{@link org.hibernate.Query}</li>
+    <li>{@link org.hibernate.Criteria}</li>
+    <li>{@link org.hibernate.criterion.Projection}</li>
+    <li>{@link org.hibernate.criterion.Projections}</li>
+    <li>{@link org.hibernate.criterion.Criterion}</li>
+    <li>{@link org.hibernate.criterion.Restrictions}</li>
+    <li>{@link org.hibernate.criterion.Order}</li>
+    <li>{@link org.hibernate.criterion.Example}</li>
+</ul>
+These interfaces are fully intended to be exposed to application code.
+<p></p>
+
+<h3>JPA</h3>
+The JPA interfaces are all defined by the JPA specification.  For details see {@link javax.persistence}.
+Not that since 5.2 Hibernate extends JPA (e.g. SessionFactory extends EntityManagerFactory) rather
+than wrapping it.
+<p></p>
+
+
+<h3>Note about package categories</h3>
+Hibernate categorizes packages into a number of groups based on intended consumers:<ul>
+    <li>
+        <strong>API</strong> - classes to which application code will generally bind directly.  These
+        are generally classes which do not have "spi" nor "internal" in their package path and are
+        not under the "org.hibernate.testing" package
+    </li>
+    <li>
+        <strong>SPI</strong> - classes to which integrator developers will commonly bind directly in
+        order to develop extensions to Hibernate, or to alter its behavior in some way.  These are
+        generally under packages with "spi" in the package path.
+    </li>
+    <li>
+        <strong>Testing Support</strong> - classes from the hibernate-testing artifact used in building
+        Hibernate test cases.  These are classes under the "org.hibernate.testing" package
+    </li>
+</ul>
+<p></p>
+
+Complete Hibernate documentation may be found online at <a href="http://hibernate.org/orm/documentation">http://hibernate.org/orm/documentation/</a>
+
+</body>

--- a/publish.gradle
+++ b/publish.gradle
@@ -4,15 +4,7 @@ apply plugin: 'com.jfrog.bintray'
 
 // To publish snapshots:
 //  ./gradlew publish -PjbossNexusUser="<YOUR USERNAME>" -PjbossNexusPassword="<YOUR PASSWORD>"
-// To release:
-//  1. Update the version, changelog, etc.
-//  2. Commit.
-//  3. Tag the release.
-//     > git tag -a -m "Release $RELEASE_VERSION" "$RELEASE_VERSION"
-//  4. Push the tag to the repository.
-//     > git push <REMOTE> "$RELEASE_VERSION"
-//  5. Publish:
-//     > ./gradlew bintrayUpload -PbintrayUser="<YOUR USERNAME>" -PbintrayKey="<YOUR API KEY>"
+// To release, see task ciRelease in release/build.gradle
 
 ext {
     // Credentials can be specified on the command-line using project properties,

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -44,7 +44,7 @@ task uploadDocumentation(type:Exec, dependsOn: assembleDocumentation) {
     final String url = "filemgmt.jboss.org:/docs_htdocs/hibernate/reactive/${project.version.family}"
 
     executable 'rsync'
-    args '-avz', '--links', '--protocol=28', "${documentationDir.absolutePath}/", url
+    args '-avz', '--delete', '--links', '--protocol=28', "${documentationDir.absolutePath}/", url
 
     doFirst {
         if ( project.version.isSnapshot() ) {

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -2,6 +2,66 @@ import java.nio.charset.StandardCharsets
 
 description = 'Release module'
 
+// To publish documentation:
+//  1. Add the relevant SSH key to your SSH agent.
+//  2. Execute this:
+//    ./gradlew uploadDocumentation -PjbossFilemgmtSshUser="<YOUR USERNAME>"
+
+final File documentationDir = mkdir( "${project.buildDir}/documentation" );
+
+/**
+ * Assembles all documentation into the {buildDir}/documentation directory.
+ */
+task assembleDocumentation(dependsOn: [rootProject.project( 'documentation' ).tasks.assemble]) {
+    description = 'Assembles all documentation into the {buildDir}/documentation directory'
+
+    doLast {
+        // copy documentation outputs into target/documentation.
+        // 		* this is used in building the dist bundles
+        //		* it is also used as a base to build a staged directory for documentation upload
+
+        // Aggregated JavaDoc
+        copy {
+            from "${rootProject.project( 'documentation' ).buildDir}/javadocs"
+            into "${documentationDir}/javadocs"
+        }
+
+        // Reference Documentation
+        copy {
+            from "${rootProject.project( 'documentation' ).buildDir}/asciidoc/reference"
+            into "${documentationDir}/reference"
+        }
+    }
+}
+assemble.dependsOn assembleDocumentation
+
+/**
+ * Upload the documentation to the JBoss doc server
+ */
+task uploadDocumentation(type:Exec, dependsOn: assembleDocumentation) {
+    description = "Uploads documentation to the JBoss doc server"
+
+    final String url = "filemgmt.jboss.org:/docs_htdocs/hibernate/reactive/${project.version.family}"
+
+    executable 'rsync'
+    args '-avz', '--links', '--protocol=28', "${documentationDir.absolutePath}/", url
+
+    doFirst {
+        if ( project.version.isSnapshot() ) {
+            logger.error( "Cannot perform upload of SNAPSHOT documentation" );
+            throw new RuntimeException( "Cannot perform upload of SNAPSHOT documentation" );
+        }
+        else {
+            logger.lifecycle( "Uploading documentation to '${url}'..." )
+        }
+    }
+
+    doLast {
+        logger.lifecycle( 'Done uploading documentation' )
+    }
+}
+
+
 // Usage: ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin -PgitBranch=master
 task ciRelease {
     group = "Release"

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -7,6 +7,9 @@ description = 'Release module'
 //  2. Execute this:
 //    ./gradlew uploadDocumentation -PjbossFilemgmtSshUser="<YOUR USERNAME>"
 
+// To tag a version and trigger a release on CI (which will include publishing to Bintray and publishing documentation):
+//  ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin -PgitBranch=master
+
 final File documentationDir = mkdir( "${project.buildDir}/documentation" );
 
 /**
@@ -61,8 +64,6 @@ task uploadDocumentation(type:Exec, dependsOn: assembleDocumentation) {
     }
 }
 
-
-// Usage: ./gradlew ciRelease -PreleaseVersion=x.y.z.Final -PdevelopmentVersion=x.y.z-SNAPSHOT -PgitRemote=origin -PgitBranch=master
 task ciRelease {
     group = "Release"
     description = "Triggers the release on CI: creates commits to change the version (release, then development), creates a tag, pushes everything. Then CI will take over and perform the release."

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,5 +11,6 @@ rootProject.name = 'hibernate-reactive'
 
 include 'hibernate-reactive-core'
 include 'example'
+include 'documentation'
 include 'release'
 


### PR DESCRIPTION
Fixes #230 

~Based on #242 , which should be merged first.~ => Done, and I rebased this on master.

The reference documentation is just a stub for now, but the javadoc may be helpful.

I already added the necessary secrets to this repository, so after this PR is merged the documentation will be published automatically (EDIT: when we release).
I tested the process on my fork and the documentation was successfully uploaded.

To have a look at the produced documentation:

```
./gradlew assembleDocumentation
xdg-open release/build/documentation/javadocs/index.html
xdg-open release/build/documentation/reference/html_single/index.html
````

(`xdg-open` works on Fedora; if you're on Mac OS, I'm not sure.)