### PR TITLE
don't throw exception when id is Short

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/IdentifierGeneration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/IdentifierGeneration.java
@@ -25,6 +25,7 @@ import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.type.IntegerType;
 import org.hibernate.type.LongType;
+import org.hibernate.type.ShortType;
 import org.hibernate.type.Type;
 
 import java.io.Serializable;
@@ -147,6 +148,9 @@ public class IdentifierGeneration {
 				}
 				else if ( identifierType == IntegerType.INSTANCE ) {
 					return longId.intValue();
+				}
+				else if ( identifierType == ShortType.INSTANCE ) {
+					return longId.shortValue();
 				}
 				else {
 					throw new HibernateException(


### PR DESCRIPTION
Hi, this patch fix the problem when id is Short the generation of id throws exception as org.hibernate.HibernateException: cannot generate identifiers of type Short.

The other same titled pull request   #523   was forgot to import ShortType since I was modifying the code directly on GitHub UI as my local fork was still pulling down dependencies, don't know how to change the pull request there instead of this one, so I recreate this.