### PR TITLE
disallow detached args to remove(), lock(), and refresh()

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
@@ -107,6 +107,14 @@ public class DefaultReactiveDeleteEventListener
 
 		final EventSource source = event.getSession();
 
+		boolean detached = event.getEntityName() != null
+				? !source.contains( event.getEntityName(), event.getObject() )
+				: !source.contains( event.getObject() );
+		if ( detached ) {
+			// Hibernate Reactive doesn't support detached instances in refresh()
+			throw new IllegalArgumentException("unmanaged instance passed to refresh()");
+		}
+
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		Object entity = persistenceContext.unproxyAndReassociate( event.getObject() );
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
@@ -62,6 +62,14 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 		}
 
 		SessionImplementor source = event.getSession();
+		boolean detached = event.getEntityName() != null
+				? !source.contains( event.getEntityName(), event.getObject() )
+				: !source.contains( event.getObject() );
+		if ( detached ) {
+			// Hibernate Reactive doesn't support detached instances in refresh()
+			throw new IllegalArgumentException("unmanaged instance passed to refresh()");
+		}
+
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		Object entity = persistenceContext.unproxyAndReassociate( event.getObject() );
 		//TODO: if object was an uninitialized proxy, this is inefficient,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -386,7 +386,9 @@ public interface Mutiny {
 		 * {@code session.delete(book).thenAccept(v -> session.flush());}
 		 * </pre>
 		 *
-		 * @param entity the instance to be removed
+		 * @param entity the managed persistent instance to be removed
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 *
 		 * @see javax.persistence.EntityManager#remove(Object)
 		 */
