### PR TITLE
Add default case for switch statements

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -260,6 +260,11 @@ public class MutinySessionImpl implements Mutiny.Session {
 			case ALWAYS:
 				delegate.setHibernateFlushMode(FlushMode.ALWAYS);
 				break;
+			//missing default case
+        		default:
+           			 // add default case
+           			break;
+
 		}
 		return this;
 	}


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html