### PR TITLE
Test against JDK11 / 15 / 16

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -185,7 +185,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Create maven package
+    - name: Create artifacts
       run: ./gradlew assemble
     - name: Detect the version of Hibernate Reactive
       id: detect-version
@@ -208,7 +208,7 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Create maven package
+    - name: Create artifacts
       run: ./gradlew assemble
     - name: Install SSH key
       uses: shimataro/ssh-key-action@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,6 +71,12 @@ jobs:
       uses: actions/setup-java@v1
     - name: Run examples on ${{ matrix.db }}
       run: ./gradlew :example:runAllExamplesOn${{ matrix.db }}
+    - name: Upload reports (if build failed)
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: reports-examples-${{ matrix.db }}
+        path: './**/build/reports/'
 
   test_dbs:
     name: Test with ${{ matrix.db }}
@@ -101,6 +107,12 @@ jobs:
         java-version: 1.8
     - name: Build and Test with ${{ matrix.db }}
       run: ./gradlew build -Pdocker -Pdb=${{ matrix.db }}
+    - name: Upload reports (if build failed)
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: reports-db-${{ matrix.db }}
+        path: './**/build/reports/'
 
   test_jdks:
     name: Test with Java ${{ matrix.java.name }}
@@ -156,6 +168,12 @@ jobs:
       run: |
         ./gradlew build -Pdocker -Ptest.jdk.version=${{ matrix.java.java-version }} \
             -Porg.gradle.java.installations.paths=${{ steps.install-compilejdk.outputs.path }},${{ steps.install-testjdk.outputs.path }}
+    - name: Upload reports (if build failed)
+      uses: actions/upload-artifact@v2
+      if: failure()
+      with:
+        name: reports-java${{ matrix.java.name }}
+        path: './**/build/reports/'
 
   snapshot:
     name: Create snapshot

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,46 @@ jobs:
     - name: Build and Test with ${{ matrix.db }}
       run: ./gradlew build -Pdocker -Pdb=${{ matrix.db }}
 
+  test_jdks:
+    name: Test with Java ${{ matrix.java.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java:
+          - {
+            name: "11",
+            java-version: 11,
+            release_type: "ga"
+          }
+          - {
+            name: "15",
+            java-version: 15,
+            release_type: "ga"
+          }
+          - {
+            name: "16-ea",
+            java-version: 16,
+            release_type: "ea"
+          }
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK ${{ matrix.java.name }}
+      uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+      id: install-testjdk
+      with:
+        java-version: ${{ matrix.java.java-version }}
+        release_type: ${{ matrix.java.release_type }}
+    - name: Set up JDK 11
+      uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
+      id: install-compilejdk
+      with:
+        java-version: 11
+    - name: Build and Test with Java ${{ matrix.java.name }}
+      run: |
+        ./gradlew build -Pdocker -Ptest.jdk.version=${{ matrix.java.java-version }} \
+            -Porg.gradle.java.installations.paths=${{ steps.install-compilejdk.outputs.path }},${{ steps.install-testjdk.outputs.path }}
+
   snapshot:
     name: Create snapshot
     if: github.event_name == 'push' && startsWith( github.ref, 'refs/heads/' )

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,21 @@ jobs:
           - 5432:5432
     steps:
     - uses: actions/checkout@v2
+    - name: Get year/month for cache key
+      id: get-date
+      run: |
+        echo "::set-output name=yearmonth::$(/bin/date -u "+%Y-%m")"
+      shell: bash
+    - name: Cache Gradle downloads
+      uses: actions/cache@v2
+      id: cache-gradle
+      with:
+        path: |
+          .gradle/caches
+          .gradle/jdks
+          .gradle/wrapper
+        # refresh cache every month to avoid unlimited growth
+        key: gradle-examples-${{ matrix.db }}-${{ steps.get-date.outputs.yearmonth }}
     - name: Set up JDK 1.8
       with:
         java-version: 1.8
@@ -65,6 +80,21 @@ jobs:
         db: [ 'MySQL', 'PostgreSQL', 'DB2' ]
     steps:
     - uses: actions/checkout@v2
+    - name: Get year/month for cache key
+      id: get-date
+      run: |
+        echo "::set-output name=yearmonth::$(/bin/date -u "+%Y-%m")"
+      shell: bash
+    - name: Cache Gradle downloads
+      uses: actions/cache@v2
+      id: cache-gradle
+      with:
+        path: |
+          .gradle/caches
+          .gradle/jdks
+          .gradle/wrapper
+        # refresh cache every month to avoid unlimited growth
+        key: gradle-db-${{ matrix.db }}-${{ steps.get-date.outputs.yearmonth }}
     - name: Set up JDK 1.8
       uses: actions/setup-java@v1
       with:
@@ -96,6 +126,21 @@ jobs:
           }
     steps:
     - uses: actions/checkout@v2
+    - name: Get year/month for cache key
+      id: get-date
+      run: |
+        echo "::set-output name=yearmonth::$(/bin/date -u "+%Y-%m")"
+      shell: bash
+    - name: Cache Gradle downloads
+      uses: actions/cache@v2
+      id: cache-gradle
+      with:
+        path: |
+          .gradle/caches
+          .gradle/jdks
+          .gradle/wrapper
+        # refresh cache every month to avoid unlimited growth
+        key: gradle-java${{ matrix.java }}-${{ steps.get-date.outputs.yearmonth }}
     - name: Set up JDK ${{ matrix.java.name }}
       uses: joschi/setup-jdk@e87a7cec853d2dd7066adf837fe12bf0f3d45e52
       id: install-testjdk
@@ -134,7 +179,7 @@ jobs:
         ORG_GRADLE_PROJECT_jbossNexusPassword: ${{ secrets.JBOSS_NEXUS_PASSWORD }}
       if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && env.ORG_GRADLE_PROJECT_jbossNexusUser
       run: ./gradlew publish
-      
+
   release:
     name: Release
     if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )

