### PR TITLE
[#361] Track ORM 5.4 snapshots

### DIFF
--- a/.github/workflows/tracking-orm-5.4.build.yml
+++ b/.github/workflows/tracking-orm-5.4.build.yml
@@ -1,0 +1,122 @@
+name: Latest ORM 5.4
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every hour at minute 25
+    - cron: '25 * * * *'
+
+jobs:
+  # The examples test the Hibernate ORM Gradle plugin. We use it for bytecode enhancements.
+  run_example_mysql:
+    name: Run examples on MySQL
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      mysql:
+        # Docker Hub image
+        image: mysql
+        env:
+          MYSQL_ROOT_PASSWORD: hreact
+          MYSQL_DATABASE: hreact
+          MYSQL_USER: hreact
+          MYSQL_PASSWORD: hreact
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        with:
+          java-version: 1.8
+        uses: actions/setup-java@v1
+      - name: Print the effective ORM version used
+        run: ./gradlew :example:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+      - name: Run examples on MySQL
+        run: ./gradlew :example:runAllExamplesOnMySQL -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+
+  run_example_postgres:
+    name: Run examples on PostgresSQL
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        env:
+          POSTGRES_DB: hreact
+          POSTGRES_USER: hreact
+          POSTGRES_PASSWORD: hreact
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        with:
+          java-version: 1.8
+        uses: actions/setup-java@v1
+      - name: Print the effective ORM version used
+        run: ./gradlew :example:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+      - name: Run examples on PostgreSQL
+        run: ./gradlew :example:runAllExamplesOnPostgreSQL -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+
+  test_postgresql:
+    name: Test with PostgreSQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective ORM version used
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+      - name: Build and Test with PostgreSQL
+        run: ./gradlew build -Pdb=pg -Pdocker -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+
+  test_mysql:
+    name: Test with MySQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective ORM version used
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+      - name: Build and Test with MySQL
+        run: ./gradlew build -Pdb=mysql -Pdocker -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+
+  test_db2:
+    name: Test with DB2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective ORM version used
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+      - name: Build and Test with DB2
+        run: ./gradlew build -Pdb=db2 -Pdocker -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing

--- a/.github/workflows/tracking-vertx-3.build.yml
+++ b/.github/workflows/tracking-vertx-3.build.yml
@@ -1,0 +1,122 @@
+name: Latest Vert.x 3
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the master branch
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    # * is a special character in YAML so you have to quote this string
+    # Run every hour at minute 25
+    - cron: '25 * * * *'
+
+jobs:
+  # The examples test the Hibernate ORM Gradle plugin. We use it for bytecode enhancements.
+  run_example_mysql:
+    name: Run examples on MySQL
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      mysql:
+        # Docker Hub image
+        image: mysql
+        env:
+          MYSQL_ROOT_PASSWORD: hreact
+          MYSQL_DATABASE: hreact
+          MYSQL_USER: hreact
+          MYSQL_PASSWORD: hreact
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd="mysqladmin ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 3306:3306
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        with:
+          java-version: 1.8
+        uses: actions/setup-java@v1
+      - name: Print the effective Vert.x version used
+        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='[3,4)' | grep io.vertx
+      - name: Run examples on MySQL
+        run: ./gradlew :example:runAllExamplesOnMySQL -PvertxVersion='[3,4)'
+
+  run_example_postgres:
+    name: Run examples on PostgresSQL
+    runs-on: ubuntu-latest
+    services:
+      # Label used to access the service container
+      postgres:
+        # Docker Hub image
+        image: postgres
+        env:
+          POSTGRES_DB: hreact
+          POSTGRES_USER: hreact
+          POSTGRES_PASSWORD: hreact
+        # Set health checks to wait until postgres has started
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        with:
+          java-version: 1.8
+        uses: actions/setup-java@v1
+      - name: Print the effective Vert.x version used
+        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='[3,4)' | grep io.vertx
+      - name: Run examples on PostgreSQL
+        run: ./gradlew :example:runAllExamplesOnPostgreSQL -PvertxVersion='[3,4)'
+
+  test_postgresql:
+    name: Test with PostgreSQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective Vert.x version used
+        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='[3,4)' | grep io.vertx
+      - name: Build and Test with PostgreSQL
+        run: ./gradlew build -Pdb=pg -Pdocker -PvertxVersion='[3,4)'
+
+  test_mysql:
+    name: Test with MySQL
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective Vert.x version used
+        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='[3,4)' | grep io.vertx
+      - name: Build and Test with MySQL
+        run: ./gradlew build -Pdb=mysql -Pdocker -PvertxVersion='[3,4)'
+
+  test_db2:
+    name: Test with DB2
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Print the effective Vert.x version used
+        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='[3,4)' | grep io.vertx
+      - name: Build and Test with DB2
+        run: ./gradlew build -Pdb=db2 -Pdocker -PvertxVersion='[3,4)'

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,13 @@ ext {
         hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
     }
 
-    vertxVersion = '3.9.3'
+    // Mainly, to allow CI to test the latest versions of Vert.X
+    // Example:
+    // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
+    if ( !project.hasProperty('vertxVersion') ) {
+        vertxVersion = '3.9.3'
+    }
+
     testcontainersVersion = '1.14.3'
     baselineJavaVersion = 1.8
 

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,8 @@ subprojects {
         // jcenter()
         // maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
         mavenCentral()
+        // Used only for testing with the latest Hibernate ORM snapshots.
+        maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
     }
     
     ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'

--- a/build.gradle
+++ b/build.gradle
@@ -32,10 +32,31 @@ ext {
         hibernateOrmVersion = '5.4.21.Final'
     }
     // For ORM, we need a parsed version (to get the family, ...)
-    hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
+
+    // For ORM, we need a parsed version (to get the family for the documentation during release).
+    // We use intervals to build with the latest ORM snapshot and this will fail version check.
+    // Because we don't need to publish or release anything we can disable the check in this case.
+    // Example:
+    // ./gradlew build -PhibernateOrmVersion='[5.4,5.5)' -PskipOrmVersionParsing
+    if ( project.hasProperty( 'skipOrmVersionParsing' ) ) {
+        // Default to true if the property is null
+        skipOrmVersionParsing = project.skipOrmVersionParsing ?: true
+    }
+    else {
+        skipOrmVersionParsing = false
+    }
+
+    if ( !Boolean.valueOf( project.skipOrmVersionParsing ) ) {
+        println "Parsing ORM version"
+        hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
+    }
+
     vertxVersion = '3.9.3'
     testcontainersVersion = '1.14.3'
     baselineJavaVersion = 1.8
+
+    println "Hibernate ORM Version: " + project.hibernateOrmVersion
+    println "Vert.x Version: " + project.vertxVersion
 }
 
 subprojects {

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -63,7 +63,7 @@ dbs.each { db ->
                 description = "Run ${mainClass} on ${db}"
                 classpath = sourceSets.main.runtimeClasspath
                 main = "org.hibernate.example.reactive.${mainClass}"
-                // The persistence unit name defined in resources/META-INF/persitence.xml
+                // The persistence unit name defined in resources/META-INF/persistence.xml
                 args db.toLowerCase() + '-example'
             }
         }

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -27,6 +27,8 @@ buildscript {
     repositories {
 //        mavenLocal()
         mavenCentral()
+        // Used only for testing with the latest Hibernate ORM snapshots.
+        maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
     }
     dependencies {
         classpath "org.hibernate:hibernate-gradle-plugin:${hibernateOrmVersion}"


### PR DESCRIPTION
This approach uses GitHub workflows, the JBoss Snapshots repository to download the latest 5.4 ORM SNAPSHOT and will be triggered by push  or pr on master and every hour via a cron job.

I'm testing and running the examples on all dbs but I think a simpler version that runs on Postgres might be enough. I've created it on a separate branch: https://github.com/DavideD/hibernate-reactive/pull/8

I've added a workflow to test 5.5 as well so that I can see that it fails for it but we can remove it for now.

If we want to build the project when ORM build, I will have to look into Jenkins.
