### PR TITLE
Add default case for switch statements

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -253,6 +253,11 @@ public class StageSessionImpl implements Stage.Session {
 			case ALWAYS:
 				delegate.setHibernateFlushMode(org.hibernate.FlushMode.ALWAYS);
 				break;
+			//missing default case
+        		default:
+            			// add default case
+            			break;
+
 		}
 		return this;
 	}


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html