### PR TITLE
Refactoring for DatabaseConfiguration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ ext {
     // For ORM, we need a parsed version (to get the family, ...)
     hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
     vertxVersion = '3.9.1'
-    testscontainersVersion = '1.13.0'
+    testscontainersVersion = '1.14.3'
     baselineJavaVersion = 1.8
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ ext {
     }
     // For ORM, we need a parsed version (to get the family, ...)
     hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
+    vertxVersion = '3.9.1'
     baselineJavaVersion = 1.8
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -34,6 +34,7 @@ ext {
     // For ORM, we need a parsed version (to get the family, ...)
     hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
     vertxVersion = '3.9.1'
+    testscontainersVersion = '1.13.0'
     baselineJavaVersion = 1.8
 }
 

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -11,8 +11,8 @@ dependencies {
     annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernateOrmVersion}"
 
     // database drivers for PostgreSQL and MySQL
-    runtimeOnly 'io.vertx:vertx-pg-client:3.9.1'
-    runtimeOnly 'io.vertx:vertx-mysql-client:3.9.1'
+    runtimeOnly "io.vertx:vertx-pg-client:${vertxVersion}"
+    runtimeOnly "io.vertx:vertx-mysql-client:${vertxVersion}"
 
     // logging (optional)
     runtimeOnly 'org.slf4j:slf4j-log4j12:1.7.30'

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -28,10 +28,10 @@ dependencies {
     // Testing
     testImplementation "org.hibernate:hibernate-testing:${hibernateOrmVersion}"
     testImplementation 'org.assertj:assertj-core:3.13.2'
-    testImplementation 'io.vertx:vertx-unit:3.9.1'
-    testImplementation 'io.vertx:vertx-pg-client:3.9.1'
-    testImplementation 'io.vertx:vertx-mysql-client:3.9.1'
-    testImplementation 'io.vertx:vertx-db2-client:3.9.1'
+    testImplementation "io.vertx:vertx-unit:${vertxVersion}"
+    testImplementation "io.vertx:vertx-pg-client:${vertxVersion}"
+    testImplementation "io.vertx:vertx-mysql-client:${vertxVersion}"
+    testImplementation "io.vertx:vertx-db2-client:${vertxVersion}"
 
     // Testcontainers
     testImplementation 'org.testcontainers:postgresql:1.13.0'

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -34,9 +34,9 @@ dependencies {
     testImplementation "io.vertx:vertx-db2-client:${vertxVersion}"
 
     // Testcontainers
-    testImplementation 'org.testcontainers:postgresql:1.13.0'
-    testImplementation 'org.testcontainers:mysql:1.13.0'
-    testImplementation 'org.testcontainers:db2:1.13.0'
+    testImplementation "org.testcontainers:postgresql:${testscontainersVersion}"
+    testImplementation "org.testcontainers:mysql:${testscontainersVersion}"
+    testImplementation "org.testcontainers:db2:${testscontainersVersion}"
     testImplementation 'org.slf4j:slf4j-log4j12:1.7.30'
 }
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -7,7 +7,9 @@ package org.hibernate.reactive.containers;
 
 import org.testcontainers.containers.Db2Container;
 
-class DB2Database {
+class DB2Database implements TestableDatabase {
+
+	public static DB2Database INSTANCE = new DB2Database();
 
 	public final static String IMAGE_NAME = "ibmcom/db2:11.5.0.0a";
 
@@ -25,7 +27,8 @@ class DB2Database {
 		      .acceptLicense()
 		      .withReuse(true);
 
-	public static String getJdbcUrl() {
+	@Override
+	public String getJdbcUrl() {
 		if ( DatabaseConfiguration.USE_DOCKER ) {
 			// Calling start() will start the container (if not already started)
 			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -5,7 +5,9 @@
  */
 package org.hibernate.reactive.containers;
 
-class MySQLDatabase {
+class MySQLDatabase implements TestableDatabase {
+
+	static MySQLDatabase INSTANCE = new MySQLDatabase();
 
 	public final static String IMAGE_NAME = "mysql:8";
 
@@ -22,7 +24,8 @@ class MySQLDatabase {
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
 			.withReuse( true );
 
-	public static String getJdbcUrl() {
+	@Override
+	public String getJdbcUrl() {
 		if ( DatabaseConfiguration.USE_DOCKER ) {
 			// Calling start() will start the container (if not already started)
 			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -7,7 +7,9 @@ package org.hibernate.reactive.containers;
 
 import org.testcontainers.containers.PostgreSQLContainer;
 
-class PostgreSQLDatabase {
+class PostgreSQLDatabase implements TestableDatabase {
+
+	public static PostgreSQLDatabase INSTANCE = new PostgreSQLDatabase();
 
 	public final static String IMAGE_NAME = "postgres:12-alpine";
 
@@ -24,7 +26,8 @@ class PostgreSQLDatabase {
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
 			.withReuse( true );
 
-	public static String getJdbcUrl() {
+	@Override
+	public String getJdbcUrl() {
 		if ( DatabaseConfiguration.USE_DOCKER ) {
 			// Calling start() will start the container (if not already started)
 			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port
@@ -40,7 +43,18 @@ class PostgreSQLDatabase {
 		return jdbcUrl + "&user=" + postgresql.getUsername() + "&password=" + postgresql.getPassword();
 	}
 
-	private PostgreSQLDatabase() {
+	@Override
+	public String statement(String... parts) {
+		StringBuilder sb = new StringBuilder();
+		for ( int i = 0; i < parts.length; i++ ) {
+			if ( i > 0 ) {
+				sb.append( "$" ).append( ( i ) );
+			}
+			sb.append( parts[i] );
+		}
+		return sb.toString();
 	}
 
+	private PostgreSQLDatabase() {
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
@@ -1,0 +1,26 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.containers;
+
+/**
+ * A database that we use for testing.
+ */
+public interface TestableDatabase {
+
+	String getJdbcUrl();
+
+	/**
+	 * Builds a prepared statement SQL string in a portable way. For example,
+	 * DB2 and MySQL use syntax like "SELECT * FROM FOO WHERE BAR = ?" but
+	 * PostgreSQL uses syntax like "SELECT * FROM FOO WHERE BAR = $1"
+	 *
+	 * @param parts The parts of the SQL not including the parameter tokens. For example:
+	 * <code>statement("SELECT * FROM FOO WHERE BAR = ", "")</code>
+	 */
+	default String statement(String... parts) {
+		return String.join( "?", parts );
+	}
+}


### PR DESCRIPTION
This code PR contains several minor changes:

* Extract version of Vert.x and Testcontainers in properties
* Allow all the databases to have aliases (not only Postgres)
* Upgrade testcontainers to version 1.14.3 (because, why not?)

None of these changes are essential but I think they will come in handy when adding new databases.
