### PR TITLE
Convert the Thread state assertions into a regular exception, but onl…

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -75,6 +75,7 @@ tasks.withType(Test) {
         events 'PASSED', 'FAILED', 'SKIPPED'
     }
     systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
+    systemProperty 'org.hibernate.reactive.common.InternalStateAssertions.ENFORCE', 'true'
 }
 
 // Example:

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
@@ -14,12 +14,23 @@ import io.vertx.core.Context;
  */
 public final class InternalStateAssertions {
 
+	private static final boolean ENFORCE = Boolean.getBoolean( "org.hibernate.reactive.common.InternalStateAssertions.ENFORCE" );
+
 	private InternalStateAssertions() {
 		//do not construct
 	}
 
 	public static void assertUseOnEventLoop() {
-		assert Context.isOnEventLoopThread() : "This method should exclusively be invoked from a Vert.x EventLoop thread";
+		if ( ENFORCE && (! Context.isOnEventLoopThread() ) ) {
+			throw new IllegalStateException( "This method should exclusively be invoked from a Vert.x EventLoop thread; currently running on thread '" + Thread.currentThread().getName() + '\'' );
+		}
+	}
+
+	public static void assertCurrentThreadMatches(Thread expectedThread) {
+		if ( ENFORCE && ( Thread.currentThread() != expectedThread ) ) {
+			throw new IllegalStateException( "Detected use of the Reactive Session from a different Thread than the one which was used to open the Reactive Session - this suggests an invalid integration; "
+			+ "original thread: '" + expectedThread.getName() + "' current Thread: '" + Thread.currentThread().getName() + '\'' );
+		}
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
@@ -6,10 +6,10 @@
 package org.hibernate.reactive.pool.impl;
 
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.reactive.common.InternalStateAssertions;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
-import io.vertx.core.Context;
 import io.vertx.sqlclient.Pool;
 
 /**
@@ -56,13 +56,7 @@ public final class ExternalSqlClientPool extends SqlClientPool {
 	@Override
 	protected Pool getPool() {
 		//First, check that the requester is running within the EventLoop:
-		if ( !Context.isOnEventLoopThread() ) {
-			//Not using the InternalStateAssertions here as this check is more critical; need to ensure all production code actually adheres to this constraint.
-			//On top of correctness (accessing the pool from a non-eventloop thread exposes us to race conditions), we also don't want to the ThreadLocal
-			//to store more Pool references than the configured Vert.x threads.
-			throw new IllegalStateException(
-					"A Reactive SQL Client Pool can only be used from within a Vert.x context. You are using Hibernate Reactive within a thread which is not a Vert.x event loop." );
-		}
+		InternalStateAssertions.assertUseOnEventLoop();
 		return pool;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -60,6 +60,7 @@ import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.Query;
 import org.hibernate.query.internal.ParameterMetadataImpl;
+import org.hibernate.reactive.common.InternalStateAssertions;
 import org.hibernate.reactive.common.ResultSetMapping;
 import org.hibernate.reactive.engine.ReactiveActionQueue;
 import org.hibernate.reactive.engine.impl.ReactivePersistenceContextAdapter;
@@ -144,7 +145,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	}
 
 	private void threadCheck() {
-		assert Thread.currentThread() == associatedWorkThread : "Detected a switch of the current thread - this suggests an invalid integration with Vert.x";
+		InternalStateAssertions.assertCurrentThreadMatches( associatedWorkThread );
 	}
 
 	@Override


### PR DESCRIPTION
…y enabled by system property

I've converted the assertions I recently introduced into regular exceptions, but making them throw only as opt-in via a system property.

This is to help in Quarkus migrating to the new appoach, as the new assertions were too disruptive; in particular I need to be able to disable all checks (temporarily) in Panache Reactive.