### PR TITLE
287 Upgrade to vert.x sql client 3.9.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,9 @@ Hibernate Reactive has been tested with:
 - MySQL 8
 - DB2 11.5
 - [Hibernate ORM](https://hibernate.org/orm/) 5.4.17.Final
-- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 3.9.1
-- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 3.9.1
-- Vert.x Reactive DB2 Client 3.9.1
+- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 3.9.2
+- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 3.9.2
+- [Vert.x Reactive DB2 Client](https://vertx.io/docs/vertx-db2-client/java/) 3.9.2
 
 Support for SQL Server is coming soon.
 

--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ ext {
     }
     // For ORM, we need a parsed version (to get the family, ...)
     hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
-    vertxVersion = '3.9.1'
+    vertxVersion = '3.9.2'
     testcontainersVersion = '1.14.3'
     baselineJavaVersion = 1.8
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -176,8 +176,8 @@ public class SqlClientPool implements ReactiveConnectionPool, ServiceRegistryAwa
 			connectOptions.setPassword( password );
 		}
 
-		//enable the prepared statement cache by default (except for DB2)
-		connectOptions.setCachePreparedStatements( !scheme.equals("db2") );
+		//enable the prepared statement cache by default (except for DB2) and MySQL
+		connectOptions.setCachePreparedStatements( !scheme.equals( "db2" ) && !scheme.equals( "mysql" ) );
 
 		final Integer cacheMaxSize = ConfigurationHelper.getInteger( Settings.PREPARED_STATEMENT_CACHE_MAX_SIZE, configurationValues );
 		if (cacheMaxSize!=null) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/SerializableExceptionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/SerializableExceptionTest.java
@@ -1,0 +1,137 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.types;
+
+import io.vertx.ext.unit.TestContext;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
+
+
+import org.junit.Test;
+
+import javax.persistence.Entity;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import java.io.Serializable;
+
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import java.io.Serializable;
+
+import java.util.Objects;
+
+/**
+ * Test an issue with Vert.x SQL client 3.9.2:
+ * it happens when running the same query twice. The first time it will guess the type of the parameters
+ * and then cache it (if the cache is enabled). The problem is that if the parameter is null in the first
+ * query, it won't guess the right type and won't try again. It's a problem for us when dealing with Buffers and
+ * Serializable.
+ */
+public class SerializableExceptionTest extends BaseReactiveTest {
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Basic.class );
+		return configuration;
+	}
+
+	@Test
+	public void testSerialization(TestContext context) {
+		Serializable expected =  new String[] { "Hello", "World!" };
+		Basic nullField = new Basic( "Fergus" );
+		Basic notNullField = new Basic( "Merida", expected );
+
+		test(
+				context,
+				// For this test to fail the entity with the null field needs to be persisted before
+				// the entity with the notNullField
+				getSessionFactory().withTransaction( (s, t) -> s.persist( nullField, notNullField ) )
+						.thenCompose( v -> openSession() )
+						.thenCompose( s -> s.find( Basic.class, notNullField.getId() ) )
+						.thenAccept( found -> {
+							context.assertNotNull( found );
+							context.assertTrue( Objects.deepEquals( expected, found.thing ) );
+						} )
+
+		);
+	}
+
+	@Entity(name = "Basic")
+	@Table(name = "Basic")
+	public static class Basic {
+
+		@Id
+		@GeneratedValue
+		Integer id;
+
+		String string;
+
+		@javax.persistence.Basic
+		Serializable thing;
+
+		public Basic(String string) {
+			this( string, null );
+		}
+
+		public Basic(String string, Serializable thing) {
+			this.string = string;
+			this.thing = thing;
+		}
+
+		public Basic(Integer id, String string) {
+			this.id = id;
+			this.string = string;
+		}
+
+		Basic() {
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getString() {
+			return string;
+		}
+
+		public void setString(String string) {
+			this.string = string;
+		}
+
+		@Override
+		public String toString() {
+			return id + ": " + string;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Basic basic = (Basic) o;
+			return Objects.equals( string, basic.string );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( string );
+		}
+	}
+}


### PR DESCRIPTION
I think I've found a bug in the vertx client for MySQL.
Disabling the query cache solves the issue.
We have a query that has a Buffer as parameter. If the first time we run the query the parameter is null, the client will infer the type in `DataTypeCodec#inferDataTypeByEncodingValue` as `DataType.NULL` instead of `DataType.BLOB`. It seems that at that point the value is cached and therefore the encoding changes depending on when you run the query.

For now I've disabled the cache for MySQL so that we can upgrade.

@aguibert Would you be able to have a look at this, please? 