@@ -437,7 +439,9 @@ public interface Mutiny {
 		 * <li>after executing direct native SQL in the same session.
 		 * </ul>
 		 *
-		 * @param entity a persistent or detached instance
+		 * @param entity a managed persistent instance
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 *
 		 * @see javax.persistence.EntityManager#refresh(Object)
 		 */
@@ -475,8 +479,10 @@ public interface Mutiny {
 		 * This operation cascades to associated instances if the association is
 		 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
 		 *
-		 * @param entity a persistent or transient instance
+		 * @param entity a managed persistent instance
 		 * @param lockMode the lock level
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 */
 		Uni<Session> lock(Object entity, LockMode lockMode);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -370,7 +370,9 @@ public interface Stage {
 		 * {@code session.delete(book).thenAccept(v -> session.flush());}
 		 * </pre>
 		 *
-		 * @param entity the instance to be removed
+		 * @param entity the managed persistent instance to be removed
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 *
 		 * @see javax.persistence.EntityManager#remove(Object)
 		 */
@@ -421,7 +423,9 @@ public interface Stage {
 		 * <li>after executing direct native SQL in the same session.
 		 * </ul>
 		 *
-		 * @param entity a persistent or detached instance
+		 * @param entity a managed persistent instance
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 *
 		 * @see javax.persistence.EntityManager#refresh(Object)
 		 */
@@ -459,8 +463,10 @@ public interface Stage {
 		 * This operation cascades to associated instances if the association is
 		 * mapped with {@link org.hibernate.annotations.CascadeType#LOCK}.
 		 *
-		 * @param entity a persistent or transient instance
+		 * @param entity a managed persistent instance
 		 * @param lockMode the lock level
+		 *
+		 * @throws IllegalArgumentException if the given instance is not managed
 		 */
 		CompletionStage<Session> lock(Object entity, LockMode lockMode);
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -117,7 +118,7 @@ public class CompositeIdTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test
+	@Test @Ignore("we don't support remove(detached) anymore")
 	public void reactiveRemoveTransientEntity(TestContext context) {
 		test(
 				context,

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -118,7 +117,7 @@ public class CompositeIdTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test @Ignore("we don't support remove(detached) anymore")
+	@Test
 	public void reactiveRemoveTransientEntity(TestContext context) {
 		test(
 				context,
@@ -131,6 +130,7 @@ public class CompositeIdTest extends BaseReactiveTest {
 						.whenComplete( (session, err) -> session.close() )
 						.thenCompose( v -> selectNameFromId( 5 ) )
 						.thenAccept( context::assertNull )
+						.handle((r, e) -> context.assertNotNull(e))
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
@@ -47,10 +47,7 @@ public class HQLQueryParameterNamedLimitTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
@@ -47,10 +47,7 @@ public class HQLQueryParameterNamedTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
@@ -50,10 +50,7 @@ public class HQLQueryParameterPositionalLimitTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
@@ -50,10 +50,7 @@ public class HQLQueryParameterPositionalTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryTest.java
@@ -45,10 +45,7 @@ public class HQLQueryTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
@@ -45,10 +45,7 @@ public class HQLUpdateQueryTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, completedFuture( openSession() )
-				.thenCompose( s -> s.remove( spelt ) )
-				.thenCompose( s -> s.remove( rye ) )
-				.thenCompose( s -> s.remove( almond ) )
-				.thenCompose( s -> s.flush() ) );
+				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
@@ -9,6 +9,7 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.LockMode;
 import org.hibernate.cfg.Configuration;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -249,7 +250,7 @@ public class MutinySessionTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test
+	@Test @Ignore("we don't support remove(detached) anymore")
 	public void reactiveRemoveTransientEntity1(TestContext context) {
 		test(
 				context,
@@ -263,7 +264,7 @@ public class MutinySessionTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test
+	@Test @Ignore("we don't support remove(detached) anymore")
 	public void reactiveRemoveTransientEntity2(TestContext context) {
 		test(
 				context,

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
@@ -9,7 +9,6 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.LockMode;
 import org.hibernate.cfg.Configuration;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -250,7 +249,7 @@ public class MutinySessionTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test @Ignore("we don't support remove(detached) anymore")
+	@Test
 	public void reactiveRemoveTransientEntity1(TestContext context) {
 		test(
 				context,
@@ -258,13 +257,15 @@ public class MutinySessionTest extends BaseReactiveTest {
 						.onItem().invokeUni( v -> selectNameFromId( 5 ).onItem().invoke( context::assertNotNull ) )
 						.onItem().transform( v -> openMutinySession() )
 						.onItem().invokeUni( session -> session.remove( new GuineaPig( 5, "Aloi" ) ) )
-						.onItem().invokeUni( session -> session.flush() )
-						.onTermination().invoke( (session, err, c) -> session.close() )
-						.onItem().invokeUni( v -> selectNameFromId( 5 ).onItem().invoke( context::assertNull ) )
+						.onItem().invoke( v -> context.fail() )
+						.onFailure().recoverWithItem( v -> null )
+//						.onItem().invokeUni( session -> session.flush() )
+//						.onTermination().invoke( (session, err, c) -> session.close() )
+//						.onItem().invokeUni( v -> selectNameFromId( 5 ).onItem().invoke( context::assertNull ) )
 		);
 	}
 
-	@Test @Ignore("we don't support remove(detached) anymore")
+	@Test
 	public void reactiveRemoveTransientEntity2(TestContext context) {
 		test(
 				context,
@@ -273,9 +274,11 @@ public class MutinySessionTest extends BaseReactiveTest {
 						.invoke( context::assertNotNull )
 						.map( v -> openMutinySession() )
 						.chain( session -> session.remove( new GuineaPig( 5, "Aloi" ) ) )
-						.chain( session -> session.flush().eventually(session::close) )
-						.then( () -> selectNameFromId( 5 ) )
-						.invoke( context::assertNull )
+						.onItem().invoke( v -> context.fail() )
+						.onFailure().recoverWithItem( v -> null )
+//						.chain( session -> session.flush().eventually(session::close) )
+//						.then( () -> selectNameFromId( 5 ) )
+//						.invoke( context::assertNull )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -10,6 +10,7 @@ import org.hibernate.LockMode;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -557,7 +558,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test
+	@Test @Ignore("we don't support remove(detached) anymore")
 	public void reactiveRemoveTransientEntity(TestContext context) {
 		test(
 				context,

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -10,7 +10,6 @@ import org.hibernate.LockMode;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -558,7 +557,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 		);
 	}
 
-	@Test @Ignore("we don't support remove(detached) anymore")
+	@Test
 	public void reactiveRemoveTransientEntity(TestContext context) {
 		test(
 				context,
@@ -571,6 +570,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						.whenComplete( (session, err) -> session.close() )
 						.thenCompose( v -> selectNameFromId( 5 ) )
 						.thenAccept( context::assertNull )
+						.handle((r, e) -> context.assertNotNull(e))
 		);
 	}
 


### PR DESCRIPTION
This makes HR follow the behavior defined by the JPA spec, instead of legacy Hibernate behavior.

See discussion in #344.