### PR TITLE
initial support for second-level cache

### DIFF
--- a/documentation/src/main/asciidoc/reference/introduction.adoc
+++ b/documentation/src/main/asciidoc/reference/introduction.adoc
@@ -64,7 +64,9 @@ Optionally, you might also add:
 - `org.hibernate.validator:hibernate-validator` and
   `org.glassfish:jakarta.el` if you're using Hibernate Validator,
 - `org.hibernate:query-validator` to enable compile-time checking of your
-  HQL queries, and/or
+  HQL queries,
+- `org.hibernate:hibernate-jcache`, along with a JCache implementation like
+  `org.ehcache:ehcache`, if you need a second-level cache, and/or
 - the Hibernate {enhancer}[bytecode enhancer] if you want to use field-level
   lazy fetching.
 
@@ -144,6 +146,39 @@ pool and cache via the following properties:
 - `hibernate.vertx.prepared_statement_cache.sql_limit`
 
 TIP: But for now, just leave these three settings alone.
+
+=== Enabling the second-level cache
+
+Hibernate Reactive supports second-level cache implementations that
+perform no blocking I/O.
+
+IMPORTANT: Make sure you disable any disk-based storage or distributed
+replication used by your preferred cache implementation. A second-level
+cache which uses blocking I/O to interact with the network or disk-based
+storage will at least partially negate the advantages of the reactive
+programming model.
+
+Configuring Hibernate's second-level cache is a rather involved topic,
+and quite outside the scope of this document. But in case it helps, we're
+testing Hibernate Reactive with the following configuration, which uses
+EHCache as the cache implementation:
+
+|===
+| Property name                            | Property value
+
+| `hibernate.cache.use_second_level_cache` | `true`
+| `hibernate.cache.region.factory_class`   | `org.hibernate.cache.jcache.JCacheRegionFactory`
+| `hibernate.javax.cache.provider`         | `org.ehcache.jsr107.EhcacheCachingProvider`
+| `hibernate.javax.cache.uri`              | `/ehcache.xml`
+|===
+
+If you're using EHCache, you'll also need to include an `ehcache.xml` file
+that explicitly configures the behavior of each cache region belonging to
+your entities and collections.
+
+TIP: Don't forget that you need to explicitly mark each entity that will
+be stored in the second-level cache with the `@Cache` annotation from
+`org.hibernate.annotations`.
 
 == Writing the Java code
 

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     testImplementation "io.vertx:vertx-pg-client:${vertxVersion}"
     testImplementation "io.vertx:vertx-mysql-client:${vertxVersion}"
     testImplementation "io.vertx:vertx-db2-client:${vertxVersion}"
+    testImplementation "org.hibernate:hibernate-jcache:${hibernateOrmVersion}"
+    testImplementation "org.ehcache:ehcache:3.8.1"
 
     // Testcontainers
     testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.mutiny;
 
 import io.smallrye.mutiny.Multi;
 import io.smallrye.mutiny.Uni;
+import org.hibernate.Cache;
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
 import org.hibernate.FlushMode;
