### PR TITLE
[#475] Fix race condition in ProxyConnection.withConnection()

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -1,3 +1,7 @@
+plugins {
+    id 'org.caffinitas.gradle.testrerun' version '0.1'
+}
+
 ext {
 	mavenPomName = 'Hibernate Reactive Core'
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/SequenceReactiveIdentifierGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/SequenceReactiveIdentifierGenerator.java
@@ -20,6 +20,7 @@ import java.util.concurrent.CompletionStage;
 
 import static org.hibernate.internal.util.config.ConfigurationHelper.getInt;
 import static org.hibernate.reactive.id.impl.IdentifierGeneration.determineSequenceName;
+import static org.hibernate.reactive.session.impl.SessionUtil.wrapReactive;
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 
 /**
@@ -75,9 +76,10 @@ public class SequenceReactiveIdentifierGenerator
 			return completedFuture(local);
 		}
 
-		return session.getReactiveConnection()
-				.selectLong( sql, NO_PARAMS )
-				.thenApply( this::next );
+		return wrapReactive( session, connection -> connection
+				.selectLong(sql, NO_PARAMS)
+				.thenApply(this::next)
+		);
 	}
 
 	protected int determineIncrementForSequenceEmulation(Properties params) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
@@ -22,6 +22,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
+import static org.hibernate.reactive.session.impl.SessionUtil.wrapReactive;
+
 /**
  * Defines common reactive operations inherited by all kinds of loaders.
  *
@@ -102,8 +104,9 @@ public interface ReactiveLoader {
 		// Adding locks and comments.
 		sql = preprocessSQL( sql, queryParameters, session.getFactory(), afterLoadActions );
 
-		return ((ReactiveConnectionSupplier) session).getReactiveConnection()
-				.selectJdbc( sql, toParameterArray(queryParameters, session) );
+		String sql_ = sql; // effectively final
+		return wrapReactive( (ReactiveConnectionSupplier) session, connection -> connection
+				.selectJdbc( sql_, toParameterArray(queryParameters, session) ));
 	}
 
 	default LimitHandler limitHandler(RowSelection selection, SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -41,6 +41,9 @@ import java.util.function.Function;
  * The {@link Query}, {@link Session}, and {@link SessionFactory}
  * interfaces declared here are simply non-blocking counterparts to
  * the similarly-named interfaces in Hibernate ORM.
+ * <p>
+ * The async process to acquire a database connection starts on
+ * subscription to at least one of the Mutiny {@link Uni}s.
  */
 public interface Mutiny {
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -23,8 +23,11 @@ public class MutinyQueryImpl<R> implements Mutiny.Query<R> {
 
 	private final ReactiveQuery<R> delegate;
 
-	public MutinyQueryImpl(ReactiveQuery<R> delegate) {
+	private final MutinyUniConnectionActivator uni;
+
+	public MutinyQueryImpl(ReactiveQuery<R> delegate, MutinyUniConnectionActivator uni) {
 		this.delegate = delegate;
+		this.uni = uni;
 	}
 
 	@Override
@@ -165,17 +168,17 @@ public class MutinyQueryImpl<R> implements Mutiny.Query<R> {
 
 	@Override
 	public Uni<R> getSingleResult() {
-		return Uni.createFrom().completionStage( delegate.getReactiveSingleResult() );
+		return uni.asUni( delegate.getReactiveSingleResult() );
 	}
 
 	@Override
 	public Uni<R> getSingleResultOrNull() {
-		return Uni.createFrom().completionStage( delegate.getReactiveSingleResultOrNull() );
+		return uni.asUni( delegate.getReactiveSingleResultOrNull() );
 	}
 
 	@Override
 	public Uni<List<R>> getResultList() {
-		return Uni.createFrom().completionStage( delegate.getReactiveResultList() );
+		return uni.asUni( delegate.getReactiveResultList() );
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -37,30 +37,32 @@ import static org.hibernate.reactive.util.impl.CompletionStages.applyToAll;
 public class MutinySessionImpl implements Mutiny.Session {
 
 	private final ReactiveSession delegate;
+	private final MutinyUniConnectionActivator uni;
 
 	public MutinySessionImpl(ReactiveSession session) {
 		this.delegate = session;
+		this.uni = MutinyUniConnectionActivator.create( session.getReactiveConnection() );
 	}
 
 	@Override
 	public Uni<Void> flush() {
 //		checkOpen();
-		return Uni.createFrom().completionStage( delegate.reactiveFlush() );
+		return uni.asUni( delegate.reactiveFlush() );
 	}
 
 	@Override
 	public <T> Uni<T> fetch(T association) {
-		return Uni.createFrom().completionStage( delegate.reactiveFetch(association, false) );
+		return uni.asUni( delegate.reactiveFetch(association, false) );
 	}
 
 	@Override
 	public <E, T> Uni<T> fetch(E entity, Attribute<E, T> field) {
-		return Uni.createFrom().completionStage( delegate.reactiveFetch(entity, field) );
+		return uni.asUni( delegate.reactiveFetch(entity, field) );
 	}
 
 	@Override
 	public <T> Uni<T> unproxy(T association) {
-		return Uni.createFrom().completionStage( delegate.reactiveFetch(association, true) );
+		return uni.asUni( delegate.reactiveFetch(association, true) );
 	}
 
 	@Override
@@ -87,98 +89,98 @@ public class MutinySessionImpl implements Mutiny.Session {
 
 	@Override
 	public <T> Uni<T> find(Class<T> entityClass, Object primaryKey) {
-		return Uni.createFrom().completionStage( delegate.reactiveFind( entityClass, primaryKey, null, null ) );
+		return uni.asUni( delegate.reactiveFind( entityClass, primaryKey, null, null ) );
 	}
 
 	@Override
 	public <T> Uni<List<T>> find(Class<T> entityClass, Object... ids) {
-		return Uni.createFrom().completionStage( delegate.reactiveFind( entityClass, ids ) );
+		return uni.asUni( delegate.reactiveFind( entityClass, ids ) );
 	}
 
 	@Override
 	public <T> Uni<T> find(Class<T> entityClass, Object primaryKey, LockMode lockMode) {
-		return Uni.createFrom().completionStage( delegate.reactiveFind( entityClass, primaryKey, new LockOptions(lockMode), null ) );
+		return uni.asUni( delegate.reactiveFind( entityClass, primaryKey, new LockOptions(lockMode), null ) );
 	}
 
 //	@Override
 	public <T> Uni<T> find(Class<T> entityClass, Object primaryKey, LockOptions lockOptions) {
-		return Uni.createFrom().completionStage( delegate.reactiveFind( entityClass, primaryKey, lockOptions, null ) );
+		return uni.asUni( delegate.reactiveFind( entityClass, primaryKey, lockOptions, null ) );
 	}
 
 	@Override
 	public <T> Uni<T> find(EntityGraph<T> entityGraph, Object id) {
 		Class<T> entityClass = ((RootGraphImplementor<T>) entityGraph).getGraphedType().getJavaType();
-		return Uni.createFrom().completionStage( delegate.reactiveFind( entityClass, id, null, entityGraph ) );
+		return uni.asUni( delegate.reactiveFind( entityClass, id, null, entityGraph ) );
 	}
 
 	@Override
 	public Uni<Void> persist(Object entity) {
-		return Uni.createFrom().completionStage( delegate.reactivePersist( entity ) );
+		return uni.asUni( delegate.reactivePersist( entity ) );
 	}
 
 	@Override
 	public Uni<Void> persistAll(Object... entity) {
-		return Uni.createFrom().completionStage( applyToAll( delegate::reactivePersist, entity ) );
+		return uni.asUni( applyToAll( delegate::reactivePersist, entity ) );
 	}
 
 	@Override
 	public Uni<Void> remove(Object entity) {
-		return Uni.createFrom().completionStage( delegate.reactiveRemove( entity ) );
+		return uni.asUni( delegate.reactiveRemove( entity ) );
 	}
 
 	@Override
 	public Uni<Void> removeAll(Object... entity) {
-		return Uni.createFrom().completionStage( applyToAll( delegate::reactiveRemove, entity ) );
+		return uni.asUni( applyToAll( delegate::reactiveRemove, entity ) );
 	}
 
 	@Override
 	public <T> Uni<T> merge(T entity) {
-		return Uni.createFrom().completionStage( delegate.reactiveMerge( entity ) );
+		return uni.asUni( delegate.reactiveMerge( entity ) );
 	}
 
 	@Override @SafeVarargs
 	public final <T> Uni<Void> mergeAll(T... entity) {
-		return Uni.createFrom().completionStage( applyToAll( delegate::reactiveMerge, entity ) );
+		return uni.asUni( applyToAll( delegate::reactiveMerge, entity ) );
 	}
 
 	@Override
 	public Uni<Void> refresh(Object entity) {
-		return Uni.createFrom().completionStage( delegate.reactiveRefresh( entity, LockOptions.NONE ) );
+		return uni.asUni( delegate.reactiveRefresh( entity, LockOptions.NONE ) );
 	}
 
 	@Override
 	public Uni<Void> refresh(Object entity, LockMode lockMode) {
-		return Uni.createFrom().completionStage( delegate.reactiveRefresh( entity, new LockOptions(lockMode) ) );
+		return uni.asUni( delegate.reactiveRefresh( entity, new LockOptions(lockMode) ) );
 	}
 
 //	@Override
 	public Uni<Void> refresh(Object entity, LockOptions lockOptions) {
-		return Uni.createFrom().completionStage( delegate.reactiveRefresh( entity, lockOptions ) );
+		return uni.asUni( delegate.reactiveRefresh( entity, lockOptions ) );
 	}
 
 	@Override
 	public Uni<Void> refreshAll(Object... entity) {
-		return Uni.createFrom().completionStage( applyToAll( e -> delegate.reactiveRefresh(e, LockOptions.NONE), entity ) );
+		return uni.asUni( applyToAll(e -> delegate.reactiveRefresh(e, LockOptions.NONE), entity ) );
 	}
 
 	@Override
 	public Uni<Void> lock(Object entity, LockMode lockMode) {
-		return Uni.createFrom().completionStage( delegate.reactiveLock( entity, new LockOptions(lockMode) ) );
+		return uni.asUni( delegate.reactiveLock( entity, new LockOptions(lockMode) ) );
 	}
 
 //	@Override
 	public Uni<Void> lock(Object entity, LockOptions lockOptions) {
-		return Uni.createFrom().completionStage( delegate.reactiveLock( entity, lockOptions ) );
+		return uni.asUni( delegate.reactiveLock( entity, lockOptions ) );
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createQuery(String jpql, Class<R> resultType) {
-		return new MutinyQueryImpl<>( delegate.createReactiveQuery( jpql, resultType ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveQuery( jpql, resultType ), this.uni );
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createQuery(String jpql) {
-		return new MutinyQueryImpl<>( delegate.createReactiveQuery( jpql ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveQuery( jpql ), this.uni );
 	}
 
 	@Override
@@ -187,46 +189,46 @@ public class MutinySessionImpl implements Mutiny.Session {
 		final MetamodelImplementor metamodel = delegate.getFactory().getMetamodel();
 		final boolean knownType = metamodel.entityPersisters().containsKey( typeName );
 		if ( knownType ) {
-			return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql, resultType ) );
+			return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql, resultType ), this.uni );
 		}
 		else {
-			return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql ) );
+			return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql ), this.uni );
 		}
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createNativeQuery(String sql, ResultSetMapping<R> resultSetMapping) {
-		return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql, resultSetMapping.getName() ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql, resultSetMapping.getName() ), this.uni );
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createNativeQuery(String sql) {
-		return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( sql ), this.uni );
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createNamedQuery(String name) {
-		return new MutinyQueryImpl<>( delegate.createReactiveNamedQuery( name ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveNamedQuery( name ), this.uni );
 	}
 
 	@Override
 	public <R> Mutiny.Query<R> createNamedQuery(String name, Class<R> resultType) {
-		return new MutinyQueryImpl<>( delegate.createReactiveNamedQuery( name, resultType ) );
+		return new MutinyQueryImpl<>( delegate.createReactiveNamedQuery( name, resultType ), this.uni );
 	}
 
 	@Override @SuppressWarnings("unchecked")
 	public <R> Mutiny.Query<R> createQuery(CriteriaQuery<R> criteriaQuery) {
-		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaQuery) );
+		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaQuery), this.uni );
 	}
 
 	@Override @SuppressWarnings("unchecked")
 	public <R> Mutiny.Query<R> createQuery(CriteriaUpdate<R> criteriaUpdate) {
-		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaUpdate) );
+		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaUpdate), this.uni );
 	}
 
 	@Override @SuppressWarnings("unchecked")
 	public <R> Mutiny.Query<R> createQuery(CriteriaDelete<R> criteriaDelete) {
-		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaDelete) );
+		return new MutinyQueryImpl<>( delegate.createReactiveQuery( (Criteria<R>) criteriaDelete), this.uni );
 	}
 
 	@Override
