### PR TITLE
Isolate code required for MySQL in test suite

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -75,6 +75,19 @@ public abstract class BaseReactiveTest {
 		StandardServiceRegistry registry = new ReactiveServiceRegistryBuilder()
 				.applySettings( configuration.getProperties() )
 				.build();
+		mysqlConfiguration( registry );
+		sessionFactory = configuration.buildSessionFactory( registry );
+		poolProvider = registry.getService( ReactiveConnectionPool.class );
+	}
+
+	/*
+	 * MySQL doesn't implement 'drop table cascade constraints'.
+	 *
+	 * The reason this is a problem in our test suite is that we
+	 * have lots of different schemas for the "same" table: Pig, Author, Book.
+	 * A user would surely only have one schema for each table.
+	 */
+	private void mysqlConfiguration(StandardServiceRegistry registry) {
 		registry.getService( ConnectionProvider.class ); //force the NoJdbcConnectionProvider to load first
 		registry.getService( SchemaManagementTool.class )
 				.setCustomDatabaseGenerationTarget( new ReactiveGenerationTarget(registry) {
@@ -93,8 +106,6 @@ public abstract class BaseReactiveTest {
 						super.release();
 					}
 				} );
-		sessionFactory = configuration.buildSessionFactory( registry );
-		poolProvider = registry.getService( ReactiveConnectionPool.class );
 	}
 
 	@After


### PR DESCRIPTION
  There are a couple of lines that are necessary for our tests
  to work with MySQL but shouldn't impact users.