### PR TITLE
Enable prepared statement caching for DB2

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -176,8 +176,7 @@ public class SqlClientPool implements ReactiveConnectionPool, ServiceRegistryAwa
 			connectOptions.setPassword( password );
 		}
 
-		//enable the prepared statement cache by default (except for DB2)
-		connectOptions.setCachePreparedStatements( !scheme.equals("db2") );
+		connectOptions.setCachePreparedStatements( true );
 
 		final Integer cacheMaxSize = ConfigurationHelper.getInteger( Settings.PREPARED_STATEMENT_CACHE_MAX_SIZE, configurationValues );
 		if (cacheMaxSize!=null) {


### PR DESCRIPTION
This PR can be merged once we upgrade to Vertx 3.9.2, which will contain this fix for DB2 prepared statement caching:
https://github.com/eclipse-vertx/vertx-sql-client/pull/707