@@ -394,19 +396,19 @@ public class MutinySessionImpl implements Mutiny.Session {
 		}
 
 		Uni<Void> flush() {
-			return Uni.createFrom().completionStage( delegate.reactiveAutoflush() );
+			return uni.asUni( delegate.reactiveAutoflush() );
 		}
 
 		Uni<Void> begin() {
-			return Uni.createFrom().completionStage( delegate.getReactiveConnection().beginTransaction() );
+			return uni.asUni( delegate.getReactiveConnection().beginTransaction() );
 		}
 
 		Uni<Void> rollback() {
-			return Uni.createFrom().completionStage( delegate.getReactiveConnection().rollbackTransaction() );
+			return uni.asUni( delegate.getReactiveConnection().rollbackTransaction() );
 		}
 
 		Uni<Void> commit() {
-			return Uni.createFrom().completionStage( delegate.getReactiveConnection().commitTransaction() );
+			return uni.asUni( delegate.getReactiveConnection().commitTransaction() );
 		}
 
 		@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -18,70 +18,72 @@ import org.hibernate.reactive.session.ReactiveStatelessSession;
  */
 public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 
-    private ReactiveStatelessSession delegate;
+    private final ReactiveStatelessSession delegate;
+    private final MutinyUniConnectionActivator uni;
 
     public MutinyStatelessSessionImpl(ReactiveStatelessSession delegate) {
         this.delegate = delegate;
+        this.uni = MutinyUniConnectionActivator.create( delegate.getReactiveConnection() );
     }
 
     @Override
     public <T> Uni<T> get(Class<T> entityClass, Object id) {
-        return Uni.createFrom().completionStage( delegate.reactiveGet(entityClass, id) );
+        return uni.asUni( delegate.reactiveGet(entityClass, id) );
     }
 
     @Override
     public <T> Uni<T> get(Class<T> entityClass, Object id, LockMode lockMode) {
-        return Uni.createFrom().completionStage( delegate.reactiveGet(entityClass, id, lockMode) );
+        return uni.asUni( delegate.reactiveGet(entityClass, id, lockMode) );
     }
 
     @Override
     public <R> Mutiny.Query<R> createQuery(String queryString) {
-        return new MutinyQueryImpl<>( delegate.createReactiveQuery(queryString) );
+        return new MutinyQueryImpl<>( delegate.createReactiveQuery(queryString), this.uni );
     }
 
     @Override
     public <R> Mutiny.Query<R> createQuery(String queryString, Class<R> resultType) {
-        return new MutinyQueryImpl<>( delegate.createReactiveQuery(queryString, resultType) );
+        return new MutinyQueryImpl<>( delegate.createReactiveQuery(queryString, resultType), this.uni );
     }
 
     @Override
     public <R> Mutiny.Query<R> createNativeQuery(String queryString) {
-        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery(queryString) );
+        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery(queryString), this.uni );
     }
 
     @Override
     public <R> Mutiny.Query<R> createNativeQuery(String queryString, Class<R> resultType) {
-        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery(queryString, resultType) );
+        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery(queryString, resultType), this.uni );
     }
 
     @Override
     public <R> Mutiny.Query<R> createNativeQuery(String queryString, ResultSetMapping<R> resultSetMapping) {
-        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( queryString, resultSetMapping.getName() ) );
+        return new MutinyQueryImpl<>( delegate.createReactiveNativeQuery( queryString, resultSetMapping.getName() ), this.uni );
     }
 
     @Override
     public Uni<Mutiny.StatelessSession> insert(Object entity) {
-        return Uni.createFrom().completionStage( delegate.reactiveInsert(entity).thenApply( v -> this ) );
+        return uni.asUni( delegate.reactiveInsert(entity).thenApply( v -> this ) );
     }
 
     @Override
     public Uni<Mutiny.StatelessSession> delete(Object entity) {
-        return Uni.createFrom().completionStage( delegate.reactiveDelete(entity).thenApply( v -> this ) );
+        return uni.asUni( delegate.reactiveDelete(entity).thenApply( v -> this ) );
     }
 
     @Override
     public Uni<Mutiny.StatelessSession> update(Object entity) {
-        return Uni.createFrom().completionStage( delegate.reactiveUpdate(entity).thenApply( v -> this ) );
+        return uni.asUni( delegate.reactiveUpdate(entity).thenApply( v -> this ) );
     }
 
     @Override
     public Uni<Mutiny.StatelessSession> refresh(Object entity) {
-        return Uni.createFrom().completionStage( delegate.reactiveRefresh(entity).thenApply( v -> this ) );
+        return uni.asUni( delegate.reactiveRefresh(entity).thenApply( v -> this ) );
     }
 
     @Override
     public Uni<Mutiny.StatelessSession> refresh(Object entity, LockMode lockMode) {
-        return Uni.createFrom().completionStage( delegate.reactiveRefresh(entity, lockMode).thenApply( v -> this ) );
+        return uni.asUni( delegate.reactiveRefresh(entity, lockMode).thenApply( v -> this ) );
     }
 
     @Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyUniConnectionActivator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyUniConnectionActivator.java