--- a/build.gradle
+++ b/build.gradle
@@ -59,10 +59,32 @@ ext {
     }
 
     testcontainersVersion = '1.14.3'
-    baselineJavaVersion = 1.8
 
     println "Hibernate ORM Version: " + project.hibernateOrmVersion
     println "Vert.x Version: " + project.vertxVersion
+
+    baselineJavaVersion = JavaLanguageVersion.of( 8 )
+    if ( project.hasProperty( 'test.jdk.version' ) ) {
+        // Testing a particular JDK version
+        // Gradle doesn't support all JDK versions unless we use toolchains
+        javaToolchainEnabled = true
+        // When using toolchains, we expect JDK11 to be used for the build -- always.
+        compileJdkVersion = JavaLanguageVersion.of( 11 )
+        testJdkVersion = JavaLanguageVersion.of( project.getProperty('test.jdk.version') )
+    }
+    else {
+        // Not testing a particular JDK version: we will use the same JDK used to run Gradle.
+        // We disable toolchains for convenience, so that anyone can just run the build with their own JDK
+        // without any additional options and without downloading the whole JDK.
+        javaToolchainEnabled = false
+        compileJdkVersion = JavaLanguageVersion.of( JavaVersion.current().getMajorVersion() )
+        testJdkVersion = compileJdkVersion
+    }
+
+    println "Java version for produced binaries: " + project.baselineJavaVersion
+    println "JDK version when running Gradle: " + JavaVersion.current().getMajorVersion()
+    println "JDK version when compiling: " + project.compileJdkVersion
+    println "JDK version when running tests: " + project.testJdkVersion
 }
 
 subprojects {
@@ -70,9 +92,16 @@ subprojects {
     apply plugin: 'com.diffplug.gradle.spotless'
     group = 'org.hibernate.reactive'
     version = projectVersion
-    sourceCompatibility = project.baselineJavaVersion
-    targetCompatibility = project.baselineJavaVersion
-    compileJava.options.encoding = 'UTF-8'
+
+    if ( project.javaToolchainEnabled ) {
+        compileJava.options.release = project.baselineJavaVersion.asInt()
+        compileJava.options.encoding = 'UTF-8'
+    }
+    else {
+        sourceCompatibility = JavaVersion.toVersion( project.baselineJavaVersion )
+        targetCompatibility = JavaVersion.toVersion( project.baselineJavaVersion )
+        compileJava.options.encoding = 'UTF-8'
+    }
 
     repositories {
         // Only enable these for local development, never push it:
@@ -89,6 +118,32 @@ subprojects {
     }
     
     ext.publishScript = rootProject.rootDir.absolutePath + '/publish.gradle'
+
+    if ( project.javaToolchainEnabled ) {
+        java {
+            toolchain {
+                languageVersion = project.compileJdkVersion
+            }
+        }
+        tasks.withType( JavaCompile ).configureEach {
+            doFirst {
+                println "Compiling with '${javaCompiler.get().metadata.installationPath}'"
+            }
+        }
+        tasks.withType( Javadoc ).configureEach {
+            doFirst {
+                println "Generating javadoc with '${javadocTool.get().metadata.installationPath}'"
+            }
+        }
+        test {
+            javaLauncher = javaToolchains.launcherFor {
+                languageVersion = project.testJdkVersion
+            }
+            doFirst {
+                println "Testing with '${javaLauncher.get().metadata.installationPath}'"
+            }
+        }
+    }
 }
 
 private static String readVersionFromProperties(File file) {

--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -59,7 +59,7 @@ task aggregateJavadocs(type: Javadoc, group: 'Documentation') {
 				"https://docs.jboss.org/hibernate/orm/" + ormMinorVersion + "/javadocs/"
 		]
 		
-		if ( JavaVersion.current().isJava11Compatible() ) {
+		if ( project.compileJdkVersion.asInt() >= 11 ) {
 			//The need to set `--source 1.8` applies to all JVMs after 11, and also to 11
 			// but after excluding the first two builds; see also specific comments on
 			// https://bugs.openjdk.java.net/browse/JDK-8212233?focusedCommentId=14245762

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,11 @@
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en
+# JDK auto-detection is not quite ready yet in Gradle 6.7.
+# On Fedora in particular, if you have the package java-1.8.0-openjdk-headless-1.8.0.265.b01-1.fc32.x86_64 installed,
+# Gradle will look for the Java binaries in /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.265.b01-1.fc32.x86_64/bin/java
+# but it won't find it and will fail.
+# It's just a JRE, so it's perfectly normal that the JDK is not present;
+# the JRE is under /usr/lib/jvm/java-1.8.0-openjdk-1.8.0.265.b01-1.fc32.x86_64/jre
+org.gradle.java.installations.auto-detect=false
+# We can't rely on Gradle's auto-download of JDKs as it doesn't support EA releases.
+# See https://github.com/gradle/gradle/blob/fc7ea24f3c525d8d12a4346eb0f15976a6be9414/subprojects/platform-jvm/src/main/java/org/gradle/jvm/toolchain/install/internal/AdoptOpenJdkRemoteBinary.java#L114
+org.gradle.java.installations.auto-download=false


### PR DESCRIPTION
This changes the Gradle configuration and Github workflow to test Hibernate Reactive with JDK 11 / 15 / 16 on each commit to master or pull request.

More specifically, in per-JDK jobs:

* We compile the project with JDK 11, but with `-release 8` so that Java 8 bytecode is produced.
* We run the tests with a JVM version 11, 15 or 16.

Also, this adds a few caches to builds, in the hope that jobs will be faster, since we're starting to have a lot of them.

Finally, this adds downloadable reports to the builds, to more easily get details about test failures.

Example run: https://github.com/yrodiere/hibernate-reactive/actions/runs/347693600

By the way, there is a test failure with JDK 15 and 16: `org.hibernate.reactive.types.BasicTypesAndCallbacksForAllDBsTest#testLocalDateType` fails with the following stack trace:

```
java.lang.AssertionError: Not equals : 2020-11-05T14:34:15.539050417 != 2020-11-05T14:34:15.539050
	at io.vertx.ext.unit.impl.TestContextImpl.reportAssertionError(TestContextImpl.java:362)
	at io.vertx.ext.unit.impl.TestContextImpl.assertEquals(TestContextImpl.java:258)
	at io.vertx.ext.unit.impl.TestContextImpl.assertEquals(TestContextImpl.java:245)
	at org.hibernate.reactive.types.BasicTypesAndCallbacksForAllDBsTest.lambda$testLocalDateTimeType$19(BasicTypesAndCallbacksForAllDBsTest.java:262)
```

It looks like timestamps returned from the database have microsecond precision whereas nanosecond precision is expected, for some reason. As to why it fails with JDK15 and not with JDK8 or 11... beats me. I didn't try to fix it, I assume you'll have a better idea of what's going on?