### PR TITLE
[#44] Add support for @ElementCollection

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
@@ -105,45 +105,45 @@ public class ReactiveActionQueue {
 //					}
 //				}
 //		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionRemoveAction.class,
-//				new ListProvider<CollectionRemoveAction>() {
-//					ExecutableList<CollectionRemoveAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionRemovals;
-//					}
-//					ExecutableList<CollectionRemoveAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionRemovals = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionUpdateAction.class,
-//				new ListProvider<CollectionUpdateAction>() {
-//					ExecutableList<CollectionUpdateAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionUpdates;
-//					}
-//					ExecutableList<CollectionUpdateAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionUpdates = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
-//		EXECUTABLE_LISTS_MAP.put(
-//				CollectionRecreateAction.class,
-//				new ListProvider<CollectionRecreateAction>() {
-//					ExecutableList<CollectionRecreateAction> get(ReactiveActionQueue instance) {
-//						return instance.collectionCreations;
-//					}
-//					ExecutableList<CollectionRecreateAction> init(ReactiveActionQueue instance) {
-//						return instance.collectionCreations = new ExecutableList<>(
-//								instance.isOrderUpdatesEnabled()
-//						);
-//					}
-//				}
-//		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionRemoveAction.class,
+				new ListProvider<ReactiveCollectionRemoveAction>() {
+					ExecutableList<ReactiveCollectionRemoveAction> get(ReactiveActionQueue instance) {
+						return instance.collectionRemovals;
+					}
+					ExecutableList<ReactiveCollectionRemoveAction> init(ReactiveActionQueue instance) {
+						return instance.collectionRemovals = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionUpdateAction.class,
+				new ListProvider<ReactiveCollectionUpdateAction>() {
+					ExecutableList<ReactiveCollectionUpdateAction> get(ReactiveActionQueue instance) {
+						return instance.collectionUpdates;
+					}
+					ExecutableList<ReactiveCollectionUpdateAction> init(ReactiveActionQueue instance) {
+						return instance.collectionUpdates = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
+		EXECUTABLE_LISTS_MAP.put(
+				ReactiveCollectionRecreateAction.class,
+				new ListProvider<ReactiveCollectionRecreateAction>() {
+					ExecutableList<ReactiveCollectionRecreateAction> get(ReactiveActionQueue instance) {
+						return instance.collectionCreations;
+					}
+					ExecutableList<ReactiveCollectionRecreateAction> init(ReactiveActionQueue instance) {
+						return instance.collectionCreations = new ExecutableList<>(
+								instance.isOrderUpdatesEnabled()
+						);
+					}
+				}
+		);
 		EXECUTABLE_LISTS_MAP.put(
 				ReactiveEntityDeleteAction.class,
 				new ListProvider<ReactiveEntityDeleteAction>() {
@@ -174,10 +174,10 @@ public class ReactiveActionQueue {
 	// Note that, unlike objects, collection insertions, updates,
 	// deletions are not really remembered between flushes. We
 	// just re-use the same Lists for convenience.
-	private ExecutableList<CollectionRecreateAction> collectionCreations;
-	private ExecutableList<CollectionUpdateAction> collectionUpdates;
+	private ExecutableList<ReactiveCollectionRecreateAction> collectionCreations;
+	private ExecutableList<ReactiveCollectionUpdateAction> collectionUpdates;
 	private ExecutableList<QueuedOperationCollectionAction> collectionQueuedOps;
-	private ExecutableList<CollectionRemoveAction> collectionRemovals;
+	private ExecutableList<ReactiveCollectionRemoveAction> collectionRemovals;
 	// TODO: The removeOrphan concept is a temporary "hack" for HHH-6484.  This should be removed once action/task
 	// ordering is improved.
 	private ExecutableList<OrphanRemovalAction> orphanRemovals;
@@ -416,9 +416,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the (re)creation of a collection
 	 */
-	public void addAction(CollectionRecreateAction action) {
-//		addAction( CollectionRecreateAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionRecreateAction action) {
+		addAction( ReactiveCollectionRecreateAction.class, action );
 	}
 
 	/**
@@ -426,9 +425,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the removal of a collection
 	 */
-	public void addAction(CollectionRemoveAction action) {
-//		addAction( CollectionRemoveAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionRemoveAction action) {
+		addAction( ReactiveCollectionRemoveAction.class, action );
 	}
 
 	/**
@@ -436,9 +434,8 @@ public class ReactiveActionQueue {
 	 *
 	 * @param action The action representing the update of a collection
 	 */
-	public void addAction(CollectionUpdateAction action) {
-//		addAction( CollectionUpdateAction.class, action );
-		throw new UnsupportedOperationException();
+	public void addAction(ReactiveCollectionUpdateAction action) {
+		addAction( ReactiveCollectionUpdateAction.class, action );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
@@ -1,0 +1,79 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+
+public class ReactiveCollectionRecreateAction extends CollectionAction implements ReactiveExecutable {
+
+	public ReactiveCollectionRecreateAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final ReactiveCollectionPersister persister = (ReactiveCollectionPersister)getPersister();
+		final SharedSessionContractImplementor session = getSession();
+		final Serializable key = getKey();
+
+		final PersistentCollection collection = getCollection();
+
+		preRecreate();
+
+		return persister.recreateReactive( collection, key, session ).thenAccept( v -> {
+			session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+			evict();
+			postRecreate();
+		} );
+	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
@@ -1,0 +1,158 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionRemoveEvent;
+import org.hibernate.event.spi.PostCollectionRemoveEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRemoveEvent;
+import org.hibernate.event.spi.PreCollectionRemoveEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+public class ReactiveCollectionRemoveAction extends CollectionAction implements ReactiveExecutable {
+	private final Object affectedOwner;
+	private final boolean emptySnapshot;
+
+	public ReactiveCollectionRemoveAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final boolean emptySnapshot,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+		if ( collection == null ) {
+			throw new AssertionFailure( "collection == null");
+		}
+		this.emptySnapshot = emptySnapshot;
+		// the loaded owner will be set to null after the collection is removed,
+		// so capture its value as the affected owner so it is accessible to
+		// both pre- and post- events
+		this.affectedOwner = session.getPersistenceContextInternal().getLoadedCollectionOwnerOrNull( collection );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final Serializable key = getKey();
+		final SharedSessionContractImplementor session = getSession();
+		final ReactiveCollectionPersister reactivePersister = (ReactiveCollectionPersister) getPersister();
+		final CollectionPersister corePersister = getPersister();
+		final PersistentCollection collection = getCollection();
+		final StatisticsImplementor statistics = session.getFactory().getStatistics();
+
+		CompletionStage<Void> removeStage = CompletionStages.voidFuture();
+
+		if ( !emptySnapshot ) {
+			// an existing collection that was either non-empty or uninitialized
+			// is replaced by null or a different collection
+			// (if the collection is uninitialized, hibernate has no way of
+			// knowing if the collection is actually empty without querying the db)
+			removeStage = removeStage.thenAccept( v -> preRemove() )
+					.thenCompose( v -> reactivePersister
+							.removeReactive( key, session )
+							.thenAccept( ignore -> {
+								evict();
+								postRemove();
+							})
+					);
+		}
+		if( collection != null ) {
+			return removeStage.thenAccept(v -> {
+				session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+				evict();
+				postRemove();
+				if ( statistics.isStatisticsEnabled() ) {
+					statistics.updateCollection( corePersister.getRole() );
+				}
+			} );
+		}
+		return removeStage.thenAccept(v -> {
+			evict();
+			postRemove();
+			if ( statistics.isStatisticsEnabled() ) {
+				statistics.updateCollection( corePersister.getRole() );
+			}
+		} );
+
+	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preRemove() {
+		final EventListenerGroup<PreCollectionRemoveEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_REMOVE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRemoveEvent event = new PreCollectionRemoveEvent(
+				getPersister(),
+				getCollection(),
+				eventSource(),
+				affectedOwner
+		);
+		for ( PreCollectionRemoveEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRemoveCollection( event );
+		}
+	}
+
+	private void postRemove() {
+		final EventListenerGroup<PostCollectionRemoveEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_REMOVE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRemoveEvent event = new PostCollectionRemoveEvent(
+				getPersister(),
+				getCollection(),
+				eventSource(),
+				affectedOwner
+		);
+		for ( PostCollectionRemoveEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRemoveCollection( event );
+		}
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
@@ -1,0 +1,186 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.action.internal.CollectionAction;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.PostCollectionRecreateEvent;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionUpdateEvent;
+import org.hibernate.event.spi.PostCollectionUpdateEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEvent;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionUpdateEvent;
+import org.hibernate.event.spi.PreCollectionUpdateEventListener;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.pretty.MessageHelper;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
+import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.stat.spi.StatisticsImplementor;
+
+
+/**
+ * Like {@link org.hibernate.action.internal.CollectionUpdateAction} but reactive
+ *
+ * @see org.hibernate.action.internal.CollectionUpdateAction
+ */
+public class ReactiveCollectionUpdateAction extends CollectionAction implements ReactiveExecutable {
+	private final boolean emptySnapshot;
+
+	public ReactiveCollectionUpdateAction(
+			final PersistentCollection collection,
+			final CollectionPersister persister,
+			final Serializable key,
+			final boolean emptySnapshot,
+			final SharedSessionContractImplementor session) {
+		super( persister, collection, key, session );
+		this.emptySnapshot = emptySnapshot;
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		final Serializable key = getKey();
+		final SharedSessionContractImplementor session = getSession();
+		final ReactiveCollectionPersister reactivePersister = (ReactiveCollectionPersister) getPersister();
+		final CollectionPersister corePersister = getPersister();
+		final PersistentCollection collection = getCollection();
+		final boolean affectedByFilters = corePersister.isAffectedByEnabledFilters( session );
+
+		preUpdate();
+
+		CompletionStage<Void> updateStage = CompletionStages.voidFuture();
+
+		// And then make sure that each operations is executed in its own stage maintaining the same order as in ORM
+		if ( !collection.wasInitialized() ) {
+			// If there were queued operations, they would have been processed
+			// and cleared by now.
+			// The collection should still be dirty.
+			if ( !collection.isDirty() ) {
+				throw new AssertionFailure( "collection is not dirty" );
+			}
+			//do nothing - we only need to notify the cache...
+		}
+		else if ( !affectedByFilters && collection.empty() ) {
+			if ( !emptySnapshot ) {
+				updateStage = updateStage
+						.thenCompose( v -> reactivePersister.removeReactive( key, session ) )
+						.thenAccept( count -> { /* We don't care, maybe we can log it as debug */} );
+			}
+		}
+		else if ( collection.needsRecreate( corePersister ) ) {
+			if ( affectedByFilters ) {
+				throw new HibernateException(
+						"cannot recreate collection while filter is enabled: " +
+								MessageHelper.collectionInfoString( corePersister, collection, key, session )
+				);
+			}
+			if ( !emptySnapshot ) {
+				updateStage = updateStage
+						.thenCompose( v -> reactivePersister.removeReactive( key, session ) )
+						.thenAccept( count -> { /* We don't care, maybe we can log it as debug */} );
+			}
+
+			return updateStage
+					.thenCompose( v -> reactivePersister
+							.recreateReactive( collection, key, session )
+							.thenAccept( ignore -> {
+								session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+								evict();
+								postUpdate();
+								final StatisticsImplementor statistics = session.getFactory().getStatistics();
+								if ( statistics.isStatisticsEnabled() ) {
+									statistics.updateCollection( corePersister.getRole() );
+								}
+							})
+					);
+		}
+		else {
+			updateStage = updateStage
+					.thenCompose( v -> reactivePersister.reactiveDeleteRows( collection, key, session ) )
+					.thenCompose( v -> reactivePersister.reactiveUpdateRows( collection, key, session ) )
+					.thenCompose( v -> reactivePersister.reactiveInsertRows( collection, key, session ) )
+					.thenAccept( ignore -> {} );
+		}
+
+		return updateStage.thenAccept(v -> {
+			session.getPersistenceContextInternal().getCollectionEntry( collection ).afterAction( collection );
+			evict();
+			postUpdate();
+
+			final StatisticsImplementor statistics = session.getFactory().getStatistics();
+			if ( statistics.isStatisticsEnabled() ) {
+				statistics.updateCollection( corePersister.getRole() );
+			}
+		} );
+	}
+
+	@Override
+	public void execute() throws HibernateException {
+		// Unsupported in reactive see reactiveExecute()
+		throw new UnsupportedOperationException( "Use reactiveExecute() instead" );
+	}
+
+	private void preUpdate() {
+		final EventListenerGroup<PreCollectionUpdateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_UPDATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionUpdateEvent event = new PreCollectionUpdateEvent(
+				getPersister(),
+				getCollection(),
+				eventSource()
+		);
+		for ( PreCollectionUpdateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreUpdateCollection( event );
+		}
+	}
+
+	private void postUpdate() {
+		final EventListenerGroup<PostCollectionUpdateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_UPDATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionUpdateEvent event = new PostCollectionUpdateEvent(
+				getPersister(),
+				getCollection(),
+				eventSource()
+		);
+		for ( PostCollectionUpdateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostUpdateCollection( event );
+		}
+	}
+
+	private void preRecreate() {
+		final EventListenerGroup<PreCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.PRE_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PreCollectionRecreateEvent event = new PreCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PreCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPreRecreateCollection( event );
+		}
+	}
+
+	private void postRecreate() {
+		final EventListenerGroup<PostCollectionRecreateEventListener> listenerGroup = listenerGroup( EventType.POST_COLLECTION_RECREATE );
+		if ( listenerGroup.isEmpty() ) {
+			return;
+		}
+		final PostCollectionRecreateEvent event = new PostCollectionRecreateEvent( getPersister(), getCollection(), eventSource() );
+		for ( PostCollectionRecreateEventListener listener : listenerGroup.listeners() ) {
+			listener.onPostRecreateCollection( event );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBasicCollectionLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBasicCollectionLoader.java
@@ -1,0 +1,68 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.loader.collection.impl;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.loader.collection.OneToManyJoinWalker;
+import org.hibernate.persister.collection.QueryableCollection;
+import org.hibernate.transform.ResultTransformer;
+
+public class ReactiveBasicCollectionLoader extends ReactiveCollectionLoader {
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) {
+		super( collectionPersister, factory, loadQueryInfluencers );
+	}
+
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			int batchSize,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		this(collectionPersister, batchSize, null, factory, loadQueryInfluencers);
+	}
+
+	public ReactiveBasicCollectionLoader(
+			QueryableCollection collectionPersister,
+			int batchSize,
+			String subquery,
+			SessionFactoryImplementor factory,
+			LoadQueryInfluencers loadQueryInfluencers) throws MappingException {
+		super(collectionPersister, factory, loadQueryInfluencers);
+
+		initFromWalker( new OneToManyJoinWalker(
+				collectionPersister,
+				batchSize,
+				subquery,
+				factory,
+				loadQueryInfluencers
+		) );
+
+		postInstantiate();
+		if (LOG.isDebugEnabled()) {
+			LOG.debugf("Static select for one-to-many %s: %s", collectionPersister.getRole(), getSQLString());
+		}
+	}
+
+	@Override
+	protected Object getResultColumnOrRow(
+			Object[] row,
+			ResultTransformer transformer,
+			ResultSet rs, SharedSessionContractImplementor session) throws SQLException, HibernateException {
+		if ( row.length == 1 ) {
+			return row[0];
+		}
+		return row;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBatchingCollectionInitializerBuilder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveBatchingCollectionInitializerBuilder.java
@@ -24,7 +24,7 @@ import org.hibernate.reactive.loader.collection.ReactiveCollectionInitializer;
 public abstract class ReactiveBatchingCollectionInitializerBuilder {
 
 	public static ReactiveBatchingCollectionInitializerBuilder getBuilder(SessionFactoryImplementor factory) {
-		switch ( factory.getSettings().getBatchFetchStyle() ) {
+		switch ( factory.getSessionFactoryOptions().getBatchFetchStyle() ) {
 			case PADDED: {
 				return ReactivePaddedBatchingCollectionInitializerBuilder.INSTANCE;
 			}
@@ -106,7 +106,6 @@ public abstract class ReactiveBatchingCollectionInitializerBuilder {
 		if (persister.isOneToMany()) {
 			return new ReactiveOneToManyLoader(persister, factory, influencers);
 		}
-		throw new UnsupportedOperationException();
-//		return new ReactiveBasicCollectionLoader(persister, factory, influencers);
+		return new ReactiveBasicCollectionLoader(persister, factory, influencers);
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -1,0 +1,271 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.collection.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.hibernate.HibernateException;
+import org.hibernate.MappingException;
+import org.hibernate.cache.CacheException;
+import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.mapping.Collection;
+import org.hibernate.persister.collection.BasicCollectionPersister;
+import org.hibernate.persister.spi.PersisterCreationContext;
+import org.hibernate.pretty.MessageHelper;
+import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.pool.impl.Parameters;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
+import org.hibernate.reactive.util.impl.CompletionStages;
+
+import org.jboss.logging.Logger;
+
+/**
+ *
+ *     -- >> see  AbstractCollectionPersister for ORM implementations
+ * 				// TODO: Check out batching logic: See AbstractCollectionPersister for usage
+ * 				// boolean useBatch = expectation.canBeBatched();
+ */
+public class ReactiveBasicCollectionPersister extends BasicCollectionPersister implements ReactiveCollectionPersister {
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger(
+			CoreMessageLogger.class,
+			ReactiveBasicCollectionPersister.class.getName()
+	);
+	private final Parameters parameters;
+
+	public ReactiveBasicCollectionPersister(
+			Collection collectionBinding,
+			CollectionDataAccess cacheAccessStrategy,
+			PersisterCreationContext creationContext) throws MappingException, CacheException {
+		super( collectionBinding, cacheAccessStrategy, creationContext );
+		this.parameters = Parameters.instance( getFactory().getJdbcServices().getDialect() );
+	}
+
+	private ReactiveConnection getReactiveConnection(SharedSessionContractImplementor session) {
+		return ( (ReactiveConnectionSupplier) session ).getReactiveConnection();
+	}
+
+	@Override
+	protected String getSQLInsertRowString() {
+		String sql = super.getSQLInsertRowString();
+		return parameters.process( sql );
+	}
+
+	@Override
+	protected String getSQLDeleteRowString() {
+		String sql = super.getSQLDeleteRowString();
+		return parameters.process( sql );
+	}
+
+	@Override
+	protected String getSQLDeleteString() {
+		String sql = super.getSQLDeleteString();
+		return parameters.process( sql );
+	}
+
+	@Override
+	protected String getSQLUpdateRowString() {
+		String sql = super.getSQLUpdateRowString();
+		return parameters.process( sql );
+	}
+
+	/**
+	 * @see org.hibernate.persister.collection.AbstractCollectionPersister#recreate(PersistentCollection, Serializable, SharedSessionContractImplementor)
+	 */
+	public CompletionStage<Void> recreateReactive(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session)
+			throws HibernateException {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowInsertEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debugf(
+					"Inserting collection: %s",
+					MessageHelper.collectionInfoString( this, collection, id, session )
+			);
+		}
+
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+
+		collection.preInsert( this );
+
+		final AtomicInteger index = new AtomicInteger( 1 );
+		return CompletionStages.total(
+				collection.entries( this ),
+				entry -> {
+					CompletionStage<Integer> st = reactiveConnection.update(
+							getSQLInsertRowString(),
+							insertRowsParamValues( entry, index, collection, id, session ) );
+					collection.afterRowInsert( this, entry, index.getAndIncrement() );
+					return st;
+				}
+		)
+				.thenAccept( total -> LOG.debugf( "Done inserting rows: %s inserted", total ) );
+	}
+
+	/**
+	 * @see org.hibernate.persister.collection.AbstractCollectionPersister#remove(Serializable, SharedSessionContractImplementor)
+	 */
+	public CompletionStage<Void> removeReactive(Serializable id, SharedSessionContractImplementor session)
+			throws HibernateException {
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+		if ( !isInverse && isRowDeleteEnabled() ) {
+			if ( LOG.isDebugEnabled() ) {
+				LOG.debugf(
+						"Deleting collection: %s",
+						MessageHelper.collectionInfoString( this, id, getFactory() )
+				);
+			}
+
+			Object[] params = { id };
+			return reactiveConnection.update( getSQLDeleteString(), params )
+					.thenCompose( CompletionStages::voidFuture );
+		}
+		return CompletionStages.voidFuture();
+	}
+
+	/**
+	 * @see org.hibernate.persister.collection.AbstractCollectionPersister#deleteRows(PersistentCollection, Serializable, SharedSessionContractImplementor)
+	 */
+	@Override
+	public CompletionStage<Void> reactiveDeleteRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		CompletionStage<Integer> loop = CompletionStages.zeroFuture();
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+
+		boolean deleteByIndex = !isOneToMany() && hasIndex && !indexContainsFormula;
+
+		final AtomicInteger offset = new AtomicInteger( 1 );
+		return CompletionStages
+				.total( collection.getDeletes( this, !deleteByIndex ), entry ->
+						reactiveConnection.update(
+								getSQLDeleteRowString(),
+								deleteRowsParamValues( entry, offset, id, session, deleteByIndex )
+						) )
+				.thenAccept( total -> LOG.debugf( "Done removing rows: %s removed", total ) );
+	}
+
+	/**
+	 * @see org.hibernate.persister.collection.AbstractCollectionPersister#updateRows(PersistentCollection, Serializable, SharedSessionContractImplementor)
+	 */
+	@Override
+	public CompletionStage<Void> reactiveUpdateRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+
+		if ( !isInverse && collection.isRowUpdatePossible() ) {
+			// TODO:  convert AbstractCollectionPersister.doUpdateRows() to reactive logic
+			// update all the modified entries
+			// NOTE this method call uses a JDBC connection and will fail for Map ElementCollection type
+			// Generally bags and sets are the only collections that cannot be mapped to a single row in the database
+			// So Maps, for instance will return isRowUpdatePossible() == TRUE
+
+			throw new UnsupportedOperationException();
+		}
+		return CompletionStages.voidFuture();
+	}
+
+	/**
+	 * @see org.hibernate.persister.collection.AbstractCollectionPersister#insertRows(PersistentCollection, Serializable, SharedSessionContractImplementor)
+	 */
+	@Override
+	public CompletionStage<Void> reactiveInsertRows(
+			PersistentCollection collection,
+			Serializable id,
+			SharedSessionContractImplementor session) throws HibernateException {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( LOG.isDebugEnabled() ) {
+			LOG.debugf(
+					"Inserting rows of collection: %s",
+					MessageHelper.collectionInfoString( this, collection, id, session )
+			);
+		}
+
+		collection.preInsert( this );
+
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+
+		final AtomicInteger index = new AtomicInteger( 0 );
+		return CompletionStages.total(
+				collection.entries( this ),
+				entry -> {
+					CompletionStage<Integer> st = reactiveConnection.update(
+							getSQLInsertRowString(),
+							insertRowsParamValues( entry, index, collection, id, session ) );
+					collection.afterRowInsert( this, entry, index.getAndIncrement() );
+					return st;
+				}
+		).thenAccept( total -> LOG.debugf( "Done inserting rows: %s inserted", total ) );
+	}
+
+	private Object[] insertRowsParamValues(Object entry, AtomicInteger index, PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		int offset = 1;
+ 		return PreparedStatementAdaptor.bind(
+				st -> {
+					int loc = writeKey( st, id, offset , session );
+
+					if ( hasIdentifier ) {
+						loc = writeIdentifier( st, collection.getIdentifier( entry, index.get() ), loc, session );
+					}
+					if ( hasIndex /* && !indexIsFormula */) {
+						loc = writeIndex( st, collection.getIndex( entry, index.get() , this ), loc, session );
+					}
+					writeElement( st, collection.getElement( entry ), loc, session );
+				}
+		);
+	}
+
+	private Object[] deleteRowsParamValues(Object entry, AtomicInteger offset, Serializable id, SharedSessionContractImplementor session, boolean deleteByIndex) {
+		return PreparedStatementAdaptor.bind(
+				st -> {
+					int loc = offset.get();
+					if ( hasIdentifier ) {
+						writeIdentifier( st, entry, loc, session );
+					}
+					else {
+						loc = writeKey( st, id, loc, session );
+						if ( deleteByIndex ) {
+							writeIndexToWhere( st, entry, loc, session );
+						}
+						else {
+							writeElementToWhere( st, entry, loc, session );
+						}
+					}
+				}
+		);
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
@@ -1,0 +1,47 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.collection.impl;
+
+import java.io.Serializable;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.collection.AbstractCollectionPersister;
+
+/**
+ * Similar to {@link AbstractCollectionPersister} in ORM
+ * <p>
+ *     The reactive classes already extend something so we cannot have an abstract class like in ORM.
+ * </p>
+ */
+public interface ReactiveCollectionPersister {
+
+	/**
+	 * Reactive version of {@link AbstractCollectionPersister#recreate(PersistentCollection, Serializable , SharedSessionContractImplementor)}
+	 */
+	CompletionStage<Void> recreateReactive(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link AbstractCollectionPersister#remove(Serializable , SharedSessionContractImplementor)}
+	 */
+	CompletionStage<Void> removeReactive(Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link AbstractCollectionPersister#deleteRows(PersistentCollection, Serializable , SharedSessionContractImplementor)}
+	 */
+	CompletionStage<Void> reactiveDeleteRows(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of {@link AbstractCollectionPersister#insertRows(PersistentCollection, Serializable , SharedSessionContractImplementor)}
+	 */
+	CompletionStage<Void> reactiveInsertRows( PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+
+	/**
+	 * Reactive version of  {@link AbstractCollectionPersister#updateRows(PersistentCollection, Serializable , SharedSessionContractImplementor)}
+	 */
+	CompletionStage<Void> reactiveUpdateRows(PersistentCollection collection, Serializable id, SharedSessionContractImplementor session);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
@@ -6,23 +6,38 @@
 package org.hibernate.reactive.persister.collection.impl;
 
 import java.io.Serializable;
+import java.sql.PreparedStatement;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
 import org.hibernate.cache.CacheException;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.engine.spi.SubselectFetch;
+import org.hibernate.internal.CoreMessageLogger;
+import org.hibernate.jdbc.Expectation;
+import org.hibernate.jdbc.Expectations;
 import org.hibernate.mapping.Collection;
 import org.hibernate.persister.collection.OneToManyPersister;
 import org.hibernate.persister.spi.PersisterCreationContext;
+import org.hibernate.pretty.MessageHelper;
 import org.hibernate.reactive.loader.collection.impl.ReactiveBatchingCollectionInitializerBuilder;
 import org.hibernate.reactive.loader.collection.ReactiveCollectionInitializer;
 import org.hibernate.reactive.loader.collection.impl.ReactiveSubselectOneToManyLoader;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
+import org.hibernate.reactive.util.impl.CompletionStages;
 
-public class ReactiveOneToManyPersister extends OneToManyPersister {
+import org.jboss.logging.Logger;
+
+public class ReactiveOneToManyPersister extends OneToManyPersister implements ReactiveCollectionPersister {
+	private static final CoreMessageLogger LOG = Logger.getMessageLogger( CoreMessageLogger.class, ReactiveOneToManyPersister.class.getName() );
+
 	public ReactiveOneToManyPersister(Collection collectionBinding, CollectionDataAccess cacheAccessStrategy, PersisterCreationContext creationContext) throws MappingException, CacheException {
 		super( collectionBinding, cacheAccessStrategy, creationContext );
 	}
@@ -54,5 +69,86 @@ public class ReactiveOneToManyPersister extends OneToManyPersister {
 
 	protected ReactiveCollectionInitializer getAppropriateInitializer(Serializable key, SharedSessionContractImplementor session) {
 		return (ReactiveCollectionInitializer) super.getAppropriateInitializer(key, session);
+	}
+
+	@Override
+	public CompletionStage<Void> recreateReactive(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		return CompletionStages.voidFuture();
+	}
+
+	private ReactiveConnection getReactiveConnection(SharedSessionContractImplementor session) {
+		return ( (ReactiveConnectionSupplier) session ).getReactiveConnection();
+	}
+
+	@Override
+	public CompletionStage<Void> removeReactive(Serializable id, SharedSessionContractImplementor session)
+			throws HibernateException {
+		ReactiveConnection reactiveConnection = getReactiveConnection( session );
+		if ( !isInverse && isRowDeleteEnabled() ) {
+			if ( LOG.isDebugEnabled() ) {
+				LOG.debugf(
+						"Deleting collection: %s",
+						MessageHelper.collectionInfoString( this, id, getFactory() )
+				);
+			}
+
+			// Remove all the old entries
+
+			int offset = 1;
+			final PreparedStatement st;
+			Expectation expectation = Expectations.appropriateExpectation( getDeleteAllCheckStyle() );
+			boolean callable = isDeleteAllCallable();
+
+			List<Object> params = new ArrayList<>();
+			params.add( id );
+			String sql = getSQLDeleteString();
+
+			return CompletionStages.voidFuture()
+					.thenCompose( s -> reactiveConnection.update( sql, params.toArray( new Object[0] )))
+					.thenCompose(CompletionStages::voidFuture);
+		}
+		return CompletionStages.voidFuture();
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveDeleteRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		//TODO: See AbstractCollectionPersister#deleteRows
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveInsertRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+
+		if ( isInverse ) {
+			return CompletionStages.voidFuture();
+		}
+
+		if ( !isRowDeleteEnabled() ) {
+			return CompletionStages.voidFuture();
+		}
+
+		// TODO: See AbstractCollectionPersister#insertRows
+		throw new UnsupportedOperationException();
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveUpdateRows(
+			PersistentCollection collection, Serializable id, SharedSessionContractImplementor session) {
+		if ( !isInverse && collection.isRowUpdatePossible() ) {
+			// TODO: See AbstractCollectionPersister#updateRows
+			throw new UnsupportedOperationException();
+		}
+		return CompletionStages.voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactivePersisterClassResolver.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactivePersisterClassResolver.java
@@ -10,10 +10,11 @@ import org.hibernate.persister.collection.CollectionPersister;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.persister.internal.StandardPersisterClassResolver;
 import org.hibernate.persister.spi.PersisterClassResolver;
+import org.hibernate.reactive.persister.collection.impl.ReactiveBasicCollectionPersister;
+import org.hibernate.reactive.persister.collection.impl.ReactiveOneToManyPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveJoinedSubclassEntityPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveSingleTableEntityPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveUnionSubclassEntityPersister;
-import org.hibernate.reactive.persister.collection.impl.ReactiveOneToManyPersister;
 
 public class ReactivePersisterClassResolver extends StandardPersisterClassResolver implements PersisterClassResolver {
 
@@ -34,6 +35,14 @@ public class ReactivePersisterClassResolver extends StandardPersisterClassResolv
 
 	@Override
 	public Class<? extends CollectionPersister> getCollectionPersisterClass(Collection metadata) {
+		return metadata.isOneToMany() ? oneToManyPersister() : elementCollectionPersister();
+	}
+
+	private Class<? extends CollectionPersister> oneToManyPersister() {
 		return ReactiveOneToManyPersister.class;
+	}
+
+	private Class<? extends CollectionPersister> elementCollectionPersister() {
+		return ReactiveBasicCollectionPersister.class;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -123,6 +123,21 @@ public class CompletionStages {
 	 * Equivalent to:
 	 * <pre>
 	 * int total = 0;
+	 * while( iterator.hasNext() ) {
+	 *   total += consumer.apply( iterator.next() );
+	 * }
+	 * </pre>
+	 */
+	public static <T> CompletionStage<Integer> total(Iterator<T> iterator, Function<T,CompletionStage<Integer>> consumer) {
+		return AsyncIterator.fromIterator( iterator )
+				.thenCompose( entry -> consumer.apply( entry ) )
+				.fold( 0, (total, next) -> total + next );
+	}
+
+	/**
+	 * Equivalent to:
+	 * <pre>
+	 * int total = 0;
 	 * for ( int i = start; i < end; i++ ) {
 	 *   total = total + consumer.apply( array[i] );
 	 * }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -1,0 +1,685 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.stage.Stage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.unit.TestContext;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests @{@link ElementCollection} on a {@link List} of basic types.
+ * <p>
+ * Example:
+ * {@code
+ *     class Person {
+ *         @ElementCollection
+ *         List<String> phones;
+ *     }
+ * }
+ * </p>
+ *
+ * @see EagerElementCollectionForBasicTypeSetTest
+ * @see EagerElementCollectionForEmbeddableEntityTypeListTest
+ */
+public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest {
+
+	private Person thePerson;
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Person.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		List<String> phones = Arrays.asList( "999-999-9999", "111-111-1111", "123-456-7890" );
+		thePerson = new Person( 7242000, "Claude", phones );
+
+		Mutiny.Session session = openMutinySession();
+		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@Test
+	public void persistWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		Person johnny = new Person( 999, "Johnny English", Arrays.asList( "888", "555" ) );
+
+		test (
+				context,
+				session.persist( johnny )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, johnny.getId() ) )
+						.invoke( found -> assertPhones( context, found, "888", "555" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.thenAccept( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		Person thomas = new Person( 7, "Thomas Reaper", Arrays.asList( "111", "111", "111", "111" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
+						.thenAccept( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		Person thomas = new Person( 567, "Thomas Reaper", Arrays.asList( "111", "111", "111", "111" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+						.invoke( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
+		);
+	}
+
+	@Test
+	public void updateCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> {
+							Stage.Session newSession = openSession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+								.thenAccept( found -> {
+									found.getPhones().set( 1, "47" );
+									found.getPhones().set( 3, "47" );
+								} )
+								.thenCompose( ignore -> newSession.flush() )
+								.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
+								.thenAccept( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void updateCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> {
+							Mutiny.Session newSession = openMutinySession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change a couple of the elements in the collection
+									.invoke( found -> {
+										found.getPhones().set( 1, "47" );
+										found.getPhones().set( 3, "47" );
+									} )
+									.call( newSession::flush )
+									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+									.invoke( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void deleteElementsFromCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> {
+							Stage.Session newSession = openSession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+									.thenAccept( found -> {
+										// it doesn't matter which elements are deleted because they are all equal
+										found.getPhones().remove( 1 );
+										found.getPhones().remove( 2 );
+									} )
+									.thenCompose( ignore -> newSession.flush() )
+									.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
+									.thenAccept( found -> assertPhones( context, found, "000", "000" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void deleteElementsFromCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> {
+							Mutiny.Session newSession = openMutinySession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+									.invoke( found -> {
+										// it doesn't matter which elements are deleted because they are all equal
+										found.getPhones().remove( 1 );
+										found.getPhones().remove( 2 );
+									} )
+									.call( newSession::flush )
+									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+									.invoke( found -> assertPhones( context, found, "000", "000" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void addOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().add( "000" ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( updatedPerson ->
+											 assertPhones(
+													 context,
+													 updatedPerson,
+													 "999-999-9999", "111-111-1111", "123-456-7890", "000"
+											 ) )
+		);
+	}
+
+	@Test
+	public void addOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.invoke( foundPerson -> foundPerson.getPhones().add( "000" ) )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( updatedPerson ->
+										 assertPhones(
+												 context,
+												 updatedPerson,
+												 "999-999-9999", "111-111-1111", "123-456-7890", "000"
+										 ) )
+		);
+	}
+
+	@Test
+	public void removeOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void removeOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.invoke( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void clearCollectionOfElementsWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.thenAccept( foundPerson -> {
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.getPhones().clear();
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() )
+						.thenAccept( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+				)
+		);
+	}
+
+	@Test
+	public void clearCollectionOfElementsWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( foundPerson -> {
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.getPhones().clear();
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+										 context.assertNotNull( foundPerson );
+										 foundPerson.getPhones().remove( "111-111-1111" );
+										 foundPerson.getPhones().add( "000" );
+									 } )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithMutinyAPI(TestContext context){
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.invoke( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove( "111-111-1111" );
+							foundPerson.getPhones().add( "000" );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.setPhones( Arrays.asList( "555" ) );
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.setPhones( Arrays.asList( "555" ) );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+		);
+	}
+
+	@Test
+	public void removePersonWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// remove thePerson entity and flush
+						.thenCompose( foundPerson -> session.remove( foundPerson ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( nullPerson -> context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.thenCompose( v -> selectFromPhonesWithStage( thePerson ) )
+						.thenAccept( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void removePersonWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.call( session::remove )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( nullPerson -> context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.chain( () -> selectFromPhonesWithMutiny( thePerson ) )
+						.invoke( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+					  // Check initial person collection hasn't changed
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+					  // Check initial person collection hasn't changed
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .thenAccept( found -> {
+						context.assertFalse( found.getPhones().isEmpty() );
+						found.setPhones( null );
+					  } )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .invoke( found -> {
+						  context.assertFalse( found.getPhones().isEmpty() );
+						  found.setPhones( null );
+					  } )
+					  .call( session::flush )
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	/**
+	 * With the Stage API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person.
+	 */
+	private CompletionStage<List<Object>> selectFromPhonesWithStage(Person person) {
+		return openSession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	/**
+	 * With the Mutiny API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person
+	 */
+	private Uni<List<Object>> selectFromPhonesWithMutiny(Person person) {
+		return openMutinySession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	/**
+	 * Utility method to check the content of the collection of elements.
+	 * It sorts the expected and actual phones before comparing.
+	 */
+	private static void assertPhones(TestContext context, Person person, String... expectedPhones) {
+		context.assertNotNull( person );
+		String[] sortedExpected = Arrays.stream( expectedPhones ).sorted()
+				.sorted( String.CASE_INSENSITIVE_ORDER )
+				.collect( Collectors.toList() )
+				.toArray( new String[expectedPhones.length] );
+		List<String> sortedActual = person.getPhones().stream()
+				.sorted( String.CASE_INSENSITIVE_ORDER )
+				.collect( Collectors.toList() );
+		Assertions.assertThat( sortedActual )
+				.containsExactly( sortedExpected );
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	static class Person {
+		@Id
+		private Integer id;
+		private String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		private List<String> phones;
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, List<String> phones) {
+			this.id = id;
+			this.name = name;
+			this.phones = phones;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setPhones(List<String> phones) {
+			this.phones = phones;
+		}
+
+		public List<String> getPhones() {
+			return phones;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Person person = (Person) o;
+			return Objects.equals( name, person.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder();
+			sb.append( id );
+			sb.append( ", " ).append( name );
+			sb.append( ", ").append( phones );
+			return sb.toString();
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -1,0 +1,558 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.stage.Stage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.unit.TestContext;
+import org.assertj.core.api.Assertions;
+
+/**
+ * Tests @{@link ElementCollection} on a {@link java.util.Set} of basic types.
+ * <p>
+ * Example:
+ * {@code
+ *     class Person {
+ *         @ElementCollection
+ *         Set<String> phones;
+ *     }
+ * }
+ * </p>,
+ *
+ * @see EagerElementCollectionForBasicTypeListTest
+ * @see EagerElementCollectionForEmbeddableEntityTypeListTest
+ */
+public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest {
+
+	private Person thePerson;
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Person.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		Set<String> phones = new HashSet<>( Arrays.asList( "999-999-9999", "111-111-1111", "123-456-7890" ) );
+		thePerson = new Person( 7242000, "Claude", phones );
+
+		Mutiny.Session session = openMutinySession();
+		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@Test
+	public void persistWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		Person johnny = new Person( 999, "Johnny English", Arrays.asList( "888", "555" ) );
+
+		test (
+				context,
+				session.persist( johnny )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, johnny.getId() ) )
+						.invoke( found -> assertPhones( context, found, "888", "555" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.thenAccept( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+
+	@Test
+	public void addOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// add one element to the collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().add( "000" ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( updatedPerson ->
+											 assertPhones(
+													 context,
+													 updatedPerson,
+													 "999-999-9999", "111-111-1111", "123-456-7890", "000"
+											 ) )
+		);
+	}
+
+	@Test
+	public void addOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// add one element to the collection
+						.invoke( foundPerson -> foundPerson.getPhones().add( "000" ) )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( updatedPerson ->
+											 assertPhones(
+													 context,
+													 updatedPerson,
+													 "999-999-9999", "111-111-1111", "123-456-7890", "000"
+											 ) )
+		);
+	}
+
+	@Test
+	public void removeOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void removeOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.invoke( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void clearCollectionOfElementsWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.thenAccept( foundPerson -> {
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.getPhones().clear();
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() )
+						.thenAccept( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+				)
+		);
+	}
+
+	@Test
+	public void clearCollectionOfElementsWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( foundPerson -> {
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.getPhones().clear();
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove( "111-111-1111" );
+							foundPerson.getPhones().add( "000" );
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithMutinyAPI(TestContext context){
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.invoke( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove( "111-111-1111" );
+							foundPerson.getPhones().add( "000" );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.setPhones( new HashSet<>( Arrays.asList( "555" ) ) );
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						.invoke( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							context.assertFalse( foundPerson.getPhones().isEmpty() );
+							foundPerson.setPhones( new HashSet<>( Arrays.asList( "555" ) ) );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+		);
+	}
+
+	@Test
+	public void removePersonWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// remove thePerson entity and flush
+						.thenCompose( foundPerson -> session.remove( foundPerson ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( nullPerson -> context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.thenCompose( v -> selectFromPhonesWithStage( thePerson ) )
+						.thenAccept( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void removePersonWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// remove thePerson entity and flush
+						.call( session::remove )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( nullPerson -> context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.chain( () -> selectFromPhonesWithMutiny( thePerson ) )
+						.invoke( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+					  // Check initial person collection hasn't changed
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+					  // Check initial person collection hasn't changed
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .thenAccept( found -> {
+						context.assertFalse( found.getPhones().isEmpty() );
+						found.setPhones( null );
+					  } )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .invoke( found -> {
+						  context.assertFalse( found.getPhones().isEmpty() );
+						  found.setPhones( null );
+					  } )
+					  .call( session::flush )
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	/**
+	 * With the Stage API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person.
+	 */
+	private CompletionStage<List<Object>> selectFromPhonesWithStage(Person person) {
+		return openSession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	/**
+	 * With the Mutiny API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person
+	 */
+	private Uni<List<Object>> selectFromPhonesWithMutiny(Person person) {
+		return openMutinySession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	/**
+	 * Utility method to check the content of the collection of elements.
+	 * It sorts the expected and actual phones before comparing.
+	 */
+	private static void assertPhones(TestContext context, Person person, String... expectedPhones) {
+		context.assertNotNull( person );
+		String[] sortedExpected = Arrays.stream( expectedPhones ).sorted()
+				.sorted( String.CASE_INSENSITIVE_ORDER )
+				.collect( Collectors.toList() )
+				.toArray( new String[expectedPhones.length] );
+		List<String> sortedActual = person.getPhones().stream()
+				.sorted( String.CASE_INSENSITIVE_ORDER )
+				.collect( Collectors.toList() );
+		Assertions.assertThat( sortedActual )
+				.containsExactly( sortedExpected );
+	}
+
+	@Entity(name = "Person")
+	@Table(name = "Person")
+	static class Person {
+		@Id
+		private Integer id;
+		private String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		private Set<String> phones;
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, Collection<String> phones) {
+			this.id = id;
+			this.name = name;
+			this.phones = new HashSet<>( phones );
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public void setPhones(Set<String> phones) {
+			this.phones = phones;
+		}
+
+		public Set<String> getPhones() {
+			return phones;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Person person = (Person) o;
+			return Objects.equals( name, person.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+
+		@Override
+		public String toString() {
+			final StringBuilder sb = new StringBuilder();
+			sb.append( id );
+			sb.append( ", " ).append( name );
+			sb.append( ", ").append( phones );
+			return sb.toString();
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeListTest.java
@@ -1,0 +1,811 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+import javax.persistence.ElementCollection;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.stage.Stage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Tests @{@link ElementCollection} on a {@link java.util.Set} of basic types.
+ * <p>
+ * Example:
+ * {@code
+ *     class Person {
+ *         @ElementCollection
+ *         List<Phone> phones;
+ *     }
+ *
+ *
+ *     @Embeddable
+ *     public static class Phone {
+ *     ...
+ *     }
+ * }
+ * </p>,
+ *
+ * @see EagerElementCollectionForBasicTypeListTest
+ * @see EagerElementCollectionForBasicTypeSetTest
+ */
+public class EagerElementCollectionForEmbeddableEntityTypeListTest extends BaseReactiveTest {
+
+	private Person thePerson;
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Person.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "999-999-9999" ) );
+		phones.add( new Phone( "111-111-1111" ) );
+		thePerson = new Person( 777777, "Claude", phones );
+
+		Stage.Session session = openSession();
+
+		test( context, session.persist( thePerson )
+				.thenCompose( v -> session.flush() )
+		);
+	}
+
+	@Test
+	public void persistWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "888" ) );
+		phones.add( new Phone( "555" ) );
+		Person johnny = new Person( 999, "Johnny English", phones );
+
+		test (
+				context,
+				session.persist( johnny )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, johnny.getId() ) )
+						.invoke( found -> assertPhones( context, found, "888", "555" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test ( context, session
+				.find( Person.class, thePerson.getId() )
+				.thenAccept( foundPerson -> assertPhones( context, foundPerson,"999-999-9999", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void findEntityWithElementCollectionMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test ( context, session
+				.find( Person.class, thePerson.getId() )
+				.invoke( foundPerson -> assertPhones( context, foundPerson,"999-999-9999", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void addOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().add(new Phone("000" )) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( updatedPerson ->
+											 assertPhones(
+													 context,
+													 updatedPerson,
+													 "999-999-9999", "111-111-1111", "000"
+											 ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		Person thomas = new Person( 7, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
+						.thenAccept( found -> assertPhones( context, found, "111", "111", "111", "111") )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		phones.add( new Phone( "111" ) );
+		Person thomas = new Person( 567, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+						.invoke( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
+		);
+	}
+
+	@Test
+	public void updateCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+
+		Person thomas = new Person( 47, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> {
+							Stage.Session newSession = openSession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+									.thenAccept( found -> {
+										found.getPhones().set( 1, new Phone( "47" ) );
+										found.getPhones().set( 3,  new Phone( "47" ) );
+									} )
+									.thenCompose( ignore -> newSession.flush() )
+									.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
+									.thenAccept( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void updateCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+
+		Person thomas = new Person( 47, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> {
+							Mutiny.Session newSession = openMutinySession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change a couple of the elements in the collection
+									.invoke( found -> {
+										found.getPhones().set( 1, new Phone( "47" ) );
+										found.getPhones().set( 3,  new Phone( "47" ) );
+									} )
+									.call( newSession::flush )
+									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+									.invoke( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void deleteElementsFromCollectionWithDuplicatesWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+
+		Person thomas = new Person( 47, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> {
+							Stage.Session newSession = openSession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+									.thenAccept( found -> {
+										// it doesn't matter which elements are deleted because they are all equal
+										found.getPhones().remove( 1 );
+										found.getPhones().remove( 2 );
+									} )
+									.thenCompose( ignore -> newSession.flush() )
+									.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
+									.thenAccept( found -> assertPhones( context, found, "000", "000" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void deleteElementsFromCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		List<Phone> phones = new ArrayList<>();
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+		phones.add( new Phone( "000" ) );
+
+		Person thomas = new Person( 47, "Thomas Reaper", phones );
+
+		test(
+				context,
+				session.persist( thomas )
+						.call( session::flush )
+						.chain( () -> {
+							Mutiny.Session newSession = openMutinySession();
+							return newSession.find( Person.class, thomas.getId() )
+									// Change one of the element in the collection
+									.invoke( found -> {
+										// it doesn't matter which elements are deleted because they are all equal
+										found.getPhones().remove( 1 );
+										found.getPhones().remove( 2 );
+									} )
+									.call( newSession::flush )
+									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+									.invoke( found -> assertPhones( context, found, "000", "000" ) );
+						} )
+		);
+	}
+
+	@Test
+	public void addOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// add one element to the collection
+						.invoke( foundPerson -> foundPerson.getPhones().add( new Phone("000" ) ) )
+						.call( session::flush )
+						// Check new person collection
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( updatedPerson ->
+										 assertPhones(
+												 context,
+												 updatedPerson,
+												 "999-999-9999", "111-111-1111", "000"
+										 ) )
+		);
+	}
+
+	@Test
+	public void removeOneElementWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.thenAccept( foundPerson -> { foundPerson.getPhones().remove( new Phone( "999-999-9999" ) ); } )
+						.thenCompose( v -> session.flush())
+						.thenCompose( v -> openSession()
+								.find( Person.class, thePerson.getId() )
+								.thenAccept( foundPerson -> assertPhones( context, foundPerson, "111-111-1111" ) )
+						)
+		);
+	}
+
+	@Test
+	public void removeOneElementWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// Remove one element from the collection
+						.invoke( foundPerson -> { foundPerson.getPhones().remove( new Phone( "999-999-9999" ) ); } )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() )
+								.invoke( foundPerson -> assertPhones( context, foundPerson, "111-111-1111" ) ) )
+		);
+	}
+
+	@Test
+	public void clearCollectionElementsStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// clear collection
+						.thenAccept( foundPerson -> foundPerson.getPhones().clear() )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId() )
+								.thenAccept( changedPerson -> assertPhones( context, changedPerson))) //context.assertTrue( changedPerson.getPhones().isEmpty() ) ) )
+		);
+	}
+
+	@Test
+	public void clearCollectionElementsMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// clear collection
+						.invoke( foundPerson -> foundPerson.getPhones().clear() )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() )
+								.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove( new Phone("111-111-1111") );
+							foundPerson.getPhones().add( new Phone("000") );
+						} )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "000" ) )
+		);
+	}
+
+	@Test
+	public void removeAndAddElementWithMutinyAPI(TestContext context){
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.invoke( foundPerson -> {
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove(  new Phone("111-111-1111") );
+							foundPerson.getPhones().add( new Phone("000") );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( person -> assertPhones( context, person, "999-999-9999", "000" ) )
+		);
+	}
+
+	@Test
+	public void replaceSecondCollectionElementStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.thenAccept( foundPerson -> {
+							// remove existing phone and add new phone
+							foundPerson.getPhones().remove( new Phone( "999-999-9999" ) );
+							foundPerson.getPhones().add( new Phone( "000-000-0000" ) );
+						} )
+						.thenCompose(v -> session.flush())
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "000-000-0000", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void replaceSecondCollectionElementMutinyAPI(TestContext context){
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						.invoke( foundPerson -> {
+							// remove existing phone and add new phone
+							foundPerson.getPhones().remove( new Phone( "999-999-9999" ) );
+							foundPerson.getPhones().add( new Phone( "000-000-0000" ) );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> assertPhones( context, changedPerson, "000-000-0000", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						// replace phones with list of 1 phone
+						.thenAccept( foundPerson -> {
+							foundPerson.setPhones( Arrays.asList( new Phone( "000-000-0000" ) ) );
+						} )
+						.thenCompose(v -> session.flush())
+						.thenCompose( s -> openSession().find( Person.class, thePerson.getId() ) )
+						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "000-000-0000" ) )
+		);
+	}
+
+	@Test
+	public void setNewElementCollectionMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test (
+				context,
+				session.find( Person.class, thePerson.getId())
+						// replace phones with list of 1 phone
+						.invoke( foundPerson -> {
+							foundPerson.setPhones( Arrays.asList( new Phone( "000-000-0000" ) ) );
+						} )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+						.invoke( changedPerson -> assertPhones( context, changedPerson, "000-000-0000" ) )
+		);
+	}
+
+	@Test
+	public void removePersonStageAPI(TestContext context){
+		Stage.Session session = openSession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// remove thePerson entity and flush
+						.thenCompose( foundPerson -> session.remove( foundPerson ) )
+						.thenCompose( v -> session.flush() )
+						.thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
+						.thenAccept( nullPerson ->  context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.thenCompose( v -> selectFromPhonesWithStage( thePerson ) )
+						.thenAccept( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void removePersonMutinyAPI(TestContext context){
+		Mutiny.Session session = openMutinySession();
+
+		test(
+				context,
+				session.find( Person.class, thePerson.getId() )
+						// remove thePerson entity and flush
+						.call( session::remove )
+						.call( session::flush )
+						.chain( () -> openMutinySession().find( Person.class, thePerson.getId()) )
+						.invoke( nullPerson ->  context.assertNull( nullPerson ) )
+						// Check with native query that the table is empty
+						.chain( () -> selectFromPhonesWithMutiny( thePerson ) )
+						.invoke( resultList -> context.assertTrue( resultList.isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty",
+										  Arrays.asList(
+												  new Phone( "222-222-2222" ),
+												  new Phone( "333-333-3333" ),
+												  new Phone( "444-444-4444" )
+										  )
+		);
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333", "444-444-4444" ) )
+					  // Check initial person collection hasn't changed
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void persistAnotherPersonWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty",
+										  Arrays.asList(
+												  new Phone( "222-222-2222" ),
+												  new Phone( "333-333-3333" ),
+												  new Phone( "444-444-4444" )
+										  )
+		);
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333", "444-444-4444" ) )
+					  // Check initial person collection hasn't changed
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionOfNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithStageAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, new Phone( "567" ), null ) );
+
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .thenCompose( v -> session.flush() )
+					  // Check new person collection
+					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void persistCollectionWithNullsWithMutinyAPI(TestContext context) {
+		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, new Phone( "567" ), null ) );
+
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.persist( secondPerson )
+					  .call( session::flush )
+					  // Check new person collection
+					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+					  // Null values don't get persisted
+					  .invoke( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithStageAPI(TestContext context) {
+		Stage.Session session = openSession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .thenAccept( found -> {
+						  context.assertFalse( found.getPhones().isEmpty() );
+						  found.setPhones( null );
+					  } )
+					  .thenCompose( v -> session.flush() )
+					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+					  .thenAccept( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	@Test
+	public void setCollectionToNullWithMutinyAPI(TestContext context) {
+		Mutiny.Session session = openMutinySession();
+
+		test( context,
+			  session.find( Person.class, thePerson.getId() )
+					  .invoke( found -> {
+						  context.assertFalse( found.getPhones().isEmpty() );
+						  found.setPhones( null );
+					  } )
+					  .call( session::flush )
+					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+					  .invoke( foundPerson -> assertPhones( context, foundPerson ) )
+		);
+	}
+
+	/**
+	 * With the Stage API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person.
+	 */
+	private CompletionStage<List<Object>> selectFromPhonesWithStage(Person person) {
+		return openSession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	/**
+	 * With the Mutiny API, run a native query to check the content of the table containing the collection of elements
+	 * associated to the selected person
+	 */
+	private Uni<List<Object>> selectFromPhonesWithMutiny(Person person) {
+		return openMutinySession()
+				.createNativeQuery( "SELECT * FROM Person_phones where Person_id = ?" )
+				.setParameter( 1, person.getId() )
+				.getResultList();
+	}
+
+	private static void assertPhones(TestContext context, Person person, String... phones) {
+		context.assertNotNull( person );
+		context.assertEquals( phones.length, person.getPhones().size() );
+		for ( String number : phones) {
+			context.assertTrue( phonesContainNumber( person, number) );
+		}
+	}
+
+	private static boolean phonesContainNumber(Person person, String phoneNum) {
+		for ( Phone phone : person.getPhones() ) {
+			if ( phone.getNumber().equals( phoneNum ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	@Entity(name = "Person")
+	public static class Person {
+
+		@Id
+		private Integer id;
+
+		private String name;
+
+		@ElementCollection(fetch = FetchType.EAGER)
+		private List<Phone> phones = new ArrayList<>();
+
+		public Person() {
+		}
+
+		public Person(Integer id, String name, List<Phone> phones) {
+			this.id = id;
+			this.name = name;
+			this.phones = phones;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		public Phone getPhone(String number) {
+			for( Phone phone : getPhones() ) {
+				if( phone.getNumber().equals( number ) ) {
+					return phone;
+				}
+			}
+			return null;
+		}
+
+		public void setPhones(List<Phone> phones) {
+			this.phones  = phones;
+		}
+
+		public List<Phone> getPhones() {
+			return phones;
+		}
+	}
+
+	@Embeddable
+	public static class Phone {
+
+		private String number;
+
+		private String country;
+
+		public Phone() {
+		}
+
+		public Phone(String number) {
+			this( "UK", number );
+		}
+
+		public Phone(String country, String number) {
+			this.country = country;
+			this.number = number;
+		}
+
+		public String getCountry() {
+			return country;
+		}
+
+		public void setCountry(String country) {
+			this.country = country;
+		}
+
+		public String getNumber() {
+			return number;
+		}
+
+		public void setNumber(String number) {
+			this.number = number;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Phone phone = (Phone) o;
+			return Objects.equals( number, phone.number );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( number );
+		}
+	}
+}


### PR DESCRIPTION
Added support for List, Set and List<{Embeddable Entity}>

Tests include:
- insert, remove, replace, clear elements
- duplicate and null elements.
- clearing of generated collection tables on delete of primary table

Logged be logging issues to address support for
- @OrderColumn
- [Map<> types ElementCollections](https://github.com/hibernate/hibernate-reactive/issues/532)
- [Embeddable entity with a collection of elements](https://github.com/hibernate/hibernate-reactive/issues/533)
- additional tests for each

See comments on [PR #531](https://github.com/hibernate/hibernate-reactive/pull/531)