### PR TITLE
overload getReference() to take detached object/proxy

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -369,6 +369,19 @@ public interface Mutiny {
 		<T> T getReference(Class<T> entityClass, Object id);
 
 		/**
+		 * Return the persistent instance of with the same identity as the
+		 * given instance, which might be detached, assuming that the instance
+		 * is still persistent in the database. This method never results in
+		 * access to the underlying data store, and thus might return a proxy
+		 * that must be initialized explicitly using {@link #fetch(Object)}.
+		 *
+		 * @param entity a detached persistent instance
+		 *
+		 * @return the persistent instance or proxy
+		 */
+		<T> T getReference(T entity);
+
+		/**
 		 * Asynchronously persist the given transient instance, first assigning
 		 * a generated identifier. (Or using the current value of the identifier
 		 * property if the entity has assigned identifiers.)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -71,6 +71,11 @@ public class MutinySessionImpl implements Mutiny.Session {
 	}
 
 	@Override
+	public <T> T getReference(T entity) {
+		return delegate.getReference( delegate.getEntityClass(entity), delegate.getEntityId(entity) );
+	}
+
+	@Override
 	public LockMode getLockMode(Object entity) {
 		return delegate.getCurrentLockMode( entity );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
@@ -126,11 +126,14 @@ public interface ReactiveSession extends ReactiveQueryExecutor {
 	void setReadOnly(Object entityOrProxy, boolean readOnly);
 	boolean isReadOnly(Object entityOrProxy);
 
-	String getEntityName(Object object);
-	Serializable getIdentifier(Object object);
-	boolean contains(Object object);
+	String getEntityName(Object entity);
+	Serializable getIdentifier(Object entity);
+	boolean contains(Object entity);
 
-	LockMode getCurrentLockMode(Object object);
+	<T> Class<? extends T> getEntityClass(T entity);
+	Serializable getEntityId(Object entity);
+
+	LockMode getCurrentLockMode(Object entity);
 
 	Filter enableFilter(String filterName);
 	void disableFilter(String filterName);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -1323,4 +1323,28 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	public void setBatchSize(Integer batchSize) {
 		setJdbcBatchSize(batchSize);
 	}
+
+	@Override @SuppressWarnings("unchecked")
+	public <T> Class<? extends T> getEntityClass(T entity) {
+		if ( entity instanceof HibernateProxy ) {
+			return ( (HibernateProxy) entity ).getHibernateLazyInitializer()
+					.getPersistentClass();
+		}
+		else {
+			return getEntityPersister(null, entity )
+					.getMappedClass();
+		}
+	}
+
+	@Override
+	public Serializable getEntityId(Object entity) {
+		if ( entity instanceof HibernateProxy ) {
+			return ( (HibernateProxy) entity ).getHibernateLazyInitializer()
+					.getIdentifier();
+		}
+		else {
+			return getEntityPersister(null, entity )
+					.getIdentifier( entity, this );
+		}
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -335,8 +335,8 @@ public interface Stage {
 		 * Return the persistent instance of the given entity class with the
 		 * given identifier, assuming that the instance exists. This method
 		 * never results in access to the underlying data store, and thus
-		 * might return a proxied instance that must be initialized explicitly
-		 * using {@link #fetch(Object)}.
+		 * might return a proxy that must be initialized explicitly using
+		 * {@link #fetch(Object)}.
 		 * <p>
 		 * You should not use this method to determine if an instance exists
 		 * (use {@link #find} instead). Use this only to retrieve an instance
@@ -351,6 +351,19 @@ public interface Stage {
 		 * @see javax.persistence.EntityManager#getReference(Class, Object)
 		 */
 		<T> T getReference(Class<T> entityClass, Object id);
+
+		/**
+		 * Return the persistent instance of with the same identity as the
+		 * given instance, which might be detached, assuming that the instance
+		 * is still persistent in the database. This method never results in
+		 * access to the underlying data store, and thus might return a proxy
+		 * that must be initialized explicitly using {@link #fetch(Object)}.
+		 *
+		 * @param entity a detached persistent instance
+		 *
+		 * @return the persistent instance or proxy
+		 */
+		<T> T getReference(T entity);
 
 		/**
 		 * Asynchronously persist the given transient instance, first assigning

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -72,6 +72,11 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
+	public <T> T getReference(T entity) {
+		return delegate.getReference( delegate.getEntityClass(entity), delegate.getEntityId(entity) );
+	}
+
+	@Override
 	public LockMode getLockMode(Object entity) {
 		return delegate.getCurrentLockMode( entity );
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
@@ -1,0 +1,231 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.Hibernate;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.stage.Stage;
+import org.junit.Test;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
+
+public class ReferenceTest extends BaseReactiveTest {
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Book.class );
+		configuration.addAnnotatedClass( Author.class );
+		return configuration;
+	}
+
+	@Test
+	public void testDetachedEntityReference(TestContext context) {
+		final Book goodOmens = new Book("Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch");
+
+		test(
+				context,
+				completedFuture( openSession() )
+						.thenCompose( s -> s.persist(goodOmens).thenCompose(v -> s.flush()) )
+						.thenApply(v -> openSession())
+						.thenCompose(s -> {
+							Book book = s.getReference(Book.class, goodOmens.getId());
+							context.assertFalse( Hibernate.isInitialized(book) );
+							return s.persist( new Author("Neil Gaiman", book) )
+									.thenCompose( v -> s.flush() );
+						} )
+						.thenApply(v -> openSession())
+						.thenCompose( s -> {
+							Book book = s.getReference(goodOmens);
+							context.assertFalse( Hibernate.isInitialized(book) );
+							return s.persist( new Author("Terry Pratchett", book) )
+									.thenCompose( v -> s.flush() );
+						} )
+						.thenApply(v -> openSession())
+						.thenCompose( s -> {
+							Book book = s.getReference(goodOmens);
+							context.assertFalse( Hibernate.isInitialized(book) );
+							return Stage.fetch(book).thenCompose( v -> Stage.fetch( book.getAuthors() ) );
+						} )
+						.thenAccept( optionalAssociation -> {
+							context.assertTrue( Hibernate.isInitialized(optionalAssociation) );
+							context.assertNotNull(optionalAssociation);
+							context.assertEquals( 2, optionalAssociation.size() );
+						} )
+		);
+	}
+
+	@Test
+	public void testDetachedProxyReference(TestContext context) {
+		final Book goodOmens = new Book("Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch");
+
+		test(
+				context,
+				completedFuture( openSession() )
+						.thenCompose( s -> s.persist(goodOmens).thenCompose(v -> s.flush()) )
+						.thenApply(v -> openSession())
+						.thenCompose( sess -> {
+							Book reference = sess.getReference(goodOmens);
+							context.assertFalse( Hibernate.isInitialized(reference) );
+							sess.close();
+							return completedFuture( openSession() )
+									.thenCompose(s -> {
+										Book book = s.getReference(Book.class, reference.getId());
+										context.assertFalse( Hibernate.isInitialized(book) );
+										context.assertFalse( Hibernate.isInitialized(reference) );
+										return s.persist( new Author("Neil Gaiman", book) )
+												.thenCompose( v -> s.flush() );
+									} )
+									.thenApply(v -> openSession())
+									.thenCompose( s -> {
+										Book book = s.getReference(reference);
+										context.assertFalse( Hibernate.isInitialized(book) );
+										context.assertFalse( Hibernate.isInitialized(reference) );
+										return s.persist( new Author("Terry Pratchett", book) )
+												.thenCompose( v -> s.flush() );
+									} )
+									.thenApply(v -> openSession())
+									.thenCompose( s -> {
+										Book book = s.getReference(reference);
+										context.assertFalse( Hibernate.isInitialized(book) );
+										context.assertFalse( Hibernate.isInitialized(reference) );
+										return Stage.fetch(book).thenCompose( v -> Stage.fetch( book.getAuthors() ) );
+									} )
+									.thenAccept( optionalAssociation -> {
+										context.assertTrue( Hibernate.isInitialized(optionalAssociation) );
+										context.assertNotNull(optionalAssociation);
+										context.assertEquals( 2, optionalAssociation.size() );
+									} );
+						} )
+		);
+	}
+
+	@Entity(name =  "Tome")
+	@Table(name = "Book")
+	public static class Book {
+
+		@Id @GeneratedValue
+		private Integer id;
+		private String title;
+
+		@OneToMany(fetch = FetchType.LAZY, mappedBy="book")
+		private List<Author> authors = new ArrayList<>();
+
+		public Book() {
+		}
+
+		public Book(String title) {
+			this.title = title;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public void setTitle(String title) {
+			this.title = title;
+		}
+
+		public List<Author> getAuthors() {
+			return authors;
+		}
+
+		public void setAuthors(List<Author> authors) {
+			this.authors = authors;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Book book = (Book) o;
+			return Objects.equals( title, book.title );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( title );
+		}
+	}
+
+	@Entity(name = "Writer")
+	@Table(name = "Author")
+	public static class Author {
+
+		@Id @GeneratedValue
+		private Integer id;
+		private String name;
+
+		@ManyToOne(fetch = FetchType.LAZY, optional = false)
+		private Book book;
+
+		public Author() {
+		}
+
+		public Author(String name, Book book) {
+			this.name = name;
+			this.book = book;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Book getBook() {
+			return book;
+		}
+
+		public void setBook(Book book) {
+			this.book = book;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Author author = (Author) o;
+			return Objects.equals( name, author.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+	}
+}


### PR DESCRIPTION
This new method gives you an easy way to transform a detached entity reference to a managed reference without hitting the database.

We should add this to Hibernate ORM core also.

fixes #355