### PR TITLE
[#407] Use dependency insight for vertx version

### DIFF
--- a/.github/workflows/tracking-vertx-3.build.yml
+++ b/.github/workflows/tracking-vertx-3.build.yml
@@ -63,7 +63,7 @@ jobs:
           java-version: 1.8
         uses: actions/setup-java@v1
       - name: Print the effective Vert.x version used
-        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='${{ matrix.vertx-version }}' | grep io.vertx
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}'
       - name: Run examples on ${{ matrix.db }}
         run: ./gradlew :example:runAllExamplesOn${{ matrix.db }} -PvertxVersion='${{ matrix.vertx-version }}'
 
@@ -81,6 +81,6 @@ jobs:
         with:
           java-version: 1.8
       - name: Print the effective Vert.x version used
-        run: ./gradlew :hibernate-reactive-core:dependencies -PvertxVersion='${{ matrix.vertx-version }}' | grep io.vertx
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}'
       - name: Build and Test with ${{ matrix.db }}
         run: ./gradlew build -Pdb=${{ matrix.db }} -Pdocker -PvertxVersion='${{ matrix.vertx-version }}'


### PR DESCRIPTION
The schedule jobs don't fail anymore and I think I was just confused about which job caused the issues.
I took the chance to change how we print the selected library