### PR TITLE
Remove layout property for logs

### DIFF
--- a/hibernate-reactive-core/src/test/resources/log4j2.properties
+++ b/hibernate-reactive-core/src/test/resources/log4j2.properties
@@ -9,5 +9,4 @@ logger.hibernate.level = info
 appender.console.name = console
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{%p} %style{%c{1}}{Blue} %m%n
 


### PR DESCRIPTION
It is not user friendly for people with some type of colour blindness.

Please, let's try to avoid changing the default colours in the project. It's very personal and everybody is more than capable of customising the working environment if needed