### PR TITLE
[#507] Rewrite loops methods to improve performance

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
@@ -67,7 +67,7 @@ public interface ReactiveResultSetProcessor {
 		);
 
 		final Object[] hydratedState = entityEntry.getLoadedState();
-		return CompletionStages.loop(
+		return CompletionStages.loopWithoutTrampoline(
 				IntStream.range( 0, hydratedState.length )
 						.filter( i-> hydratedState[ i ] instanceof CompletionStage ),
 				i -> ( (CompletionStage<Object>) hydratedState[ i ] )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -46,6 +46,10 @@ public class CompletionStages {
 	private static final CompletionStage<Boolean> TRUE = completedFuture( true );
 	private static final CompletionStage<Boolean> FALSE = completedFuture( false );
 
+	public static CompletionStage<Void> voidFuture(Object ignore) {
+		return voidFuture();
+	}
+
 	public static CompletionStage<Void> voidFuture() {
 		return VOID;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -219,4 +219,17 @@ public class CompletionStages {
 			default: return CompletionStages.loop( entity, op );
 		}
 	}
+
+	public static CompletionStage<Void> loopWithoutTrampoline(IntStream stream, Function<Integer,CompletionStage<?>> consumer) {
+		return loopWithoutTrampoline( stream.iterator(), consumer );
+	}
+
+	public static <T> CompletionStage<Void> loopWithoutTrampoline(Iterator<T> iterator, Function<T, CompletionStage<?>> consumer) {
+		CompletionStage<?> loopStage = voidFuture();
+		while ( iterator.hasNext() ) {
+			final T next = iterator.next();
+			loopStage = loopStage.thenCompose( v -> consumer.apply( next ) );
+		}
+		return loopStage.thenCompose( CompletionStages::voidFuture );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -220,10 +220,16 @@ public class CompletionStages {
 		}
 	}
 
+	/**
+	 * Same as {@link #loop(Stream, Function)} but doesn't use the trampoline pattern
+	 */
 	public static CompletionStage<Void> loopWithoutTrampoline(IntStream stream, Function<Integer,CompletionStage<?>> consumer) {
 		return loopWithoutTrampoline( stream.iterator(), consumer );
 	}
 
+	/**
+	 * Same as {@link #loop(Iterator, Function)} but doesn't use the trampoline pattern
+	 */
 	public static <T> CompletionStage<Void> loopWithoutTrampoline(Iterator<T> iterator, Function<T, CompletionStage<?>> consumer) {
 		CompletionStage<?> loopStage = voidFuture();
 		while ( iterator.hasNext() ) {


### PR DESCRIPTION
Resolves #507

I rewrote the methods we use for loops so that we don't need the dependency to asyncUtil.
I assumed it was responsible for the creation of the object causing the issue.

I'm not sure if there is more we can do considering that we will have to loop through the objects one way or the other.