@@ -1,0 +1,45 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.mutiny.impl;
+
+import io.smallrye.mutiny.Uni;
+import org.hibernate.reactive.pool.ReactiveConnection;
+
+import java.util.concurrent.CompletionStage;
+
+/**
+ * Internal helper interface to "enhance" the {@link Uni}s returned by Mutiny methods
+ * to acquire the database connection on subscription.
+ * <p>
+ * It's implemented as a functional-interface with a static create methods so that the
+ * implementing classes can pass a method-reference e.g. from {@link MutinySessionImpl}
+ * to {@link MutinyQueryImpl} without having to pass around even more delegates.
+ */
+@FunctionalInterface
+interface MutinyUniConnectionActivator {
+    <R> Uni<R> asUni(CompletionStage<R> completionStage);
+
+    /**
+     * Creates an instance of {@link MutinyUniConnectionActivator} that hooks into the
+     * subscription phase of an {@link Uni} created for a {@link CompletionStage} using
+     * the given {@link ReactiveConnection}.
+     */
+    static MutinyUniConnectionActivator create(ReactiveConnection reactiveConnection) {
+        return new MutinyUniConnectionActivator() {
+            @Override
+            public <R> Uni<R> asUni(CompletionStage<R> completionStage) {
+                return Uni.createFrom().completionStage( completionStage )
+                        .onSubscribe()
+                        .invoke(
+                                // Just need to trigger the async process to acquire a
+                                // connection in this "onSubscribe" callback, no need
+                                // to return a new Uni or so.
+                                reactiveConnection::openConnection
+                        );
+            }
+        };
+    }
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
@@ -177,4 +177,9 @@ public class BatchingConnection implements ReactiveConnection {
     public void close() {
         delegate.close();
     }
+
+    @Override
+    public CompletionStage<ReactiveConnection> openConnection() {
+        return delegate.openConnection();
+    }
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
@@ -62,4 +62,14 @@ public interface ReactiveConnection {
 
 	void close();
 
+	/**
+	 * Used internally to trigger the asynchronous operation to acquire
+	 * a database connection.
+	 * <p>
+     * It is most likely wrong to use this method from application code.
+	 * See the docs of {@link org.hibernate.reactive.mutiny.Mutiny} and
+	 * {@link org.hibernate.reactive.stage.Stage} about the contracts
+	 * when a database connection will be acquired.
+	 */
+	CompletionStage<ReactiveConnection> openConnection();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ClosedReactiveConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ClosedReactiveConnection.java
@@ -1,0 +1,104 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.pool.impl;
+
+import org.hibernate.reactive.pool.ReactiveConnection;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+
+final class ClosedReactiveConnection implements ReactiveConnection {
+
+    static final ReactiveConnection INSTANCE = new ClosedReactiveConnection();
+
+    private <X> CompletionStage<X> closedFailure() {
+        CompletableFuture<X> f = new CompletableFuture<>();
+        f.completeExceptionally(new IllegalStateException("The session resp. proxied-connection has been closed"));
+        return f;
+    }
+
+    @Override
+    public CompletionStage<Void> execute(String sql) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> executeOutsideTransaction(String sql) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Integer> update(String sql) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Integer> update(String sql, Object[] paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> update(String sql, Object[] paramValues, boolean allowBatching, Expectation expectation) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<int[]> update(String sql, List<Object[]> paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Long> updateReturning(String sql, Object[] paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Result> select(String sql) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Result> select(String sql, Object[] paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<ResultSet> selectJdbc(String sql, Object[] paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Long> selectLong(String sql, Object[] paramValues) {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> beginTransaction() {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> commitTransaction() {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> rollbackTransaction() {
+        return closedFailure();
+    }
+
+    @Override
+    public CompletionStage<Void> executeBatch() {
+        return closedFailure();
+    }
+
+    @Override
+    public void close() {
+        // it's closed, we're good
+    }
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ClosedReactiveConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ClosedReactiveConnection.java
@@ -12,93 +12,122 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+/**
+ * Helper class to deal with closed {@link ProxyConnection}s.
+ * Provides static instances of the exception to throw, a {@link CompletableFuture}
+ * completed with that exception and the {@link ReactiveConnection} implementation
+ * that will only return this exceptionally completed future.
+ */
 final class ClosedReactiveConnection implements ReactiveConnection {
 
     static final ReactiveConnection INSTANCE = new ClosedReactiveConnection();
 
-    private <X> CompletionStage<X> closedFailure() {
-        CompletableFuture<X> f = new CompletableFuture<>();
-        f.completeExceptionally(new IllegalStateException("The session resp. proxied-connection has been closed"));
+    private static final CompletableFuture<Object> closedConnectionFuture;
+    private static final RuntimeException closedConnectionException;
+    static {
+        closedConnectionException = new ClosedConnectionException();
+
+        closedConnectionFuture = new CompletableFuture<>();
+        closedConnectionFuture.completeExceptionally(closedConnectionException);
+    }
+
+    static <X> CompletionStage<X> completionStage() {
+        @SuppressWarnings("unchecked") CompletableFuture<X> f = (CompletableFuture<X>) closedConnectionFuture;
         return f;
+    }
+
+    static IllegalStateException failure() {
+        return new IllegalStateException("The session resp. proxied-connection has been closed");
     }
 
     @Override
     public CompletionStage<Void> execute(String sql) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> executeOutsideTransaction(String sql) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Integer> update(String sql) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Integer> update(String sql, Object[] paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> update(String sql, Object[] paramValues, boolean allowBatching, Expectation expectation) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<int[]> update(String sql, List<Object[]> paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Long> updateReturning(String sql, Object[] paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Result> select(String sql) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Result> select(String sql, Object[] paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<ResultSet> selectJdbc(String sql, Object[] paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Long> selectLong(String sql, Object[] paramValues) {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> beginTransaction() {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> commitTransaction() {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> rollbackTransaction() {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public CompletionStage<Void> executeBatch() {
-        return closedFailure();
+        return completionStage();
     }
 
     @Override
     public void close() {
         // it's closed, we're good
+    }
+
+    @Override
+    public CompletionStage<ReactiveConnection> openConnection() {
+        return completionStage();
+    }
+
+    static final class ClosedConnectionException extends RuntimeException {
+        ClosedConnectionException() {
+            super("The session resp. proxied-connection has been closed", null, false, false);
+        }
     }
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
@@ -34,7 +34,7 @@ final class ProxyConnection implements ReactiveConnection {
 		this.tenantId = tenantId;
 	}
 
-	private <T> CompletionStage<T> withConnection(Function<ReactiveConnection, CompletionStage<T>> operation) {
+	<T> CompletionStage<T> withConnection(Function<ReactiveConnection, CompletionStage<T>> operation) {
 		if ( !connected ) {
 			connected = true; // we're not allowed to fetch two connections!
 			CompletionStage<ReactiveConnection> connection =

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
@@ -104,9 +104,14 @@ final class ProxyConnection implements ReactiveConnection {
 				completionStage = connection.thenApply(newConnection -> {
 					// Again, change to 'connection' guarded via 'stateChange'.
 					synchronized (stateChange) {
-						this.connection = newConnection;
+						if (!closed) {
+							this.connection = newConnection;
+							return newConnection;
+						}
+						newConnection.close();
+						// Return something that gives at least some descriptive exception
+						return ClosedReactiveConnection.INSTANCE;
 					}
-					return newConnection;
 				});
 				connectionCompletionStage = completionStage;
 			}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -24,6 +24,7 @@ import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
@@ -290,5 +291,10 @@ public class SqlClientConnection implements ReactiveConnection {
 	@Override
 	public CompletionStage<Void> executeBatch() {
 		return voidFuture();
+	}
+
+	@Override
+	public CompletionStage<ReactiveConnection> openConnection() {
+		return CompletableFuture.completedFuture( this );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -87,12 +87,12 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 
 	@Override
 	public ReactiveConnection getProxyConnection() {
-		return new ProxyConnection( this );
+		return ProxyConnection.newInstance( this );
 	}
 
 	@Override
 	public ReactiveConnection getProxyConnection(String tenantId) {
-		return new ProxyConnection( this, tenantId );
+		return ProxyConnection.newInstance( this, tenantId );
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeSQLQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveNativeSQLQueryPlan.java
@@ -16,6 +16,8 @@ import org.hibernate.reactive.session.ReactiveQueryExecutor;
 
 import java.util.concurrent.CompletionStage;
 
+import static org.hibernate.reactive.session.impl.SessionUtil.wrapReactive;
+
 public class ReactiveNativeSQLQueryPlan extends NativeSQLQueryPlan {
 
 	private final String sourceQuery;
@@ -63,6 +65,7 @@ public class ReactiveNativeSQLQueryPlan extends NativeSQLQueryPlan {
 		String sql = session.getDialect()
 				.addSqlHintOrComment( queryParameters.getFilteredSQL(), queryParameters, commentsEnabled );
 
-		return session.getReactiveConnection().update( sql, params );
+		return wrapReactive( session, connection ->
+			connection.update( sql, params ) );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/SessionUtil.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/SessionUtil.java
@@ -6,8 +6,12 @@
 package org.hibernate.reactive.session.impl;
 
 import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 
 import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
 
 public class SessionUtil {
 
@@ -19,6 +23,16 @@ public class SessionUtil {
 		if ( optional==null ) {
 			throwEntityNotFound(session, entityName, identifier);
 		}
+	}
+
+	public static <R> CompletionStage<R> wrapReactive(ReactiveConnectionSupplier reactiveConnection, Function<ReactiveConnection, CompletionStage<R>> operation) {
+		return wrapReactive( reactiveConnection.getReactiveConnection(), operation );
+	}
+
+	public static <R> CompletionStage<R> wrapReactive(ReactiveConnection reactiveConnection, Function<ReactiveConnection, CompletionStage<R>> operation) {
+		return reactiveConnection
+				.openConnection()
+				.thenCompose(operation);
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -42,6 +42,11 @@ import java.util.function.Function;
  * The {@link Query}, {@link Session}, and {@link SessionFactory}
  * interfaces declared here are simply non-blocking counterparts to
  * the similarly-named interfaces in Hibernate ORM.
+ * <p>
+ * Unlike {@link org.hibernate.reactive.mutiny.Mutiny}, the async
+ * process to acquire a database starts when one operation that needs
+ * a connection is involved. However, the exact details of when
+ * that async connection-acquire starts may change.
  */
 public interface Stage {
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
+import static org.hibernate.reactive.session.impl.SessionUtil.wrapReactive;
 import static org.hibernate.reactive.util.impl.CompletionStages.applyToAll;
 import static org.hibernate.reactive.util.impl.CompletionStages.returnOrRethrow;
 
@@ -405,11 +406,11 @@ public class StageSessionImpl implements Stage.Session {
 		}
 
 		CompletionStage<Void> flush() {
-			return delegate.reactiveAutoflush();
+			return wrapReactive( delegate, r -> delegate.reactiveAutoflush() );
 		}
 
 		CompletionStage<Void> begin() {
-			return delegate.getReactiveConnection().beginTransaction();
+			return wrapReactive( delegate, r -> delegate.getReactiveConnection().beginTransaction() );
 		}
 
 		CompletionStage<Void> end() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -6,16 +6,22 @@
 package org.hibernate.reactive;
 
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.Timeout;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.sqlclient.*;
 import org.hibernate.boot.registry.StandardServiceRegistry;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
 import org.hibernate.reactive.common.AutoCloseable;
 import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.impl.MutinySessionImpl;
+import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.containers.DatabaseConfiguration;
 import org.hibernate.reactive.containers.DatabaseConfiguration.DBType;
@@ -23,6 +29,7 @@ import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.ReactiveConnectionPool;
 import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder;
 import org.hibernate.reactive.provider.service.ReactiveGenerationTarget;
+import org.hibernate.reactive.session.impl.ReactiveSessionImpl;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
 import org.junit.After;
@@ -30,7 +37,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
+import java.lang.reflect.Field;
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
@@ -158,6 +168,69 @@ public abstract class BaseReactiveTest {
 
 	protected Stage.SessionFactory getSessionFactory() {
 		return sessionFactory.unwrap( Stage.SessionFactory.class );
+	}
+
+	private static Field accessibleField(Class<?> clazz, String name) throws Exception {
+		Field field = clazz.getDeclaredField(name);
+		field.setAccessible(true);
+		return field;
+	}
+
+	private static Object accessibleFieldGet(Class<?> clazz, String name, Object instance) throws Exception {
+		return accessibleField(clazz, name).get(instance);
+	}
+
+	protected Mutiny.Session injectDelayedConnection(Mutiny.Session session, CountDownLatch synchronizer) {
+		try {
+			Object reactiveSessionImpl = accessibleFieldGet(MutinySessionImpl.class, "delegate", session);
+			Object proxyConnection = accessibleFieldGet(ReactiveSessionImpl.class, "reactiveConnection", reactiveSessionImpl);
+			Object sqlClientPool = accessibleFieldGet(proxyConnection.getClass(), "sqlClientPool", proxyConnection);
+			Pool pool = (Pool) accessibleFieldGet(DefaultSqlClientPool.class, "pool", sqlClientPool);
+			Pool delayingPool = new Pool() {
+				@Override
+				public void getConnection(Handler<AsyncResult<SqlConnection>> handler) {
+					pool.getConnection(ar -> {
+						// maybe there's a nicer way to do this asynchronously
+						new Thread(() -> {
+							try {
+								if (!synchronizer.await(60, TimeUnit.SECONDS))
+									handler.handle(Future.failedFuture("synchronizer await failed"));
+								handler.handle(ar);
+							} catch (InterruptedException e) {
+								handler.handle(Future.failedFuture(e));
+							}
+						}).start();
+					});
+				}
+
+				@Override
+				public Query<RowSet<Row>> query(String sql) {
+					return pool.query(sql);
+				}
+
+				@Override
+				public PreparedQuery<RowSet<Row>> preparedQuery(String sql) {
+					return pool.preparedQuery(sql);
+				}
+
+				@Override
+				public void begin(Handler<AsyncResult<Transaction>> handler) {
+					pool.begin(handler);
+				}
+
+				@Override
+				public void close() {
+					pool.close();
+				}
+			};
+			accessibleField(DefaultSqlClientPool.class, "pool")
+					.set(sqlClientPool, delayingPool);
+		}
+		catch (Exception e) {
+			throw new RuntimeException(e);
+		}
+
+		return session;
 	}
 
 	protected Stage.Session openSession() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/pool/impl/ProxyConnectionRaceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/pool/impl/ProxyConnectionRaceTest.java
@@ -1,0 +1,290 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.pool.impl;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.pool.ReactiveConnectionPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import static org.junit.Assert.*;
+
+/**
+ * Low-level test to prevent "single-thread-connection-race" in {@link ProxyConnection}.
+ * <p>
+ * See {@link org.hibernate.reactive.MutinySessionTest#reactiveProxyConnectionRace(TestContext)} and
+ * <a href="https://github.com/hibernate/hibernate-reactive/issues/475">#475</a>.
+ * </p>
+ */
+public class ProxyConnectionRaceTest {
+    private ExecutorService executor;
+
+    /**
+     * Concurrency for "hammering" test - at least 4 threads, max=availableProcessors.
+     */
+    private static final int parallelism = Math.max(4, Runtime.getRuntime().availableProcessors());
+
+    /**
+     * +1 thread for the {@link CompletableFuture} scheduled in {@link ReactiveConnectionPoolMock#getConnection()},
+     * see parallelism multiplicators in {@link #concurrentWithConnectionN(int)}
+     */
+    private static final int threadPoolSize = parallelism * 3 + 1;
+
+    @Before
+    public void setup() {
+        executor = Executors.newFixedThreadPool(threadPoolSize);
+    }
+
+    @After
+    public void teardown() throws Exception {
+        try {
+            executor.shutdownNow();
+            assertTrue(
+                    "At least one thread keeps spinning around, not good",
+                    executor.awaitTermination(30, TimeUnit.SECONDS));
+        } finally {
+            executor = null;
+        }
+    }
+
+    /**
+     * Test case that exercises the code paths in {@link ProxyConnection} for a Quarkus/Vert.x code
+     * snippet like this:
+     *
+     * <code><pre>
+     * import io.smallrye.mutiny.Uni;
+     * import org.hibernate.reactive.mutiny.Mutiny;
+     *
+     * public class SomeRestEndpoint {
+     *     &#64;Inject
+     *     Mutiny.Session mutinySession;
+     *
+     *     &#64;GET
+     *     public Uni&lt;String&gt; doSomeTransactionalStuff() {
+     *         Uni&lt;String&gt; work = mutinySession.find(SomeEntity.class, 42L)
+     *             .map(e -> e.getColumnValue());
+     *
+     *         return mutinySession.withTransaction(tx -> work);
+     *     }
+     * }
+     * </pre></code>
+     */
+    @Test
+    public void noRace() throws InterruptedException, ExecutionException, TimeoutException {
+        CountDownLatch connectionCompleteLatch = new CountDownLatch(1);
+        ReactiveConnectionPoolMock reactiveConnectionPool = new ReactiveConnectionPoolMock(connectionCompleteLatch);
+
+        ProxyConnection proxyConnection = new ProxyConnection(reactiveConnectionPool);
+
+        // Simulate the `mutinySession.find` which triggers a 'ProxyConnection.withConnection()'
+        // Just let it return some string when it could actually "do" something with the connection from the pool.
+        String result1 = "piece-of-work #1";
+        CompletionStage<String> cs1 = proxyConnection.withConnection(
+                reactiveConnection -> CompletableFuture.completedFuture(result1));
+        CompletableFuture<String> cf1 = cs1.toCompletableFuture(); // this is basically just a cast to CF
+
+        // Work cannot be completed yet, because the connection pool hasn't returned a connection yet.
+        assertFalse(cf1.isDone());
+
+        // Simulate the 'mutinySession.withTransaction' which triggers another 'ProxyConnection.withConnection()'
+        // Just let it return some string when it could actually "do" something with the connection from the pool.
+        String result2 = "piece-of-work #2";
+        CompletionStage<String> cs2 = proxyConnection.withConnection(
+                reactiveConnection -> CompletableFuture.completedFuture(result2));
+        CompletableFuture<String> cf2 = cs2.toCompletableFuture(); // this is basically just a cast to CF
+
+        // Work cannot be completed yet, because the connection pool hasn't returned a connection yet.
+        assertFalse(cf2.isDone());
+
+        // Simulate that the connection from the pool is now available
+        connectionCompleteLatch.countDown();
+
+        // It shouldn't take long for the CF to finish - it will eventually complete.
+        // There will be some time required as stuff in this test is ran asynchronously.
+        // Overloaded CI systems can cause tests to become really slow, so 30s is
+        // hopefully long enough to let this test not become flaky. Crossing fingers.
+        String response1 = cf1.get(30, TimeUnit.SECONDS);
+        String response2 = cf2.get(30, TimeUnit.SECONDS);
+
+        assertEquals(result1, response1);
+        assertEquals(result2, response2);
+    }
+
+    /**
+     * Make sure that running many concurrent calls to {@link ProxyConnection#withConnection(Function)}
+     * doesn't break the functionality, albeit it's not good/recommended practice to do that.
+     * <p>
+     * However, using {@link org.hibernate.reactive.mutiny.Mutiny.Session} via
+     * {@link io.smallrye.mutiny.Multi} can lead to exactly this situation. This test however only
+     * exercises the {@link ProxyConnection#withConnection(Function)} part.
+     * <p>
+     * This variant of the test simulates the situation that the connection-pool supplies the
+     * connection after all {@link ProxyConnection#withConnection(Function)} invocations have
+     * issued. The other variants {@link #concurrentWithConnection1Iterations()} and
+     * {@link #concurrentWithConnection2Iterations()} let the connection-pool return the
+     * connection after 1 respective 2 invocations of {@link ProxyConnection#withConnection(Function)}.
+     */
+    @Test
+    public void concurrentWithConnectionAllIterations() throws Exception {
+        concurrentWithConnectionN(parallelism);
+    }
+
+    /**
+     * See {@link #concurrentWithConnectionAllIterations()}.
+     */
+    @Test
+    public void concurrentWithConnection2Iterations() throws Exception {
+        concurrentWithConnectionN(2);
+    }
+
+    /**
+     * See {@link #concurrentWithConnectionAllIterations()}.
+     */
+    @Test
+    public void concurrentWithConnection1Iterations() throws Exception {
+        concurrentWithConnectionN(1);
+    }
+
+    public void concurrentWithConnectionN(int nWithConnectionCalls) throws Exception {
+        for (int i = 0; i < 5; i++) {
+            concurrentWithConnectionN(nWithConnectionCalls, parallelism);
+            concurrentWithConnectionN(nWithConnectionCalls, parallelism * 2);
+            concurrentWithConnectionN(nWithConnectionCalls, parallelism * 3);
+        }
+    }
+
+    public void concurrentWithConnectionN(int nWithConnectionCalls, int workers) throws Exception {
+        CountDownLatch connectionCompleteLatch = new CountDownLatch(1);
+        ReactiveConnectionPoolMock reactiveConnectionPool = new ReactiveConnectionPoolMock(connectionCompleteLatch);
+
+        ProxyConnection proxyConnection = new ProxyConnection(reactiveConnectionPool);
+
+        CountDownLatch withConnectionReady = new CountDownLatch(workers);
+        CountDownLatch withConnectionLatch = new CountDownLatch(1);
+
+        // The CompletionStage by worker# instances as returned from ProxyConnection.withConnection
+        ConcurrentHashMap<Integer, CompletionStage<Integer>> scheduledStages = new ConcurrentHashMap<>();
+        // The ReactiveConnection instance by worker#
+        ConcurrentHashMap<Integer, ReactiveConnection> completedStages = new ConcurrentHashMap<>();
+
+        // counter to adjust when the connection is simulated to be returned from the connection-pool
+        AtomicInteger numWithConnectionDone = new AtomicInteger();
+
+        List<CompletableFuture<?>> futures = new ArrayList<>();
+        for (int i = 0; i < workers; i++) {
+            int num = i; // effectively final i
+            futures.add(CompletableFuture.runAsync(() -> {
+                // tell the "main" thread that this worker is ready
+                withConnectionReady.countDown();
+
+                // wait for the main thread to let this worker start
+                try {
+                    assertTrue(withConnectionLatch.await(30, TimeUnit.SECONDS));
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e); // just bark
+                }
+
+                // jump into 'withConnection'
+                CompletionStage<Integer> cs = proxyConnection.withConnection(
+                        conn -> CompletableFuture.supplyAsync(
+                                () -> {
+                                    completedStages.put(num, conn);
+                                    return num;
+                                },
+                                executor));
+
+                // check whether the connection shall be returned from the connection-pool
+                if (numWithConnectionDone.incrementAndGet() == nWithConnectionCalls) {
+                    connectionCompleteLatch.countDown();
+                }
+
+                scheduledStages.put(num, cs);
+            }, executor));
+        }
+
+        // Wait until all workers are ready...
+        assertTrue(withConnectionReady.await(30, TimeUnit.SECONDS));
+
+        // Trigger all workers to call ProxyConnection.withConnection() somewhat simultaneously
+        withConnectionLatch.countDown();
+
+        // make sure our workers have finished
+        CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]))
+                .get(30, TimeUnit.SECONDS);
+
+        // check that the CompletionStages returned by withConnection() did complete
+        for (int i = 0; i < workers; i++) {
+            CompletionStage<Integer> cs = scheduledStages.get(i);
+            assertNotNull(cs);
+            assertEquals(Integer.valueOf(i), cs.toCompletableFuture().get(5, TimeUnit.SECONDS));
+        }
+
+        // verify that all CompletionStages passed into ProxyConnection.withConnection() did execute
+        Set<Integer> expected0toParallelism = IntStream.range(0, workers).boxed().collect(Collectors.toSet());
+        assertEquals(expected0toParallelism, completedStages.keySet());
+
+        // verify that it's the same ReactiveConnection instance passed into all 'operations'
+        Iterator<ReactiveConnection> iCompleted = completedStages.values().iterator();
+        ReactiveConnection conn = iCompleted.next();
+        assertNotNull(conn);
+        while (iCompleted.hasNext())
+            assertSame(conn, iCompleted.next());
+    }
+
+    class ReactiveConnectionPoolMock implements ReactiveConnectionPool {
+        final CountDownLatch connectionCompleteLatch;
+        final AtomicInteger getConnectionCounter = new AtomicInteger();
+
+        ReactiveConnectionPoolMock(CountDownLatch getConnectionMock) {
+            this.connectionCompleteLatch = getConnectionMock;
+        }
+
+        @Override
+        public CompletionStage<ReactiveConnection> getConnection() {
+            // Verify that ReactiveConnectionPool.getConnection() is only called once
+            assertEquals("Only one invocation of ReactiveConnectionPool.getConnection() is allowed", 0, getConnectionCounter.getAndIncrement());
+
+            return CompletableFuture.supplyAsync(() -> {
+                try {
+                    if (!connectionCompleteLatch.await(60, TimeUnit.SECONDS))
+                        throw new RuntimeException("Oops - the connection request ran for 60 seconds but the test didn't make any progress");
+
+                    // Just need some connection object, but not 'null'
+                    return new SqlClientConnection(null, null, null, false);
+                } catch (InterruptedException e) {
+                    throw new RuntimeException(e);
+                }
+            }, executor); // schedule this CF onto the test's own executor-service
+        }
+
+        @Override
+        public CompletionStage<ReactiveConnection> getConnection(String tenantId) {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+
+        @Override
+        public ReactiveConnection getProxyConnection() {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+
+        @Override
+        public ReactiveConnection getProxyConnection(String tenantId) {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+    }
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/pool/impl/ProxyConnectionTestHelper.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/pool/impl/ProxyConnectionTestHelper.java
@@ -1,0 +1,62 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.pool.impl;
+
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.pool.ReactiveConnectionPool;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+/**
+ * Helper class for tests that want to guarantee that a database connection is available
+ * at a certain point.
+ */
+public class ProxyConnectionTestHelper {
+    public static CompletableFuture<Object> delayedProxyConnection() {
+        CompletableFuture<Object> delay = new CompletableFuture<>();
+        ProxyConnection.setNewProxyConnectionWrapperForTests( (pool, tenant) ->
+                ProxyConnection.newInstanceForTests( new ReactiveConnectionPoolMock( pool::getConnection, delay ), tenant )
+        );
+        return delay;
+    }
+
+    public static void cleanupDelayedProxyConnection() {
+        ProxyConnection.resetNewProxyConnectionWrapperForTests();
+    }
+
+    static class ReactiveConnectionPoolMock implements ReactiveConnectionPool {
+        private final CompletableFuture<Object> delay;
+        private final Supplier<CompletionStage<ReactiveConnection>> connSupplier;
+
+        ReactiveConnectionPoolMock(Supplier<CompletionStage<ReactiveConnection>> connSupplier, CompletableFuture<Object> delay) {
+            // empty
+            this.connSupplier = connSupplier;
+            this.delay = delay;
+        }
+
+        @Override
+        public CompletionStage<ReactiveConnection> getConnection() {
+            return delay.thenCompose( x -> connSupplier.get() );
+        }
+
+        @Override
+        public CompletionStage<ReactiveConnection> getConnection(String tenantId) {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+
+        @Override
+        public ReactiveConnection getProxyConnection() {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+
+        @Override
+        public ReactiveConnection getProxyConnection(String tenantId) {
+            throw new UnsupportedOperationException("not tested/exercised, so it's not implemented");
+        }
+    }
+}


### PR DESCRIPTION
In many cases, the first call to `withConnection()` might trigger the creation of a new connection (sets `connected=true`) and the second call to `withTransaction()` hits the `connected == true && connection == null` case resulting in the `IllegalStateException`.

The problem is related to the state management in `withConnection()`:
* The first invocation sets `connected=true` and triggers `sqlClientPool.getConnection()`, which is likely async and can run for some time.
* Any other invocation (same thread or any other thread) of `withConnection()` that arrives before the `getConnection`-stage completed will see `connected==true && connection==null` and trigger the `IllegalStateException`

Another issue is that the fields used to track the state (`closed`, `connection` are not declared `volatile`/guarded by appropriate fences).

This fix ensures that all invocations of `withConnection()` do either return the already borrowed `ReactiveConnection` in a "happy hot code path" or "queue up" the operations in a single `CompletionStage` that borrows the connection.

Fixes #475 