### PR TITLE
Sync artifacts with Maven Central upon release using the bintrayPublish task

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -96,4 +96,6 @@ jobs:
       env:
         ORG_GRADLE_PROJECT_bintrayUser: ${{ secrets.BINTRAY_USER }}
         ORG_GRADLE_PROJECT_bintrayKey: ${{ secrets.BINTRAY_KEY }}
-      run: ./gradlew bintrayUpload
+        ORG_GRADLE_PROJECT_sonatypeOssrhUser: ${{ secrets.SONATYPE_OSSRH_USER }}
+        ORG_GRADLE_PROJECT_sonatypeOssrhPassword: ${{ secrets.SONATYPE_OSSRH_PASSWORD }}
+      run: ./gradlew bintrayUpload bintrayPublish

--- a/publish.gradle
+++ b/publish.gradle
@@ -23,6 +23,12 @@ ext {
     if (!project.hasProperty('bintrayKey')) {
         bintrayKey = credentials.bintrayKey
     }
+    if (!project.hasProperty('sonatypeOssrhUser')) {
+        sonatypeOssrhUser = credentials.sonatypeOssrhUser
+    }
+    if (!project.hasProperty('sonatypeOssrhPassword')) {
+        sonatypeOssrhPassword = credentials.sonatypeOssrhPassword
+    }
 }
 
 task sourcesJar(type: Jar) {
@@ -137,6 +143,8 @@ bintray {
             }
             mavenCentralSync {
                 sync = true
+                user = project.sonatypeOssrhUser
+                password = project.sonatypeOssrhPassword
             }
         }
     }


### PR DESCRIPTION
I wasn't able to test this all the way through, for obvious reasons, but I checked that the call to the Bintray Rest API responsible for triggering the Maven Central sync actually happens.

I added the necessary secrets to the repository, but I'm not sure I have the correct username/password. What I found was the username and password for the Sonatype OSSRH JIRA account, so I used that, hoping a single set of credentials is used throughout all Sonatype applications.

Normally, the user and password are saved in the configuration of the Hibernate Organization on Bintray, but I don't have administrative rights to that organization.
@Sanne Could you please check the username password under the "Accounts" section of the Hibernate Organization on Bintray match the username and password we have in our Google Doc?