### PR TITLE
fix broken use of streams in populateDB() in tests

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
@@ -32,7 +32,7 @@ public class CompositeIdTest extends BaseReactiveTest {
 		return getSessionFactory()
 				.withSession(
 						session -> session.persist( new GuineaPig(5, "Aloi", 100) )
-							.thenApply( v -> { session.flush(); return null; } )
+							.thenCompose( v -> session.flush() )
 				 );
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
@@ -32,7 +32,7 @@ public class MutinySessionTest extends BaseReactiveTest {
 		return getMutinySessionFactory()
 				.withSession(
 						session -> session.persist( new GuineaPig(5, "Aloi") )
-								.invoke(session::flush)
+								.chain(session::flush)
 				);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -38,7 +38,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 		return getSessionFactory()
 				.withSession(
 						session -> session.persist( new GuineaPig(5, "Aloi") )
-								.thenApply( v -> { session.flush(); return null; } )
+								.thenCompose( v -> session.flush() )
 				);
 	}
 


### PR DESCRIPTION
I have no clue how we didn't notice this earlier.

I was bugging @cescoffier a couple of days ago because my `Uni`s weren't being serialized, and it turns out we were using `invoke()` to chain `Uni`s in the test. How embarrassing.