### PR TITLE
Thread and EventLoop context Assertions

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
@@ -1,0 +1,25 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.common;
+
+import io.vertx.core.Context;
+
+/**
+ * Commonly used assertions to verify that the operations
+ * are running on the expected events and threads.
+ * @author Sanne Grinovero
+ */
+public final class InternalStateAssertions {
+
+	private InternalStateAssertions() {
+		//do not construct
+	}
+
+	public static void assertUseOnEventLoop() {
+		assert Context.isOnEventLoopThread() : "This method should exclusively be invoked from a Vert.x EventLoop thread";
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive.mutiny.impl;
 
 import io.smallrye.mutiny.Uni;
+
 import org.hibernate.Cache;
 import org.hibernate.HibernateException;
 import org.hibernate.internal.SessionCreationOptions;
@@ -22,6 +23,8 @@ import javax.persistence.metamodel.Metamodel;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
+
+import static org.hibernate.reactive.common.InternalStateAssertions.assertUseOnEventLoop;
 
 /**
  * Implementation of {@link Mutiny.SessionFactory}.
@@ -88,12 +91,14 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory {
 	}
 
 	private CompletionStage<ReactiveConnection> connection(String tenantId) {
+		assertUseOnEventLoop();
 		return tenantId == null
 				? pool().getConnection()
 				: pool().getConnection( tenantId );
 	}
 
 	private ReactiveConnection proxyConnection(String tenantId) {
+		assertUseOnEventLoop();
 		return tenantId==null
 				? pool().getProxyConnection()
 				: pool().getProxyConnection( tenantId );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
@@ -13,6 +13,8 @@ import java.util.function.Function;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.ReactiveConnectionPool;
 
+import static org.hibernate.reactive.common.InternalStateAssertions.assertUseOnEventLoop;
+
 /**
  * A proxy {@link ReactiveConnection} that initializes the
  * underlying connection lazily.
@@ -35,6 +37,7 @@ final class ProxyConnection implements ReactiveConnection {
 	}
 
 	private <T> CompletionStage<T> withConnection(Function<ReactiveConnection, CompletionStage<T>> operation) {
+		assertUseOnEventLoop();
 		if ( !connected ) {
 			connected = true; // we're not allowed to fetch two connections!
 			CompletionStage<ReactiveConnection> connection =
@@ -138,4 +141,5 @@ final class ProxyConnection implements ReactiveConnection {
 			connection = null;
 		}
 	}
+
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -100,6 +100,7 @@ import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
+import static org.hibernate.reactive.common.InternalStateAssertions.assertUseOnEventLoop;
 import static org.hibernate.reactive.session.impl.SessionUtil.checkEntityFound;
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 import static org.hibernate.reactive.util.impl.CompletionStages.nullFuture;
@@ -1313,6 +1314,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	}
 
 	public ReactiveConnection getReactiveConnection() {
+		assertUseOnEventLoop();
 		return reactiveConnection;
 	}
 


### PR DESCRIPTION
I'm introducing some assertions, which are now passing after Davide's #478 (They didn't pass before).

I know we don't often use `assert`, but I feel it's a good compromise in this context:

- we're only focusing on Vertx currently
- we need to nail down our design mistakes
- it's not going to bother anyone at runtime, other than tests and people who enable assertions

WDYT ?