### PR TITLE
don't throw exception when id is Short

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/IdentifierGeneration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/IdentifierGeneration.java
@@ -148,6 +148,9 @@ public class IdentifierGeneration {
 				else if ( identifierType == IntegerType.INSTANCE ) {
 					return longId.intValue();
 				}
+				else if ( identifierType == ShortType.INSTANCE ) {
+					return longId.shortValue();
+				}
 				else {
 					throw new HibernateException(
 							"cannot generate identifiers of type "


### PR DESCRIPTION
Hi, this patch fix the problem when id is Short the generation of id throws exception as `org.hibernate.HibernateException: cannot generate identifiers of type Short`.