### PR TITLE
run all operations in a Vert.x context

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -73,8 +73,6 @@ import org.hibernate.reactive.event.ReactiveRefreshEventListener;
 import org.hibernate.reactive.event.impl.DefaultReactiveAutoFlushEventListener;
 import org.hibernate.reactive.event.impl.DefaultReactiveInitializeCollectionEventListener;
 import org.hibernate.reactive.loader.custom.impl.ReactiveCustomLoader;
-import org.hibernate.reactive.mutiny.Mutiny;
-import org.hibernate.reactive.mutiny.impl.MutinySessionImpl;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
 import org.hibernate.reactive.pool.BatchingConnection;
 import org.hibernate.reactive.pool.ReactiveConnection;
@@ -83,8 +81,6 @@ import org.hibernate.reactive.session.CriteriaQueryOptions;
 import org.hibernate.reactive.session.ReactiveNativeQuery;
 import org.hibernate.reactive.session.ReactiveQuery;
 import org.hibernate.reactive.session.ReactiveSession;
-import org.hibernate.reactive.stage.Stage;
-import org.hibernate.reactive.stage.impl.StageSessionImpl;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import javax.persistence.EntityGraph;
@@ -1315,12 +1311,6 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	public <T> T unwrap(Class<T> clazz) {
 		if ( ReactiveSession.class.isAssignableFrom( clazz ) ) {
 			return clazz.cast(this);
-		}
-		if ( Stage.Session.class.isAssignableFrom( clazz ) ) {
-			return clazz.cast( new StageSessionImpl( this ) );
-		}
-		if ( Mutiny.Session.class.isAssignableFrom( clazz ) ) {
-			return clazz.cast( new MutinySessionImpl( this ) );
 		}
 		return super.unwrap( clazz );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -38,30 +38,36 @@ import static org.hibernate.reactive.util.impl.CompletionStages.returnOrRethrow;
 public class StageSessionImpl implements Stage.Session {
 
 	private final ReactiveSession delegate;
+	private final StageSessionFactoryImpl factory;
 
-	public StageSessionImpl(ReactiveSession session) {
+	public StageSessionImpl(ReactiveSession session, StageSessionFactoryImpl factory) {
 		this.delegate = session;
+		this.factory = factory;
+	}
+
+	private <T> CompletionStage<T> stage(Function<Void, CompletionStage<T>> stage) {
+		return factory.stage(stage);
 	}
 
 	@Override
 	public CompletionStage<Void> flush() {
 //		checkOpen();
-		return delegate.reactiveFlush();
+		return stage( v -> delegate.reactiveFlush() );
 	}
 
 	@Override
 	public <T> CompletionStage<T> fetch(T association) {
-		return delegate.reactiveFetch(association, false);
+		return stage( v -> delegate.reactiveFetch(association, false) );
 	}
 
 	@Override
 	public <E,T> CompletionStage<T> fetch(E entity, Attribute<E,T> field) {
-		return delegate.reactiveFetch(entity, field);
+		return stage( v -> delegate.reactiveFetch(entity, field) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> unproxy(T association) {
-		return delegate.reactiveFetch(association, true);
+		return stage( v -> delegate.reactiveFetch(association, true) );
 	}
 
 	@Override
@@ -88,88 +94,88 @@ public class StageSessionImpl implements Stage.Session {
 
 	@Override
 	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey) {
-		return delegate.reactiveFind( entityClass, primaryKey, null, null );
+		return stage( v -> delegate.reactiveFind( entityClass, primaryKey, null, null ) );
 	}
 
 	@Override
 	public <T> CompletionStage<List<T>> find(Class<T> entityClass, Object... ids) {
-		return delegate.reactiveFind( entityClass, ids );
+		return stage( v -> delegate.reactiveFind( entityClass, ids ) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey, LockMode lockMode) {
-		return delegate.reactiveFind( entityClass, primaryKey, new LockOptions(lockMode), null );
+		return stage( v -> delegate.reactiveFind( entityClass, primaryKey, new LockOptions(lockMode), null ) );
 	}
 
 //	@Override
 	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey, LockOptions lockOptions) {
-		return delegate.reactiveFind( entityClass, primaryKey, lockOptions, null );
+		return stage( v -> delegate.reactiveFind( entityClass, primaryKey, lockOptions, null ) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> find(EntityGraph<T> entityGraph, Object id) {
 		Class<T> entityClass = ((RootGraphImplementor<T>) entityGraph).getGraphedType().getJavaType();
-		return delegate.reactiveFind( entityClass, id, null, entityGraph );
+		return stage( v -> delegate.reactiveFind( entityClass, id, null, entityGraph ) );
 	}
 
 	@Override
 	public CompletionStage<Void> persist(Object entity) {
-		return delegate.reactivePersist( entity );
+		return stage( v -> delegate.reactivePersist( entity ) );
 	}
 
 	@Override
 	public CompletionStage<Void> persist(Object... entity) {
-		return applyToAll( delegate::reactivePersist, entity );
+		return stage( v -> applyToAll( delegate::reactivePersist, entity ) );
 	}
 
 	@Override
 	public CompletionStage<Void> remove(Object entity) {
-		return delegate.reactiveRemove( entity );
+		return stage( v -> delegate.reactiveRemove( entity ) );
 	}
 
 	@Override
 	public CompletionStage<Void> remove(Object... entity) {
-		return applyToAll( delegate::reactiveRemove, entity );
+		return stage( v -> applyToAll( delegate::reactiveRemove, entity ) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> merge(T entity) {
-		return delegate.reactiveMerge( entity );
+		return stage( v -> delegate.reactiveMerge( entity ) );
 	}
 
 	@Override @SafeVarargs
 	public final <T> CompletionStage<Void> merge(T... entity) {
-		return applyToAll( delegate::reactiveMerge, entity );
+		return stage( v -> applyToAll( delegate::reactiveMerge, entity ) );
 	}
 
 	@Override
 	public CompletionStage<Void> refresh(Object entity) {
-		return delegate.reactiveRefresh( entity, LockOptions.NONE );
+		return stage( v -> delegate.reactiveRefresh( entity, LockOptions.NONE ) );
 	}
 
 	@Override
 	public CompletionStage<Void> refresh(Object entity, LockMode lockMode) {
-		return delegate.reactiveRefresh( entity, new LockOptions(lockMode) );
+		return stage( v -> delegate.reactiveRefresh( entity, new LockOptions(lockMode) ) );
 	}
 
 //	@Override
 	public CompletionStage<Void> refresh(Object entity, LockOptions lockOptions) {
-		return delegate.reactiveRefresh( entity, lockOptions );
+		return stage( v -> delegate.reactiveRefresh( entity, lockOptions ) );
 	}
 
 	@Override
 	public CompletionStage<Void> refresh(Object... entity) {
-		return applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entity );
+		return stage( v -> applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entity ) );
 	}
 
 	@Override
 	public CompletionStage<Void> lock(Object entity, LockMode lockMode) {
-		return delegate.reactiveLock( entity, new LockOptions(lockMode) );
+		return stage( v -> delegate.reactiveLock( entity, new LockOptions(lockMode) ) );
 	}
 
 //	@Override
 	public CompletionStage<Void> lock(Object entity, LockOptions lockOptions) {
-		return delegate.reactiveLock( entity, lockOptions );
+		return stage( v -> delegate.reactiveLock( entity, lockOptions ) );
 	}
 
 	@Override


### PR DESCRIPTION
See #480.

Previously, work could be done on the calling thread, outside of a Vert.x context.

This code makes the Mutiny API do work lazily, dispatching it to the Vert.x context.

Open questions:

- Is it too expensive to do this for *every* operation? Should we only do it in `withSession()` / `withTransaction()`, and just make the other operations lazy, but not dispatch them to the Vert.x context?
- How do I do this with `CompletionStage`s?
- Is this code actually correct, @vietj @cescoffier?