### PR TITLE
Element collection string

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
@@ -105,45 +105,45 @@ public class ReactiveActionQueue {
 //					}
 //				}
 //		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionRemoveAction.class,
-//				new ListProvider<CollectionRemoveAction>() {
-//					ExecutableList<CollectionRemoveAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionRemovals;
-//					}
-//					ExecutableList<CollectionRemoveAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionRemovals = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionUpdateAction.class,
-//				new ListProvider<CollectionUpdateAction>() {
-//					ExecutableList<CollectionUpdateAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionUpdates;
-//					}
-//					ExecutableList<CollectionUpdateAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionUpdates = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionRecreateAction.class,
-//				new ListProvider<CollectionRecreateAction>() {
-//					ExecutableList<CollectionRecreateAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionCreations;
-//					}
-//					ExecutableList<CollectionRecreateAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionCreations = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionRemoveAction.class,
+				new ListProvider<ReactiveCollectionRemoveAction>() {
+					ExecutableList<ReactiveCollectionRemoveAction> get(ReactiveActionQueue instance) {
+						return instance.collectionRemovals;
+					}
+					ExecutableList<ReactiveCollectionRemoveAction> init(ReactiveActionQueue instance) {
+						return instance.collectionRemovals = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionUpdateAction.class,
+				new ListProvider<ReactiveCollectionUpdateAction>() {
+					ExecutableList<ReactiveCollectionUpdateAction> get(ReactiveActionQueue instance) {
+						return instance.collectionUpdates;
+					}
+					ExecutableList<ReactiveCollectionUpdateAction> init(ReactiveActionQueue instance) {
+						return instance.collectionUpdates = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionRecreateAction.class,
+				new ListProvider<ReactiveCollectionRecreateAction>() {
+					ExecutableList<ReactiveCollectionRecreateAction> get(ReactiveActionQueue instance) {
+						return instance.collectionCreations;
+					}
+					ExecutableList<ReactiveCollectionRecreateAction> init(ReactiveActionQueue instance) {
+						return instance.collectionCreations = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
 		EXECUTABLE_LISTS_MAP.put(
 				ReactiveEntityDeleteAction.class,
 				new ListProvider<ReactiveEntityDeleteAction>() {
@@ -174,10 +174,10 @@ public class ReactiveActionQueue {
 	// Note that, unlike objects, collection insertions, updates,
 	// deletions are not really remembered between flushes. We
 	// just re-use the same Lists for convenience.
-	private ExecutableList<CollectionRecreateAction> collectionCreations;
-	private ExecutableList<CollectionUpdateAction> collectionUpdates;
+	private ExecutableList<ReactiveCollectionRecreateAction> collectionCreations;
+	private ExecutableList<ReactiveCollectionUpdateAction> collectionUpdates;
 	private ExecutableList<QueuedOperationCollectionAction> collectionQueuedOps;
-	private ExecutableList<CollectionRemoveAction> collectionRemovals;
+	private ExecutableList<ReactiveCollectionRemoveAction> collectionRemovals;
 	// TODO: The removeOrphan concept is a temporary "hack" for HHH-6484.  This should be removed once action/task
 	// ordering is improved.
 	private ExecutableList<OrphanRemovalAction> orphanRemovals;
@@ -416,9 +416,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the (re)creation of a collection
 	 */
-	public void addAction(CollectionRecreateAction action) {
-//		addAction( CollectionRecreateAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionRecreateAction action) {
+		addAction( ReactiveCollectionRecreateAction.class, action );
 	}
 
 	/**
@@ -426,9 +425,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the removal of a collection
 	 */
-	public void addAction(CollectionRemoveAction action) {
-//		addAction( CollectionRemoveAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionRemoveAction action) {
+		addAction( ReactiveCollectionRemoveAction.class, action );
 	}
 
 	/**
@@ -436,9 +434,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the update of a collection
 	 */
-	public void addAction(CollectionUpdateAction action) {
-//		addAction( CollectionUpdateAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionUpdateAction action) {
+		addAction( ReactiveCollectionUpdateAction.class, action );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
@@ -1,0 +1,79 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+
+public class ReactiveCollectionRecreateAction extends CollectionAction implements ReactiveExecutable {
+
+	public ReactiveCollectionRecreateAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final ReactiveCollectionPersister persister = (ReactiveCollectionPersister)getPersister();
+		final SharedSessionContractImplementor session = getSession();
+		final Serializable key = getKey();
+
+		final PersistentCollection collection = getCollection();
+
+		preRecreate();
+
+		return persister.recreateReactive( collection, key, session ).thenAccept( v -> {
+			session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+			evict();
+			postRecreate();
+		} );
+	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
@@ -1,0 +1,183 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionRemoveEvent;
+import org.hibernate.event.spi.PostCollectionRemoveEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRemoveEvent;
+import org.hibernate.event.spi.PreCollectionRemoveEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+public class ReactiveCollectionRemoveAction extends CollectionAction implements ReactiveExecutable { ;
+	private final Object affectedOwner;
+	private final boolean emptySnapshot;
+
+	public ReactiveCollectionRemoveAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final boolean emptySnapshot,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+		if ( collection == null ) {
+			throw new AssertionFailure( "collection == null");
+		}
+		this.emptySnapshot = emptySnapshot;
+		// the loaded owner will be set to null after the collection is removed,
+		// so capture its value as the affected owner so it is accessible to
+		// both pre- and post- events
+		this.affectedOwner = session.getPersistenceContextInternal().getLoadedCollectionOwnerOrNull( collection );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final Serializable key = getKey();
+		final SharedSessionContractImplementor session = getSession();
+		final ReactiveCollectionPersister reactivePersister = (ReactiveCollectionPersister) getPersister();
+		final CollectionPersister corePersister = getPersister();
+		final PersistentCollection collection = getCollection();
+		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+
+		CompletionStage<Void> removeStage = CompletionStages.voidFuture();
+
+		if ( !emptySnapshot ) {
+			// an existing collection that was either non-empty or uninitialized
+			// is replaced by null or a different collection
+			// (if the collection is uninitialized, hibernate has no way of
+			// knowing if the collection is actually empty without querying the db)
+			removeStage = removeStage.thenAccept( v -> preRemove() )
+					.thenCompose( v -> reactivePersister
+							.removeReactive( key, session )
+							.thenAccept( ignore -> {
+								evict();
+								postRemove();
+							})
+					);
+		}
+		if( collection != null ) {
+			return removeStage.thenAccept(v -> {
+				session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+				evict();
+				postRemove();
+				if ( statistics.isStatisticsEnabled() ) {
+					statistics.updateCollection( corePersister.getRole() );
+				}
+			} );
+		}
+		return removeStage.thenAccept(v -> {
+			evict();
+			postRemove();
+			if ( statistics.isStatisticsEnabled() ) {
+				statistics.updateCollection( corePersister.getRole() );
+			}
+		} );
+
+	}
+
+//	@Override
+//	public int compareTo(Object o) {
+//		return 0;
+//	}
+
+//	@Override
+//	public Serializable[] getPropertySpaces() {
+//		return new Serializable[0];
+//	}
+//
+//	@Override
+//	public AfterTransactionCompletionProcess getAfterTransactionCompletionProcess() {
+//		return null;
+//	}
+//
+//	@Override
+//	public BeforeTransactionCompletionProcess getBeforeTransactionCompletionProcess() {
+//		return null;
+//	}
+//
+//	@Override
+//	public void afterDeserialize(SharedSessionContractImplementor session) {
+//
+//	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preRemove() {
+		final EventListenerGroup<PreCollectionRemoveEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_REMOVE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRemoveEvent event = new PreCollectionRemoveEvent(
+				getPersister(),
+				getCollection(),
+				eventSource(),
+				affectedOwner
+		);
+		for ( PreCollectionRemoveEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRemoveCollection( event );
+		}
+	}
+
+	private void postRemove() {
+		final EventListenerGroup<PostCollectionRemoveEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_REMOVE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRemoveEvent event = new PostCollectionRemoveEvent(
+				getPersister(),
+				getCollection(),
+				eventSource(),
+				affectedOwner
+		);
+		for ( PostCollectionRemoveEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRemoveCollection( event );
+		}
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
@@ -1,0 +1,211 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionUpdateEvent;
+import org.hibernate.event.spi.PostCollectionUpdateEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionUpdateEvent;
+import org.hibernate.event.spi.PreCollectionUpdateEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.pretty.MessageHelper;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+
+/**
+ * Like {@link org.hibernate.action.internal.CollectionUpdateAction} but reactive
+ *
+ * @see org.hibernate.action.internal.CollectionUpdateAction
+ */
+public class ReactiveCollectionUpdateAction extends CollectionAction implements ReactiveExecutable {
+	private final boolean emptySnapshot;
+
+	public ReactiveCollectionUpdateAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final boolean emptySnapshot,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+		this.emptySnapshot = emptySnapshot;
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final Serializable key = getKey();
+		final SharedSessionContractImplementor session = getSession();
+		final ReactiveCollectionPersister reactivePersister = (ReactiveCollectionPersister) getPersister();
+		final CollectionPersister corePersister = getPersister();
+		final PersistentCollection collection = getCollection();
+		final boolean affectedByFilters = corePersister.isAffectedByEnabledFilters( session );
+
+		preUpdate();
+
+		CompletionStage<Void> updateStage = CompletionStages.voidFuture();
+
+		// And then make sure that each operations is executed in its own stage maintaining the same order as in ORM
+		if ( !collection.wasInitialized() ) {
+			// If there were queued operations, they would have been processed
+			// and cleared by now.
+			// The collection should still be dirty.
+			if ( !collection.isDirty() ) {
+				throw new AssertionFailure( "collection is not dirty" );
+			}
+			//do nothing - we only need to notify the cache...
+		}
+		else if ( !affectedByFilters && collection.empty() ) {
+			if ( !emptySnapshot ) {
+				updateStage = updateStage
+						.thenCompose( v -> reactivePersister.removeReactive( key, session ) )
+						.thenAccept( count -> { /* We don't care, maybe we can log it as debug */} );
+			}
+		}
+		else if ( collection.needsRecreate( corePersister ) ) {
+			if ( affectedByFilters ) {
+				throw new HibernateException(
+						"cannot recreate collection while filter is enabled: " +
+								MessageHelper.collectionInfoString( corePersister, collection, key, session )
+				);
+			}
+			if ( !emptySnapshot ) {
+				updateStage = updateStage
+						.thenCompose( v -> reactivePersister.removeReactive( key, session ) )
+						.thenAccept( count -> { /* We don't care, maybe we can log it as debug */} );
+			}
+
+			return updateStage
+					.thenCompose( v -> reactivePersister
+							.recreateReactive( collection, key, session )
+							.thenAccept( ignore -> {
+								session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+								evict();
+								postUpdate();
+								final StatisticsImplementor statistics = session.getFactory().getStatistics();
+								if ( statistics.isStatisticsEnabled() ) {
+									statistics.updateCollection( corePersister.getRole() );
+								}
+							})
+					);
+		}
+		else {
+			updateStage = updateStage
+					.thenCompose( v -> reactivePersister.reactiveDeleteRows( collection, key, session ) )
+					.thenCompose( v -> reactivePersister.reactiveUpdateRows( collection, key, session ) )
+					.thenCompose( v -> reactivePersister.reactiveInsertRows( collection, key, session ) )
+					.thenAccept( ignore -> {} );
+		}
+
+		return updateStage.thenAccept(v -> {
+			session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+			evict();
+			postUpdate();
+
+			final StatisticsImplementor statistics = session.getFactory().getStatistics();
+			if ( statistics.isStatisticsEnabled() ) {
+				statistics.updateCollection( corePersister.getRole() );
+			}
+		} );
+	}
+
+//	@Override
+//	public int compareTo(Object o) {
+//		return 0;
+//	}
+
+//	@Override
+//	public Serializable[] getPropertySpaces() {
+//		return new Serializable[0];
+//	}
+//
+//	@Override
+//	public AfterTransactionCompletionProcess getAfterTransactionCompletionProcess() {
+//		return null;
+//	}
+//
+//	@Override
+//	public BeforeTransactionCompletionProcess getBeforeTransactionCompletionProcess() {
+//		return null;
+//	}
+//
+//	@Override
+//	public void afterDeserialize(SharedSessionContractImplementor session) {
+//
+//	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preUpdate() {
+		final EventListenerGroup<PreCollectionUpdateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_UPDATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionUpdateEvent event = new PreCollectionUpdateEvent(
+				getPersister(),
+				getCollection(),
+				eventSource()
+		);
+		for ( PreCollectionUpdateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreUpdateCollection( event );
+		}
+	}
+
+	private void postUpdate() {
+		final EventListenerGroup<PostCollectionUpdateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_UPDATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionUpdateEvent event = new PostCollectionUpdateEvent(
+				getPersister(),
+				getCollection(),
+				eventSource()
+		);
+		for ( PostCollectionUpdateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostUpdateCollection( event );
+		}
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBasicCollectionLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBasicCollectionLoader.java
@@ -1,0 +1,68 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.loader.collection.impl;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.loader.collection.OneToManyJoinWalker;
+import org.hibernate.persister.collection.QueryableCollection;
+import org.hibernate.transform.ResultTransformer;
+
+public class ReactiveBasicCollectionLoader extends ReactiveCollectionLoader {
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) {
+		super( collectionPersister, factory, loadQueryInfluencers );
+	}
+
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			int batchSize,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		this(collectionPersister, batchSize, null, factory, loadQueryInfluencers);
+	}
+
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			int batchSize,
+			String subquery,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		super(collectionPersister, factory, loadQueryInfluencers);
+
+		initFromWalker( new OneToManyJoinWalker(
+				collectionPersister,
+				batchSize,
+				subquery,
+				factory,
+				loadQueryInfluencers
+		) );
+
+		postInstantiate();
+		if (LOG.isDebugEnabled()) {
+			LOG.debugf("Static select for one-to-many %s: %s", collectionPersister.getRole(), getSQLString());
+		}
+	}
+
+	@Override
+	protected Object getResultColumnOrRow(
+			Object[] row,
+			ResultTransformer transformer,
+			ResultSet rs, SharedSessionContractImplementor session) throws SQLException, HibernateException {
+		if ( row.length == 1 ) {
+			return row[0];
+		}
+		return row;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBatchingCollectionInitializerBuilder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBatchingCollectionInitializerBuilder.java
@@ -24,7 +24,7 @@ import org.hibernate.reactive.loader.collection.ReactiveCollectionInitializer;
 public abstract class ReactiveBatchingCollectionInitializerBuilder {
 
 	public static ReactiveBatchingCollectionInitializerBuilder getBuilder(SessionFactoryImplementor factory) {
-		switch ( factory.getSettings().getBatchFetchStyle() ) {
+		switch ( factory.getSessionFactoryOptions().getBatchFetchStyle() ) {
 			case PADDED: {
 				return ReactivePaddedBatchingCollectionInitializerBuilder.INSTANCE;
 			}
@@ -106,7 +106,6 @@ public abstract class ReactiveBatchingCollectionInitializerBuilder {
 		if (persister.isOneToMany()) {
 			return new ReactiveOneToManyLoader(persister, factory, influencers);
 		}
-		throw new UnsupportedOperationException();
-//		return new ReactiveBasicCollectionLoader(persister, factory, influencers);
+		return new ReactiveBasicCollectionLoader(persister, factory, influencers);
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -90,7 +90,7 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 								if ( hasIdentifier ) {
 									loc = writeIdentifier( st, collection.getIdentifier( entry, i ), loc, session );
 								}
-								getIdentifierType().nullSafeSet( st, id, 1, session );
+								loc = writeElement( st, collection.getElement( entry ), loc, session );
 
 								// FIXME: Set the other parameters as well
 							}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -1,0 +1,179 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.collection.impl;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.mapping.Collection;
+import org.hibernate.persister.collection.BasicCollectionPersister;
+import org.hibernate.persister.spi.PersisterCreationContext;
+import org.hibernate.pretty.MessageHelper;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
+import org.hibernate.reactive.util.impl.CompletionStages;
+
+import org.jboss.logging.Logger;
+
+public class ReactiveBasicCollectionPersister extends BasicCollectionPersister implements ReactiveCollectionPersister {
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			CoreMessageLogger.class,
+			ReactiveBasicCollectionPersister.class.getName()
+	);
+	private static final String VALUE_STR = "(?, ?)";
+
+	public ReactiveBasicCollectionPersister(
+			Collection collectionBinding,
+			CollectionDataAccess cacheAccessStrategy,
+			PersisterCreationContext creationContext) throws MappingException, CacheException {
+		super( collectionBinding, cacheAccessStrategy, creationContext );
+	}
+
+	private ReactiveConnection getReactiveConnection(SharedSessionContractImplementor session) {
+		return ( (ReactiveConnectionSupplier) session ).getReactiveConnection();
+	}
+
+	public CompletionStage<Void> recreateReactive(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session)
+			throws HibernateException {
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowInsertEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debugf(
+					"Inserting collection: %s",
+					MessageHelper.collectionInfoString( this, collection, id, session )
+			);
+		}
+
+		// create all the new entries
+		Iterator entries = collection.entries( this );
+
+		if ( entries.hasNext() ) {
+			collection.preInsert( this );
+
+			List<Object> valuePairList = new ArrayList<>();
+
+			while ( entries.hasNext() ) {
+				valuePairList.add( id );
+				valuePairList.add( entries.next() );
+			}
+
+			// In order to insert element collection values create a native query with placeholders followed by
+			// value sets
+			return reactiveConnection
+					.update(
+							getSQLInsertElementCollectionString(
+									valuePairList.size() / 2 ),
+							valuePairList.toArray( new Object[0] )
+					)
+					.thenAccept( ignore -> {
+					} );
+		}
+
+		return CompletionStages.voidFuture();
+	}
+
+	// FIXME: this method currently only works for List<String> element collections and uses a VALUE_STR = "(?, ?)"
+	// will not work for List, Map, etc... of @Embedded entity (i.e. complex type)
+	private String getSQLInsertElementCollectionString(int numRows) {
+		String defaultInsertString = getSQLInsertRowString();
+		StringBuilder buf = new StringBuilder( defaultInsertString.length() + ( numRows + 2 ) * VALUE_STR.length() );
+		buf.append( defaultInsertString );
+		for ( int i = 1; i < numRows; i++ ) {
+			buf.append( ", " );
+			buf.append( VALUE_STR );
+		}
+		return buf.toString();
+	}
+
+	public CompletionStage<Integer> removeReactive(Serializable id, SharedSessionContractImplementor session)
+			throws HibernateException {
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+		if ( !isInverse && isRowDeleteEnabled() ) {
+			if ( LOG.isDebugEnabled() ) {
+				LOG.debugf(
+						"Deleting collection: %s",
+						MessageHelper.collectionInfoString( this, id, getFactory() )
+				);
+			}
+
+			List<Object> params = new ArrayList<>();
+			params.add( id );
+			String sql = getSQLDeleteString();
+			return reactiveConnection.update( sql, params.toArray( new Object[0] ) );
+		}
+		return CompletionStages.completedFuture( -1 );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveDeleteRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		//TODO: See AbstractCollectionPersister#deleteRows
+		throw new UnsupportedOperationException();
+
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveUpdateRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+		if ( !isInverse && collection.isRowUpdatePossible() ) {
+			// TODO: See AbstractCollectionPersister#updateRows
+			throw new UnsupportedOperationException();
+		}
+		return CompletionStages.voidFuture();
+	}
+	@Override
+	public CompletionStage<Void> reactiveInsertRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		// FIXME: Not sure what to implement here for OneToMany use-case
+		// Maybe nothing due to the ReactiveCollectionUpdate/Remove/Recreate Action classes perform necessary operations
+		// on the collection (basically delete and replace rather than operating on individual rows
+		throw new UnsupportedOperationException();
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
@@ -1,0 +1,65 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.collection.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+/**
+ * Similar to {@link org.hibernate.persister.collection.AbstractCollectionPersister} in ORM
+ * <p>
+ *     The reactive classes already extend something so we cannot have an abstract class like in ORM.
+ * </p>
+ */
+public interface ReactiveCollectionPersister {
+
+	/**
+	 * Reactive version of {@link org.hibernate.persister.collection.AbstractCollectionPersister}.recreate()
+	 * @param collection
+	 * @param id
+	 * @param session
+	 * @return Void completion stage
+	 */
+	CompletionStage<Void> recreateReactive(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link org.hibernate.persister.collection.AbstractCollectionPersister}.remove()
+	 * @param id
+	 * @param session
+	 * @return Integer completion stage
+	 */
+	CompletionStage<Integer> removeReactive(Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link org.hibernate.persister.collection.AbstractCollectionPersister}.deleteRows()
+	 * @param collection
+	 * @param id
+	 * @param session
+	 * @return Void completion stage
+	 */
+	CompletionStage<Void> reactiveDeleteRows(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link org.hibernate.persister.collection.AbstractCollectionPersister}.insertRows()
+	 * @param collection
+	 * @param id
+	 * @param session
+	 * @return Void completion stage
+	 */
+	CompletionStage<Void> reactiveInsertRows( PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link org.hibernate.persister.collection.AbstractCollectionPersister}.updateRows()
+	 * @param collection
+	 * @param id
+	 * @param session
+	 * @return Void completion stage
+	 */
+	CompletionStage<Void> reactiveUpdateRows(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
@@ -6,23 +6,38 @@
 package org.hibernate.reactive.persister.collection.impl;
 
 import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.jdbc.Expectations;
 import org.hibernate.mapping.Collection;
 import org.hibernate.persister.collection.OneToManyPersister;
 import org.hibernate.persister.spi.PersisterCreationContext;
+import org.hibernate.pretty.MessageHelper;
 import org.hibernate.reactive.loader.collection.impl.ReactiveBatchingCollectionInitializerBuilder;
 import org.hibernate.reactive.loader.collection.ReactiveCollectionInitializer;
 import org.hibernate.reactive.loader.collection.impl.ReactiveSubselectOneToManyLoader;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
+import org.hibernate.reactive.util.impl.CompletionStages;
 
-public class ReactiveOneToManyPersister extends OneToManyPersister {
+import org.jboss.logging.Logger;
+
+public class ReactiveOneToManyPersister extends OneToManyPersister implements ReactiveCollectionPersister {
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, ReactiveOneToManyPersister.class.getName() );
+
 	public ReactiveOneToManyPersister(Collection collectionBinding, CollectionDataAccess cacheAccessStrategy, PersisterCreationContext creationContext) throws MappingException, CacheException {
 		super( collectionBinding, cacheAccessStrategy, creationContext );
 	}
@@ -54,5 +69,86 @@ public class ReactiveOneToManyPersister extends OneToManyPersister {
 
 	protected ReactiveCollectionInitializer getAppropriateInitializer(Serializable key, SharedSessionContractImplementor session) {
 		return (ReactiveCollectionInitializer) super.getAppropriateInitializer(key, session);
+	}
+
+	@Override
+	public CompletionStage<Void> recreateReactive(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		return CompletionStages.voidFuture();
+	}
+
+	private ReactiveConnection getReactiveConnection(SharedSessionContractImplementor session) {
+		return ( (ReactiveConnectionSupplier) session ).getReactiveConnection();
+	}
+
+	@Override
+	public CompletionStage<Integer> removeReactive(Serializable id, SharedSessionContractImplementor session)
+			throws HibernateException {
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+		if ( !isInverse && isRowDeleteEnabled() ) {
+			if ( LOG.isDebugEnabled() ) {
+				LOG.debugf(
+						"Deleting collection: %s",
+						MessageHelper.collectionInfoString( this, id, getFactory() )
+				);
+			}
+
+			// Remove all the old entries
+
+			int offset = 1;
+			final PreparedStatement st;
+			Expectation expectation = Expectations.appropriateExpectation( getDeleteAllCheckStyle() );
+			boolean callable = isDeleteAllCallable();
+
+			List<Object> params = new ArrayList<>();
+			params.add( id );
+			String sql = getSQLDeleteString();
+
+			return reactiveConnection.update( sql, params.toArray( new Object[0] ) );
+		}
+		return CompletionStages.completedFuture( -1 );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveDeleteRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		//TODO: See AbstractCollectionPersister#deleteRows
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveInsertRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		// FIXME: Not sure what to implement here for OneToMany use-case
+		// Maybe nothing due to the ReactiveCollectionUpdate/Remove/Recreate Action classes perform necessary operations
+		// on the collection (basically delete and replace rather than operating on individual rows
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveUpdateRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		if ( !isInverse && collection.isRowUpdatePossible() ) {
+			// TODO: See AbstractCollectionPersister#updateRows
+			throw new UnsupportedOperationException();
+		}
+		return CompletionStages.voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactivePersisterClassResolver.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactivePersisterClassResolver.java
@@ -10,10 +10,11 @@ import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.internal.StandardPersisterClassResolver;
 import org.hibernate.persister.spi.PersisterClassResolver;
+import org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister;
+import org.hibernate.reactive.persister.collection.impl.ReactiveOneToManyPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveJoinedSubclassEntityPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveSingleTableEntityPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveUnionSubclassEntityPersister;
-import org.hibernate.reactive.persister.collection.impl.ReactiveOneToManyPersister;
 
 public class ReactivePersisterClassResolver extends StandardPersisterClassResolver implements PersisterClassResolver {
 
@@ -34,6 +35,14 @@ public class ReactivePersisterClassResolver extends StandardPersisterClassResolv
 
 	@Override
 	public Class<? extends CollectionPersister> getCollectionPersisterClass(Collection metadata) {
+		return metadata.isOneToMany() ? oneToManyPersister() : elementCollectionPersister();
+	}
+
+	private Class<? extends CollectionPersister> oneToManyPersister() {
 		return ReactiveOneToManyPersister.class;
+	}
+
+	private Class<? extends CollectionPersister> elementCollectionPersister() {
+		return ReactiveBasicCollectionPersister.class;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -46,6 +46,10 @@ public class CompletionStages {
 	private static final CompletionStage<Boolean> TRUE = completedFuture( true );
 	private static final CompletionStage<Boolean> FALSE = completedFuture( false );
 
+	public static CompletionStage<Void> voidFuture(Object ignore) {
+		return voidFuture();
+	}
+
 	public static CompletionStage<Void> voidFuture() {
 		return VOID;
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionTest.java
@@ -1,0 +1,275 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
+
+public class EagerElementCollectionTest extends BaseReactiveTest {
+
+	private Person thePerson;
+
+	@Rule
+	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Person.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		String[] phoneArray = new String[]{ "999-999-9999", "111-111-1111", "123-456-7890" };
+		thePerson = new Person( 7242000, "Claude", phoneArray);
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( thePerson )
+				.thenCompose( v -> session.flush() )
+			    .thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+		);
+	}
+
+	/*
+	 * This test performs a simple check of Person entity collection values after persisting
+	 */
+	@Test
+	public void findPhonesElementCollectionStageSession(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( found -> {
+							context.assertNotNull( found );
+							context.assertEquals( 3, found.getPhones().size() );
+							context.assertTrue( found.getPhones().contains( "999-999-9999" ) );
+							context.assertTrue( found.getPhones().contains( "123-456-7890" ) );
+							context.assertTrue( found.getPhones().contains( "111-111-1111" ) );						} )
+		);
+	}
+
+	/*
+	 * remove the first phone element value
+	 */
+	@Test
+	public void removeFirstPhoneElement(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenCompose( foundPerson -> {
+							foundPerson.getPhones().remove(0);
+							return session.flush();
+						} )
+						.thenCompose( v -> openSession()
+								.find( Person.class, thePerson.getId() )
+								.thenAccept( changedPerson -> {
+									context.assertEquals( 2, changedPerson.getPhones().size() );
+								} )
+						)
+		);
+	}
+
+	/*
+	 * clear the phone list and verify the new size() == 0
+	 */
+	@Test
+	public void clearPhoneElements(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.thenCompose( foundPerson -> {
+							foundPerson.getPhones().clear();
+							return session.flush();
+						} )
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId() )
+						.thenAccept( changedPerson -> {
+							context.assertEquals( 0, changedPerson.getPhones().size() );
+						} )
+				)
+		);
+	}
+
+	/*
+	 * perform a set(index) with a new phone number on the phones list and check expected value
+	 */
+	@Test
+	public void replaceSecondPhoneElement(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenCompose( foundPerson -> {
+										 context.assertNotNull( foundPerson );
+										 context.assertEquals( 3, foundPerson.getPhones().size() );
+										 foundPerson.getPhones().set( 1, "000-000-0000" );
+										 return session.flush();
+									 }
+						)
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( changedPerson -> {
+							context.assertNotNull( changedPerson );
+							context.assertEquals( 3, changedPerson.getPhones().size() );
+							// Can't assume order so need to check all values in the list
+							context.assertTrue( changedPerson.getPhones().contains( "999-999-9999" ) );
+							context.assertTrue( changedPerson.getPhones().contains( "123-456-7890" ) );
+							context.assertTrue( changedPerson.getPhones().contains( "000-000-0000" ) );
+						} )
+		);
+	}
+
+	/*
+	 * Overwrite the phone list with a new String list with 1 value
+	 */
+	@Test
+	public void setNewElementCollection(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenCompose( foundPerson -> {
+										 context.assertNotNull( foundPerson );
+										 context.assertEquals( 3, foundPerson.getPhones().size() );
+										 List<String> nums = new ArrayList();
+										 nums.add("000 000 0000");
+										 foundPerson.setPhones( nums );
+										 return session.flush();
+									 }
+						)
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( changedPerson -> {
+							context.assertNotNull( changedPerson );
+							context.assertEquals( 1, changedPerson.getPhones().size() );
+							context.assertEquals( "000 000 0000",  changedPerson.getPhones().get(0));
+						} )
+		);
+	}
+
+	/*
+	 * Removes the Person entity and checks if NULL afterwards
+	 */
+	@Test
+	public void removePerson(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenCompose( foundPerson -> session.remove( foundPerson ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( nullPerson ->  context.assertNull( nullPerson ) )
+						// add native query to check if Person_phones == NULL
+						.thenCompose( v -> openSession().createNativeQuery("SELECT * FROM Person_phones where Person_id = " + thePerson.getId()).getResultList())
+						.thenAccept( resultList ->  context.assertTrue(  resultList.isEmpty())
+						)
+		);
+	}
+
+	@Test
+	public void addAndVerifySecondPerson(TestContext context) {
+		String[] phoneArray = new String[]{ "222-222-2222", "333-333-3333" };
+		Person secondPerson = new Person( 9910000, "Kitty", phoneArray);
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId())
+					  .thenAccept( foundPerson -> {
+						  context.assertNotNull( foundPerson );
+						  context.assertEquals( 2, foundPerson.getPhones().size() );
+					  } )
+					  .thenCompose( s -> openSession().createNativeQuery("SELECT * FROM Person_phones where Person_id = " + secondPerson.getId()).getResultList())
+					  .thenAccept( resultList ->  context.assertEquals( 2, resultList.size()) )
+					  .thenCompose( s -> openSession().createNativeQuery("SELECT * FROM Person_phones where Person_id = " + thePerson.getId()).getResultList())
+					  .thenAccept( resultList ->  context.assertEquals( 3, resultList.size()) )
+				)
+
+		);
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+		@Id
+		private Integer id;
+		private String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		private List<String> phones = new ArrayList<>();
+
+		/*
+		 TODO: We also need to check that all the tests pass with the @OrderColumn annotation
+				@ElementCollection(fetch = FetchType.EAGER)
+				@OrderColumn(name = "phone_order")
+				private List<String> workNumbers = new ArrayList<>();
+
+				I don't know if it's better to keep it in this class or a separate one. Your choice.
+		*/
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, String[] phones) {
+			this.id = id;
+			this.name = name;
+			if( phones != null ) {
+				this.phones.addAll( Arrays.asList( phones ) );
+			}
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setPhones(List<String> phones) {
+			this.phones = phones;
+		}
+
+		public List<String> getPhones() {
+			return phones;
+		}
+	}
+
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerEmbeddedElementCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerEmbeddedElementCollectionTest.java
@@ -1,0 +1,138 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.persistence.Column;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
+
+public class EagerEmbeddedElementCollectionTest  extends BaseReactiveTest {
+
+	private Person thePerson;
+
+	@Rule
+	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Person.class );
+
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		Phone[] phoneArray = new Phone[]{ new Phone("999-999-9999"), new Phone("111-111-1111")};
+		thePerson = new Person( 777777, "Claude", phoneArray);
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( thePerson )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+		);
+	}
+
+	/*
+	 * This test performs a simple check of Person entity collection values after persisting
+	 */
+	@Test
+	public void findPhonesElementCollectionStageSession(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( found -> {
+							context.assertNotNull( found );
+							context.assertEquals( 2, found.getPhones().size() );
+						} )
+		);
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@ElementCollection
+		private List<Phone> phones = new ArrayList<>();
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, Phone[] phones) {
+			this.id = id;
+			this.name = name;
+			if( phones != null ) {
+				this.phones.addAll( Arrays.asList( phones ) );
+			}
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public List<Phone> getPhones() {
+			return phones;
+		}
+	}
+
+	@Embeddable
+	public static class Phone {
+
+		@Column(name = "`number`")
+		private String number;
+
+		public Phone() {
+		}
+
+		public Phone(String number) {
+			this.number = number;
+		}
+
+		public String getNumber() {
+			return number;
+		}
+
+		public void setNumber(String number) {
+			this.number = number;
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerParentChildTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerParentChildTest.java
@@ -1,0 +1,135 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.HashSet;
+import java.util.Set;
+import javax.persistence.ElementCollection;
+//import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.provider.Settings;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
+
+public class EagerParentChildTest extends BaseReactiveTest {
+
+	private Parent theParent;
+
+	@Rule
+	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Parent.class );
+		configuration.addAnnotatedClass( Child.class );
+		configuration.setProperty( Settings.SHOW_SQL, System.getProperty( Settings.SHOW_SQL, "true") );
+		configuration.setProperty( Settings.FORMAT_SQL, System.getProperty(Settings.FORMAT_SQL, "true") );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb( TestContext context) {
+
+		theParent = new Parent( 1111111, "Mary");
+		Set<Child> children = new HashSet<>();
+		children.add(new Child( "Sarah")); //, theParent));
+		children.add(new Child( "Jorge")); //, theParent));
+		theParent.setChildren( children );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( theParent )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Parent.class, theParent.getId()) )
+		);
+	}
+
+	/*
+	 * This test performs a simple check of Person entity collection values after persisting
+	 */
+	@Test
+	public void findParentStageSession(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Parent.class, theParent.getId())
+						.thenAccept( found -> {
+							context.assertNotNull( found );
+							context.assertEquals( 2, found.getChildren().size() );
+						} )
+		);
+	}
+
+	@Entity(name = "Parent")
+	public static class Parent
+	{
+		/** */
+		@Id
+		public Integer id;
+
+		public String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		public Set<Child> children;
+
+		public Parent() { }
+
+		/** */
+		public Parent(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		/** */
+		public Integer getId() { return this.id; }
+		public void setId(Integer value) { this.id = value; }
+
+		/** */
+		public String getName() { return this.name; }
+		public void setName(String value) { this.name = value; }
+
+		/** */
+		public Set<Child> getChildren() { return this.children; }
+		public void setChildren(Set<Child> value) { this.children = value; }
+	}
+
+	@Entity(name="Child")
+	public static class Child {
+		/** */
+		@Id
+		@GeneratedValue
+		public Long id;
+
+		public String name;
+
+		public Child() {};
+
+		public Child(String name) {
+			this.name = name;
+		}
+
+		/** */
+		public String getName() { return this.name; }
+		public void setName(String value) { this.name = value; }
+
+	}
+
+}


### PR DESCRIPTION
This is a cleaned up version of changes required to support ElementCollection's in reactive.

The initial commit set supports List<String> values.  The included EagerElementCollectionTest tests find collection, remove element, replace element, replace collection and remove Entity containing the collection to test cascade remove of the collection's generated table entity.

Additional work to complete ElementCollection support includes:
- Changes and tests for other collection types Map, Set, etc...
- Support for @Embedded entity collections

Also found issues trying to do edits for the OneToMany use-case... so I updated the test for follow-on discussion.