@@ -1167,6 +1168,12 @@ public interface Mutiny {
 		 * Obtain the JPA {@link Metamodel} for the persistence unit.
 		 */
 		Metamodel getMetamodel();
+
+		/**
+		 * Obtain the {@link Cache} object for managing the second-level
+		 * cache.
+		 */
+		Cache getCache();
 
 		/**
 		 * Destroy the session factory and clean up its connection pool.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive.mutiny.impl;
 
 import io.smallrye.mutiny.Uni;
+import org.hibernate.Cache;
 import org.hibernate.HibernateException;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.reactive.mutiny.Mutiny;
@@ -104,6 +105,11 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory {
 	@Override
 	public Metamodel getMetamodel() {
 		return delegate.getMetamodel();
+	}
+
+	@Override
+	public Cache getCache() {
+		return delegate.getCache();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryExecutor.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive.session;
 
 import org.hibernate.Incubating;
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.query.spi.sql.NativeSQLQuerySpecification;
 import org.hibernate.engine.spi.QueryParameters;
@@ -39,4 +40,5 @@ public interface ReactiveQueryExecutor extends ReactiveConnectionSupplier {
 
     <T> ResultSetMapping<T> getResultSetMapping(Class<T> resultType, String mappingName);
 
+    void addBulkCleanupAction(BulkOperationCleanupAction action);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeSQLQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeSQLQueryPlan.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive.session.impl;
 
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.query.spi.NativeSQLQueryPlan;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -35,7 +36,10 @@ public class ReactiveNativeSQLQueryPlan extends NativeSQLQueryPlan {
 																 ReactiveQueryExecutor session) {
 		SharedSessionContractImplementor sessionContract = session.getSharedContract();
 
-		coordinateSharedCacheCleanup(sessionContract);
+		session.addBulkCleanupAction( new BulkOperationCleanupAction(
+				session.getSharedContract(),
+				getCustomQuery().getQuerySpaces()
+		) );
 
 		if ( queryParameters.isCallable() ) {
 			throw new IllegalArgumentException("callable not yet supported for native queries");

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -16,6 +16,7 @@ import org.hibernate.MappingException;
 import org.hibernate.ObjectDeletedException;
 import org.hibernate.ObjectNotFoundException;
 import org.hibernate.TypeMismatchException;
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.internal.StatefulPersistenceContext;
@@ -341,7 +342,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 		return reactiveAutoFlushIfRequired( reactivePlan.getQuerySpaces() )
 				// FIXME: I guess I can fix this as a separate issue
 //				dontFlushFromFind++;   //stops flush being called multiple times if this method is recursively called
-				.thenCompose( v -> reactivePlan.performReactiveList(parameters, this ) )
+				.thenCompose( v -> reactivePlan.performReactiveList( parameters, this ) )
 				.whenComplete( (list, x) -> {
 //					dontFlushFromFind--;
 					afterOperation( x == null );
@@ -543,6 +544,11 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					afterOperation( x == null );
 					delayedAfterCompletion();
 				} );
+	}
+
+	@Override
+	public void addBulkCleanupAction(BulkOperationCleanupAction action) {
+		getReactiveActionQueue().addAction( action );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.UnresolvableObjectException;
+import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.internal.Versioning;
@@ -313,7 +314,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
                 ? getQueryPlan( query, false )
                 : (ReactiveHQLQueryPlan) plan;
 
-        return reactivePlan.performReactiveList(parameters, this )
+        return reactivePlan.performReactiveList( parameters, this )
                 .whenComplete( (list, x) -> {
                     getPersistenceContext().clear();
                     afterOperation( x == null );
@@ -380,13 +381,18 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
     }
 
     @Override
-    public List<?> list(String query, QueryParameters queryParameters) throws HibernateException {
+    public void addBulkCleanupAction(BulkOperationCleanupAction action) {
+        action.getAfterTransactionCompletionProcess()
+                .doAfterTransactionCompletion( true, this );
+    }
+
+    @Override
+    public List<?> list(String query, QueryParameters queryParameters) {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public List<?> listCustomQuery(CustomQuery customQuery, QueryParameters queryParameters)
-            throws HibernateException {
+    public List<?> listCustomQuery(CustomQuery customQuery, QueryParameters queryParameters) {
         throw new UnsupportedOperationException();
     }
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive.stage;
 
+import org.hibernate.Cache;
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
 import org.hibernate.FlushMode;
@@ -1152,6 +1153,12 @@ public interface Stage {
 		 * Obtain the JPA {@link Metamodel} for the persistence unit.
 		 */
 		Metamodel getMetamodel();
+
+		/**
+		 * Obtain the {@link Cache} object for managing the second-level
+		 * cache.
+		 */
+		Cache getCache();
 
 		/**
 		 * Destroy the session factory and clean up its connection pool.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive.stage.impl;
 
+import org.hibernate.Cache;
 import org.hibernate.HibernateException;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.reactive.pool.ReactiveConnectionPool;
@@ -103,6 +104,11 @@ public class StageSessionFactoryImpl implements Stage.SessionFactory {
 	@Override
 	public Metamodel getMetamodel() {
 		return delegate.getMetamodel();
+	}
+
+	@Override
+	public Cache getCache() {
+		return delegate.getCache();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
@@ -1,0 +1,128 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.annotations.Cache;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.cfg.Environment;
+import org.junit.Test;
+
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import static org.hibernate.annotations.CacheConcurrencyStrategy.NONSTRICT_READ_WRITE;
+
+public class CacheTest extends BaseReactiveTest {
+
+    @Override
+    protected Configuration constructConfiguration() {
+        Configuration configuration = super.constructConfiguration();
+        configuration.addAnnotatedClass( Named.class );
+        configuration.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "true" );
+        configuration.setProperty( Environment.CACHE_REGION_FACTORY, "org.hibernate.cache.jcache.JCacheRegionFactory" );
+        configuration.setProperty( "hibernate.javax.cache.provider", "org.ehcache.jsr107.EhcacheCachingProvider" );
+        configuration.setProperty( "hibernate.javax.cache.uri", "/ehcache.xml" );
+        return configuration;
+    }
+
+    @Test
+    public void testCache(TestContext context) {
+        test( context,
+                getSessionFactory().withTransaction(
+                        (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
+                )
+                        //populate the cache
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("from Named" ).getResultList()
+                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
+                        ) )
+                        //change the database
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("update Named set name='x'||name" ).executeUpdate()
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 1)
+                                        .thenAccept( n-> context.assertEquals("foo", n.name) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 2)
+                                        .thenAccept( n-> context.assertEquals("bar", n.name) )
+                        ) )
+                        //repopulate the cache
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("from Named" )/*.setCacheMode(CacheMode.REFRESH)*/.getResultList()
+                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 1)
+                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
+                        ) )
+        );
+    }
+
+    @Test
+    public void testCache2(TestContext context) {
+        test( context,
+                getSessionFactory().withTransaction(
+                        (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
+                )
+                        //populate the cache
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("from Named" ).getResultList()
+                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
+                        ) )
+                        //change the database
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("update Named set name='x'||name" ).executeUpdate()
+                        ) )
+                        .thenAccept( v-> getSessionFactory().getCache().evict(Named.class) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 1)
+                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 2)
+                                        .thenAccept( n-> context.assertEquals("xbar", n.name) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 1)
+                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 2)
+                                        .thenAccept( n-> context.assertEquals("xbar", n.name) )
+                        ) )
+                        //repopulate the cache
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.createQuery("from Named" )/*.setCacheMode(CacheMode.REFRESH)*/.getResultList()
+                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
+                        ) )
+                        .thenCompose( v-> getSessionFactory().withSession(
+                                s -> s.find(Named.class, 1)
+                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
+                        ) )
+        );
+    }
+
+    @Entity(name="Named")
+    @Cacheable
+    @Cache(region="named", usage=NONSTRICT_READ_WRITE)
+    static class Named {
+        @Id @GeneratedValue
+        Integer id;
+        String name;
+
+        public Named(String name) {
+            this.name = name;
+        }
+
+        public Named() {}
+    }
+
+}

--- a/hibernate-reactive-core/src/test/resources/ehcache.xml
+++ b/hibernate-reactive-core/src/test/resources/ehcache.xml
@@ -1,0 +1,7 @@
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns="http://www.ehcache.org/v3"
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.5.xsd">
+    <cache alias="named">
+        <heap unit="entries">100</heap>
+    </cache>
+</config>


### PR DESCRIPTION
- add `SessionFactory.getCache()`
- add some basic tests for EHCache

For #184