### PR TITLE
Vertx 3 *and* 4 Compatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '3.9.4'
+        vertxVersion = '4.0.0.Beta3'
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '4.0.0.CR1'
+        vertxVersion = '3.9.4'
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,14 @@ ext {
         hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
     }
 
+    //We want to consistently compile with a specific version of Vert.x, and yet be able to test
+    //with a more flexible range.
+    vertxCompileVersion = '4.0.0.CR2'
     // Mainly, to allow CI to test the latest versions of Vert.X
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '3.9.4'
+        vertxVersion = vertxCompileVersion
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '4.0.0.Beta3'
+        vertxVersion = '4.0.0.CR1'
     }
 
     testcontainersVersion = '1.15.0'

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 //    annotationProcessor 'org.jboss.logging:jboss-logging-processor:2.1.0.Final'
 
     //Specific implementation details of Hibernate Reactive:
-    implementation "io.vertx:vertx-sql-client:${vertxVersion}"
+    compileOnly "io.vertx:vertx-sql-client:${vertxCompileVersion}"
+    runtimeOnly "io.vertx:vertx-sql-client:${vertxVersion}"
 
     // Testing
     testImplementation 'org.assertj:assertj-core:3.13.2'

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -110,7 +110,7 @@ public class ReactiveConnectionPoolTest {
 	public void configureWithWrongCredentials(TestContext context) {
 		thrown.expect( CompletionException.class );
 		thrown.expectMessage( "io.vertx.pgclient.PgException:" );
-		thrown.expectMessage( "\\\"bogus\\\"" );
+		thrown.expectMessage( "bogus" );
 
 		String url = DatabaseConfiguration.getJdbcUrl();
 		Map<String,Object> config = new HashMap<>();

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -110,7 +110,7 @@ public class ReactiveConnectionPoolTest {
 	public void configureWithWrongCredentials(TestContext context) {
 		thrown.expect( CompletionException.class );
 		thrown.expectMessage( "io.vertx.pgclient.PgException:" );
-		thrown.expectMessage( "\"bogus\"" );
+		thrown.expectMessage( "\\\"bogus\\\"" );
 
 		String url = DatabaseConfiguration.getJdbcUrl();
 		Map<String,Object> config = new HashMap<>();


### PR DESCRIPTION

Some horribly looking reflection, but I think it's worth it - especially considering we'll want to drop Vertx 3 compatibility soon. 

WDYT?

Some close methods in Vert.x 4 now return a `io.vertx.core.Future` - we didn't notice this during previous experiments as it's source-compatible, but we catch the mistake now by reconfiguring Gradle to always build with Vertx 4 and then run tests (and tests only) with Vertx 3 on classpath. This trips as it's an incompatible change at bytecode level.

IMO the new close() methods need to be propagated, but it's hard to do so as long as we also want to keep Vert.x 3 compatibility... So I propose we merge this, and then it should be easier to start reviewin this aspect for a better Vert.x 4 integration.

[ developed in pair with @DavideD ]