### PR TITLE
[#440] Compatibility with Vert.x 3 and 4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,10 +10,11 @@ on:
 
 jobs:
   run_examples:
-    name: Run examples on ${{ matrix.db }}
+    name: Run examples on ${{ matrix.db }} and Vert.x ${{ matrix.vert.x-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        vertx-version: ['3.9.4', '4.0.0.CR2']
         db: [ 'MySQL', 'PostgreSQL' ]
     services:
        # Label used to access the service container
@@ -69,8 +70,12 @@ jobs:
       with:
         java-version: 1.8
       uses: actions/setup-java@v1
+    - name: Print the effective Vert.x version used at compile and runtime
+      run: |
+        ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath;
+        ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath
     - name: Run examples on ${{ matrix.db }}
-      run: ./gradlew :example:runAllExamplesOn${{ matrix.db }}
+      run: ./gradlew :example:runAllExamplesOn${{ matrix.db }} -PvertxVersion='${{ matrix.vertx-version }}'
     - name: Upload reports (if build failed)
       uses: actions/upload-artifact@v2
       if: failure()
@@ -79,10 +84,11 @@ jobs:
         path: './**/build/reports/'
 
   test_dbs:
-    name: Test with ${{ matrix.db }}
+    name: Test with ${{ matrix.db }} and Vert.x ${{ matrix.vert.x-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        vertx-version: ['3.9.4', '4.0.0.CR2']
         db: [ 'MySQL', 'PostgreSQL', 'DB2' ]
     steps:
     - uses: actions/checkout@v2
@@ -105,8 +111,12 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Build and Test with ${{ matrix.db }}
-      run: ./gradlew build -Pdocker -Pdb=${{ matrix.db }}
+    - name: Print the effective Vert.x version used at compile and runtime
+      run: |
+        ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath;
+        ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath
+    - name: Build and Test with ${{ matrix.db }} and Vert.x ${{ matrix.vertx-version }}
+      run: ./gradlew build -Pdocker -Pdb=${{ matrix.db }} -PvertxVersion='${{ matrix.vertx-version }}'
     - name: Upload reports (if build failed)
       uses: actions/upload-artifact@v2
       if: failure()

--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -21,6 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        vertx-version: ['3.9.4', '4.0.0.CR2']
         orm-version: ['[5.4,5.5)', '[5.5,5.6)']
         db: ['MySQL', 'PostgreSQL']
     services:
@@ -64,14 +65,19 @@ jobs:
         uses: actions/setup-java@v1
       - name: Print the effective ORM version used
         run: ./gradlew :example:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='${{ matrix.orm-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
-      - name: Run examples on ${{ matrix.db }}
-        run: ./gradlew :example:runAllExamplesOn${{ matrix.db }} -PhibernateOrmVersion='${{ matrix.orm-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
+      - name: Print the effective Vert.x version used at compile and runtime
+        run: |
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath -PskipOrmVersionParsing -PenableJBossSnapshotsRep;
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath  -PskipOrmVersionParsing -PenableJBossSnapshotsRep
+      - name: Run examples on ${{ matrix.db }} and ${{ matrix.vertx-version }}
+        run: ./gradlew :example:runAllExamplesOn${{ matrix.db }} -PhibernateOrmVersion='${{ matrix.orm-version }}' -PvertxVersion='${{ matrix.vertx-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
 
   test_dbs:
     name: Test with ${{ matrix.db }} and ORM ${{ matrix.orm-version }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
+        vertx-version: ['3.9.4', '4.0.0.CR2']
         orm-version: ['[5.4,5.5)', '[5.5,5.6)']
         db: ['MySQL', 'PostgreSQL', 'DB2']
     steps:
@@ -81,7 +87,11 @@ jobs:
         with:
           java-version: 1.8
       - name: Print the effective ORM version used
-        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='${{ matrix.orm-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
-      - name: Build and Test with ${{ matrix.db }}
-        run: ./gradlew build -Pdb=${{ matrix.db }} -Pdocker -PhibernateOrmVersion='${{ matrix.orm-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
+        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency org.hibernate:hibernate-core -PhibernateOrmVersion='${{ matrix.orm-version }}' -PvertxVersion='${{ matrix.vertx-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
+      - name: Print the effective Vert.x version used at compile and runtime
+        run: |
+         ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath -PskipOrmVersionParsing -PenableJBossSnapshotsRep;
+         ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath -PskipOrmVersionParsing -PenableJBossSnapshotsRep
+      - name: Build and Test with ${{ matrix.db }} and ${{ matrix.vertx-version }}
+        run: ./gradlew build -Pdb=${{ matrix.db }} -Pdocker -PhibernateOrmVersion='${{ matrix.orm-version }}' -PvertxVersion='${{ matrix.vertx-version }}' -PskipOrmVersionParsing -PenableJBossSnapshotsRep
 

--- a/.github/workflows/tracking-vertx.build.yml
+++ b/.github/workflows/tracking-vertx.build.yml
@@ -1,4 +1,4 @@
-name: Latest Vert.x 3
+name: Latest Vert.x 3 and 4
 
 on:
   # Trigger the workflow on push or pull request,
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        vertx-version: ['[3,4)']
+        vertx-version: ['[3,4)', '[4,5)']
         db: ['MySQL', 'PostgreSQL']
     services:
       # Label used to access the service container
@@ -62,8 +62,10 @@ jobs:
         with:
           java-version: 1.8
         uses: actions/setup-java@v1
-      - name: Print the effective Vert.x version used
-        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}'
+      - name: Print the effective Vert.x version used at compile and runtime
+        run: |
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath;
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath
       - name: Run examples on ${{ matrix.db }}
         run: ./gradlew :example:runAllExamplesOn${{ matrix.db }} -PvertxVersion='${{ matrix.vertx-version }}'
 
@@ -72,7 +74,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        vertx-version: ['[3,4)']
+        vertx-version: ['[3,4)', '[4,5)']
         db: [ 'MySQL', 'PostgreSQL', 'DB2' ]
     steps:
       - uses: actions/checkout@v2
@@ -80,7 +82,9 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
-      - name: Print the effective Vert.x version used
-        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}'
+      - name: Print the effective Vert.x version used at compile and runtime
+        run: |
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration compileClasspath;
+          ./gradlew :example:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}' --configuration runtimeClasspath
       - name: Build and Test with ${{ matrix.db }}
         run: ./gradlew build -Pdb=${{ matrix.db }} -Pdocker -PvertxVersion='${{ matrix.vertx-version }}'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '3.9.4'
+        vertxVersion = '4.0.0.Beta3'
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '4.0.0.CR1'
+        vertxVersion = '3.9.4'
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -51,11 +51,14 @@ ext {
         hibernateOrmVersion = Version.parseProjectVersion( project.hibernateOrmVersion )
     }
 
+    //We want to consistently compile with a specific version of Vert.x, and yet be able to test
+    //with a more flexible range.
+    vertxCompileVersion = '4.0.0.CR2'
     // Mainly, to allow CI to test the latest versions of Vert.X
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '3.9.4'
+        vertxVersion = vertxCompileVersion
     }
 
     testcontainersVersion = '1.15.0'

--- a/build.gradle
+++ b/build.gradle
@@ -64,7 +64,8 @@ ext {
     testcontainersVersion = '1.15.0'
 
     logger.lifecycle "Hibernate ORM Version: " + project.hibernateOrmVersion
-    logger.lifecycle "Vert.x Version: " + project.vertxVersion
+    logger.lifecycle "Vert.x Version at compile: " + project.vertxCompileVersion
+    logger.lifecycle "Vert.x Version at runtime: " + project.vertxVersion
 }
 
 subprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -55,7 +55,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty('vertxVersion') ) {
-        vertxVersion = '4.0.0.Beta3'
+        vertxVersion = '4.0.0.CR1'
     }
 
     testcontainersVersion = '1.15.0'

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -23,7 +23,8 @@ dependencies {
 //    annotationProcessor 'org.jboss.logging:jboss-logging-processor:2.1.0.Final'
 
     //Specific implementation details of Hibernate Reactive:
-    implementation "io.vertx:vertx-sql-client:${vertxVersion}"
+    compileOnly "io.vertx:vertx-sql-client:${vertxCompileVersion}"
+    runtimeOnly "io.vertx:vertx-sql-client:${vertxVersion}"
 
     // Testing
     testImplementation 'org.assertj:assertj-core:3.13.2'

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -215,14 +215,12 @@ public class SqlClientConnection implements ReactiveConnection {
 		try {
 			final Method method = SqlClient.class.getMethod( "close" );
 			final Class<?> returnType = method.getReturnType();
-			// if it's void we're on Vert.x v. 3.9
-			if ( returnType.equals( Void.TYPE ) ) {
-				return method;
-			}
-			else {
-				// else it is Vert.x 4
-				return null;
-			}
+			// if it returns void
+			return returnType.equals( Void.TYPE )
+					// then we're on Vert.x v. 3.9
+					? method
+					// else it's Vert.x 4
+					: null;
 		}
 		catch (NoSuchMethodException e) {
 			return null; //some new Vert.x version? No need for Vertx 3 compatibility in this case.
@@ -230,21 +228,18 @@ public class SqlClientConnection implements ReactiveConnection {
 	}
 
 	private static Method identifyBeginMethodOnVertxVersion3() {
-		final Method method;
 		try {
-			method = SqlConnection.class.getMethod( "begin" );
+			final Method method = SqlConnection.class.getMethod( "begin" );
+			final Class<?> returnType = method.getReturnType();
+			// if it returns Transaction
+			return Transaction.class.equals( returnType )
+					// then we're on Vert.x v. 3.9
+					? method
+					// else it's Vert.x 4
+					: null;
 		}
 		catch (NoSuchMethodException e) {
 			return null; //some new Vert.x version? No need for Vertx 3 compatibility in this case.
-		}
-		final Class<?> returnType = method.getReturnType();
-		// if it returns Transaction then we're on Vert.x v. 3.9
-		if ( Transaction.class.equals( returnType ) ) {
-			return method;
-		}
-		else {
-			// else it is Vert.x 4
-			return null;
 		}
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -110,7 +110,7 @@ public class ReactiveConnectionPoolTest {
 	public void configureWithWrongCredentials(TestContext context) {
 		thrown.expect( CompletionException.class );
 		thrown.expectMessage( "io.vertx.pgclient.PgException:" );
-		thrown.expectMessage( "\\\"bogus\\\"" );
+		thrown.expectMessage( "bogus" );
 
 		String url = DatabaseConfiguration.getJdbcUrl();
 		Map<String,Object> config = new HashMap<>();

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -110,7 +110,7 @@ public class ReactiveConnectionPoolTest {
 	public void configureWithWrongCredentials(TestContext context) {
 		thrown.expect( CompletionException.class );
 		thrown.expectMessage( "io.vertx.pgclient.PgException:" );
-		thrown.expectMessage( "\"bogus\"" );
+		thrown.expectMessage( "\\\"bogus\\\"" );
 
 		String url = DatabaseConfiguration.getJdbcUrl();
 		Map<String,Object> config = new HashMap<>();


### PR DESCRIPTION
Follows https://github.com/hibernate/hibernate-reactive/pull/456

This PR is built on top of @Sanne's one.
I've included @gavinking's [fix for transaction](https://github.com/hibernate/hibernate-reactive/pull/457) in this commit: https://github.com/hibernate/hibernate-reactive/commit/caf34eac71ba77c7c313e221262980b7d1e2e53b

I've also added a minor clean up and an update to the workflows.
The workflows now will test with Vert.x 3.9.4 and 4.0.0.CR2

It's a draft because I need to wait for the new GitHub workflows to complete.