### PR TITLE
Add --add-opens options required for Gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -144,7 +144,7 @@ subprojects {
         }
         tasks.test {
             // Configure JVM Options
-            jvmArgs.addAll(getProperty('toolchain.launcher.jvmargs').toString().split(' '))
+            jvmArgs(getProperty('toolchain.launcher.jvmargs').toString().split(' '))
         }
 
 	    // Display version of Java tools

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,7 @@
 # Keep all these properties in sync unless you know what you are doing!
 org.gradle.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
-toolchain.compiler.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
+# Needs add-opens because of https://github.com/gradle/gradle/issues/15538
+toolchain.compiler.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8 --add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 toolchain.javadoc.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.launcher.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 


### PR DESCRIPTION
In order to work around illegal accesses in Gradle.

Workaround for https://github.com/gradle/gradle/issues/15538

This should fix the JDK16 build.

Signed-off-by: Yoann Rodière <yoann@hibernate.org>