### PR TITLE
support for OPTIMISTIC + OPTIMISTIC_FORCE_INCREMENT LockModes

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
@@ -1,0 +1,25 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Contract representing some process that needs to occur during after transaction completion.
+ *
+ * @author Steve Ebersole
+ */
+public interface ReactiveAfterTransactionCompletionProcess {
+	/**
+	 * Perform whatever processing is encapsulated here after completion of the transaction.
+	 *
+	 * @param success Did the transaction complete successfully?  True means it did.
+	 * @param session The session on which the transaction is completing.
+	 */
+	CompletionStage<Void> doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
@@ -5,13 +5,14 @@
  */
 package org.hibernate.reactive.engine;
 
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.reactive.session.ReactiveSession;
 
 import java.util.concurrent.CompletionStage;
 
 /**
  * Contract representing some process that needs to occur during after transaction completion.
  *
+ * @author Gavin King
  * @author Steve Ebersole
  */
 public interface ReactiveAfterTransactionCompletionProcess {
@@ -21,5 +22,5 @@ public interface ReactiveAfterTransactionCompletionProcess {
 	 * @param success Did the transaction complete successfully?  True means it did.
 	 * @param session The session on which the transaction is completing.
 	 */
-	CompletionStage<Void> doAfterTransactionCompletion(boolean success, SharedSessionContractImplementor session);
+	CompletionStage<Void> doAfterTransactionCompletion(boolean success, ReactiveSession session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
@@ -1,0 +1,24 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine;
+
+import org.hibernate.engine.spi.SessionImplementor;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Contract representing some process that needs to occur during before transaction completion.
+ *
+ * @author Steve Ebersole
+ */
+public interface ReactiveBeforeTransactionCompletionProcess {
+	/**
+	 * Perform whatever processing is encapsulated here before completion of the transaction.
+	 *
+	 * @param session The session on which the transaction is preparing to complete.
+	 */
+	CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
@@ -5,13 +5,14 @@
  */
 package org.hibernate.reactive.engine;
 
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.reactive.session.ReactiveSession;
 
 import java.util.concurrent.CompletionStage;
 
 /**
  * Contract representing some process that needs to occur during before transaction completion.
  *
+ * @author Gavin King
  * @author Steve Ebersole
  */
 public interface ReactiveBeforeTransactionCompletionProcess {
@@ -20,5 +21,5 @@ public interface ReactiveBeforeTransactionCompletionProcess {
 	 *
 	 * @param session The session on which the transaction is preparing to complete.
 	 */
-	CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session);
+	CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
@@ -1,0 +1,59 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import org.hibernate.LockMode;
+import org.hibernate.LockOptions;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
+import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A BeforeTransactionCompletionProcess impl to verify and increment an entity version as party
+ * of before-transaction-completion processing
+ *
+ * @author Scott Marlow
+ * @author Gavin King
+ */
+public class ReactiveEntityIncrementVersionProcess implements ReactiveBeforeTransactionCompletionProcess {
+	private final Object object;
+
+	/**
+	 * Constructs an EntityIncrementVersionProcess for the given entity.
+	 *
+	 * @param object The entity instance
+	 */
+	public ReactiveEntityIncrementVersionProcess(Object object) {
+		this.object = object;
+	}
+
+	/**
+	 * Perform whatever processing is encapsulated here before completion of the transaction.
+	 *
+	 * @param session The session on which the transaction is preparing to complete.
+	 */
+	@Override
+	public CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session) {
+		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+		// Don't increment version for an entity that is not in the PersistenceContext;
+		if ( entry == null ) {
+			return CompletionStages.voidFuture();
+		}
+
+		return ( (ReactiveEntityPersister) entry.getPersister() )
+				.lockReactive(
+						entry.getId(),
+						entry.getVersion(),
+						object,
+						new LockOptions(LockMode.PESSIMISTIC_FORCE_INCREMENT),
+						session
+				);
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
@@ -8,9 +8,9 @@ package org.hibernate.reactive.engine.impl;
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
+import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import java.util.concurrent.CompletionStage;
@@ -40,7 +40,7 @@ public class ReactiveEntityIncrementVersionProcess implements ReactiveBeforeTran
 	 * @param session The session on which the transaction is preparing to complete.
 	 */
 	@Override
-	public CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session) {
+	public CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
 		// Don't increment version for an entity that is not in the PersistenceContext;
 		if ( entry == null ) {
@@ -53,7 +53,7 @@ public class ReactiveEntityIncrementVersionProcess implements ReactiveBeforeTran
 						entry.getVersion(),
 						object,
 						new LockOptions(LockMode.PESSIMISTIC_FORCE_INCREMENT),
-						session
+						session.getSharedContract()
 				);
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
@@ -1,0 +1,58 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import org.hibernate.dialect.lock.OptimisticEntityLockException;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.pretty.MessageHelper;
+import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
+import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * A BeforeTransactionCompletionProcess impl to verify an entity version as part of
+ * before-transaction-completion processing
+ *
+ * @author Scott Marlow
+ * @author Gavin King
+ */
+public class ReactiveEntityVerifyVersionProcess implements ReactiveBeforeTransactionCompletionProcess {
+	private final Object object;
+
+	/**
+	 * Constructs an EntityVerifyVersionProcess
+	 *
+	 * @param object The entity instance
+	 */
+	public ReactiveEntityVerifyVersionProcess(Object object) {
+		this.object = object;
+	}
+
+	@Override
+	public CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session) {
+		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
+		// Don't check version for an entity that is not in the PersistenceContext;
+		if ( entry == null ) {
+			return CompletionStages.voidFuture();
+		}
+
+		return ( (ReactiveEntityPersister) entry.getPersister() )
+				.reactiveGetCurrentVersion( entry.getId(), session )
+				.thenAccept( latestVersion -> {
+					if ( !entry.getVersion().equals( latestVersion ) ) {
+						throw new OptimisticEntityLockException(
+								object,
+								"Newer version [" + latestVersion +
+										"] of entity [" + MessageHelper.infoString( entry.getEntityName(), entry.getId() ) +
+										"] found in database"
+						);
+					}
+				} );
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
@@ -7,10 +7,10 @@ package org.hibernate.reactive.engine.impl;
 
 import org.hibernate.dialect.lock.OptimisticEntityLockException;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.pretty.MessageHelper;
 import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
+import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import java.util.concurrent.CompletionStage;
@@ -35,7 +35,7 @@ public class ReactiveEntityVerifyVersionProcess implements ReactiveBeforeTransac
 	}
 
 	@Override
-	public CompletionStage<Void> doBeforeTransactionCompletion(SessionImplementor session) {
+	public CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
 		// Don't check version for an entity that is not in the PersistenceContext;
 		if ( entry == null ) {
@@ -43,7 +43,7 @@ public class ReactiveEntityVerifyVersionProcess implements ReactiveBeforeTransac
 		}
 
 		return ( (ReactiveEntityPersister) entry.getPersister() )
-				.reactiveGetCurrentVersion( entry.getId(), session )
+				.reactiveGetCurrentVersion( entry.getId(), session.getSharedContract() )
 				.thenAccept( latestVersion -> {
 					if ( !entry.getVersion().equals( latestVersion ) ) {
 						throw new OptimisticEntityLockException(

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
@@ -164,13 +164,15 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 				ck = null;
 			}
 
-			return ((ReactiveEntityPersister) persister).lockReactive(
-					entry.getId(),
-					entry.getVersion(),
-					object,
-					lockOptions,
-					source
-			).thenAccept( v -> entry.setLockMode(requestedLockMode) )
+			return ((ReactiveEntityPersister) persister)
+					.lockReactive(
+							entry.getId(),
+							entry.getVersion(),
+							object,
+							lockOptions,
+							source
+					)
+					.thenAccept( v -> entry.setLockMode(requestedLockMode) )
 					.whenComplete( (r, e) -> {
 						// the database now holds a lock + the object is flushed from the cache,
 						// so release the soft lock

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePostLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePostLoadEventListener.java
@@ -1,0 +1,70 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.event.impl;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.LockMode;
+import org.hibernate.classic.Lifecycle;
+import org.hibernate.engine.spi.EntityEntry;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.event.spi.PostLoadEvent;
+import org.hibernate.event.spi.PostLoadEventListener;
+import org.hibernate.jpa.event.spi.CallbackRegistry;
+import org.hibernate.jpa.event.spi.CallbackRegistryConsumer;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.reactive.engine.impl.ReactiveEntityIncrementVersionProcess;
+import org.hibernate.reactive.engine.impl.ReactiveEntityVerifyVersionProcess;
+import org.hibernate.reactive.session.ReactiveSession;
+
+/**
+ * We do 2 things here:<ul>
+ * <li>Call {@link Lifecycle} interface if necessary</li>
+ * <li>Perform needed {@link EntityEntry#getLockMode()} related processing</li>
+ * </ul>
+ *
+ * @author Gavin King
+ * @author Steve Ebersole
+ */
+public class DefaultReactivePostLoadEventListener implements PostLoadEventListener, CallbackRegistryConsumer {
+	private CallbackRegistry callbackRegistry;
+
+	@Override
+	public void injectCallbackRegistry(CallbackRegistry callbackRegistry) {
+		this.callbackRegistry = callbackRegistry;
+	}
+
+	@Override
+	public void onPostLoad(PostLoadEvent event) {
+		final Object entity = event.getEntity();
+
+		callbackRegistry.postLoad( entity );
+
+		final SessionImplementor session = event.getSession();
+		final EntityEntry entry = session.getPersistenceContextInternal().getEntry( entity );
+		if ( entry == null ) {
+			throw new AssertionFailure( "possible non-threadsafe access to the session" );
+		}
+
+		final LockMode lockMode = entry.getLockMode();
+		if ( LockMode.PESSIMISTIC_FORCE_INCREMENT.equals( lockMode ) ) {
+			final EntityPersister persister = entry.getPersister();
+			final Object nextVersion = persister.forceVersionIncrement(
+					entry.getId(),
+					entry.getVersion(),
+					session
+			);
+			entry.forceLocked( entity, nextVersion );
+		}
+		else if ( LockMode.OPTIMISTIC_FORCE_INCREMENT.equals( lockMode ) ) {
+			((ReactiveSession) session).getReactiveActionQueue()
+					.registerProcess( new ReactiveEntityIncrementVersionProcess( entity ) );
+		}
+		else if ( LockMode.OPTIMISTIC.equals( lockMode ) ) {
+			((ReactiveSession) session).getReactiveActionQueue()
+					.registerProcess( new ReactiveEntityVerifyVersionProcess( entity ) );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePostLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePostLoadEventListener.java
@@ -14,7 +14,6 @@ import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PostLoadEventListener;
 import org.hibernate.jpa.event.spi.CallbackRegistry;
 import org.hibernate.jpa.event.spi.CallbackRegistryConsumer;
-import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.reactive.engine.impl.ReactiveEntityIncrementVersionProcess;
 import org.hibernate.reactive.engine.impl.ReactiveEntityVerifyVersionProcess;
 import org.hibernate.reactive.session.ReactiveSession;
@@ -48,17 +47,8 @@ public class DefaultReactivePostLoadEventListener implements PostLoadEventListen
 			throw new AssertionFailure( "possible non-threadsafe access to the session" );
 		}
 
-		final LockMode lockMode = entry.getLockMode();
-		if ( LockMode.PESSIMISTIC_FORCE_INCREMENT.equals( lockMode ) ) {
-			final EntityPersister persister = entry.getPersister();
-			final Object nextVersion = persister.forceVersionIncrement(
-					entry.getId(),
-					entry.getVersion(),
-					session
-			);
-			entry.forceLocked( entity, nextVersion );
-		}
-		else if ( LockMode.OPTIMISTIC_FORCE_INCREMENT.equals( lockMode ) ) {
+		LockMode lockMode = entry.getLockMode();
+		if ( LockMode.OPTIMISTIC_FORCE_INCREMENT.equals( lockMode ) ) {
 			((ReactiveSession) session).getReactiveActionQueue()
 					.registerProcess( new ReactiveEntityIncrementVersionProcess( entity ) );
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -802,15 +802,19 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 		}
 	}
 
-	default CompletionStage<Object> reactiveLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	default CompletionStage<Object> reactiveLoad(Serializable id, Object optionalObject, LockOptions lockOptions,
+												 SharedSessionContractImplementor session) {
 		return reactiveLoad( id, optionalObject, lockOptions, session, null );
 	}
 
-	default CompletionStage<Object> reactiveLoad(Serializable id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
+	default CompletionStage<Object> reactiveLoad(Serializable id, Object optionalObject, LockOptions lockOptions,
+												 SharedSessionContractImplementor session, Boolean readOnly) {
 		if ( log.isTraceEnabled() ) {
 			log.tracev( "Fetching entity: {0}", infoString( this, id, getFactory() ) );
 		}
-		return getAppropriateLoader( lockOptions, session ).load( id, optionalObject, session, lockOptions, readOnly );
+
+		return getAppropriateLoader( lockOptions, session )
+				.load( id, optionalObject, session, lockOptions, readOnly );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
@@ -78,7 +78,7 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	/**
 	 * Obtain a pessimistic lock without blocking
 	 */
-	CompletionStage<?> lockReactive(
+	CompletionStage<Void> lockReactive(
 			Serializable id,
 			Object version,
 			Object object,
@@ -104,6 +104,9 @@ public interface ReactiveEntityPersister extends EntityPersister {
 
 	ReactiveUniqueEntityLoader getAppropriateLoader(LockOptions lockOptions,
 													SharedSessionContractImplementor session);
+
+	CompletionStage<Object> reactiveGetCurrentVersion(Serializable id,
+													  SharedSessionContractImplementor session);
 
 	/**
 	 * Get the current database state of the object, in a "hydrated" form, without

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveIntegrator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveIntegrator.java
@@ -56,6 +56,7 @@ public class ReactiveIntegrator implements Integrator {
 			eventListenerRegistry.getEventListenerGroup( EventType.LOCK ).appendListener( new DefaultReactiveLockEventListener() );
 			eventListenerRegistry.getEventListenerGroup( EventType.LOAD ).appendListener( new DefaultReactiveLoadEventListener() );
 			eventListenerRegistry.getEventListenerGroup( EventType.INIT_COLLECTION ).appendListener( new DefaultReactiveInitializeCollectionEventListener() );
+			eventListenerRegistry.getEventListenerGroup( EventType.POST_LOAD ).appendListener( new DefaultReactivePostLoadEventListener() );
 		}
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
@@ -11,6 +11,8 @@ import org.hibernate.FlushMode;
 import org.hibernate.Incubating;
 import org.hibernate.LockMode;
 import org.hibernate.UnknownProfileException;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.internal.MergeContext;
 import org.hibernate.internal.util.collections.IdentitySet;
 import org.hibernate.reactive.engine.ReactiveActionQueue;
@@ -36,6 +38,11 @@ import java.util.concurrent.CompletionStage;
 public interface ReactiveSession extends ReactiveQueryExecutor {
 
 	ReactiveActionQueue getReactiveActionQueue();
+
+	PersistenceContext getPersistenceContext();
+
+	@Override
+	SessionImplementor getSharedContract();
 
 	<T> CompletionStage<T> reactiveFetch(T association, boolean unproxy);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -27,7 +27,7 @@ import org.hibernate.engine.spi.NamedQueryDefinition;
 import org.hibernate.engine.spi.NamedSQLQueryDefinition;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
-import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.event.internal.MergeContext;
 import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.AutoFlushEvent;
@@ -126,7 +126,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	}
 
 	@Override
-	public SharedSessionContractImplementor getSharedContract() {
+	public SessionImplementor getSharedContract() {
 		return this;
 	}
 


### PR DESCRIPTION
These `LockMode`s force a version check or upgrade right at the end of the transaction.

This required building infrastructure for reactive before/after transaction completion events.

Fixes #201

Still TODO: support passing `OPTIMISTIC`, `OPTIMISTIC_FORCE_INCREMENT` to `session.lock()`