### PR TITLE
[#575] Set default port for MariaDB

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
@@ -123,14 +123,9 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
             }
         }
 
-        int port = uri.getPort();
-        if (port==-1) {
-            switch (scheme) {
-                case "postgresql": case "postgres": port = 5432; break;
-                case "mysql": port = 3306; break;
-                case "db2": port = 50000; break;
-            }
-        }
+        int port = uri.getPort() == -1
+                ? defaultPort( scheme )
+                : uri.getPort();
 
         if ( username == null ) {
             throw new HibernateError( "database username not specified (set the property 'javax.persistence.jdbc.user', or include it as a parameter in the connection URL)" );
@@ -173,6 +168,21 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
         }
 
         return connectOptions;
+    }
+
+    private int defaultPort(String scheme) {
+        switch ( scheme ) {
+            case "postgresql":
+            case "postgres":
+                return 5432;
+            case "mariadb":
+            case "mysql":
+                return 3306;
+            case "db2":
+                return 50000;
+            default:
+                throw new IllegalArgumentException( "Unknown default port for scheme: " + scheme );
+        }
     }
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -141,9 +141,14 @@ public abstract class BaseReactiveTest {
 
 		final Async async = context.async();
 		Handler<AsyncResult<org.hibernate.SessionFactory>> result = r -> {
-			sessionFactory = r.result();
-			poolProvider = registry.getService( ReactiveConnectionPool.class );
-			async.complete();
+			if ( r.failed() ) {
+				context.fail( r.cause() );
+			}
+			else {
+				sessionFactory = r.result();
+				poolProvider = registry.getService( ReactiveConnectionPool.class );
+				async.complete();
+			}
 		};
 
 		vertxContextRule.vertx().executeBlocking( sfPromise, result );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DefaultPortTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DefaultPortTest.java
@@ -1,0 +1,67 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import org.hibernate.reactive.containers.DatabaseConfiguration;
+import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
+import org.hibernate.reactive.provider.Settings;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import io.vertx.sqlclient.SqlConnectOptions;
+import org.assertj.core.api.Assertions;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
+
+/**
+ * Test the default port is set correctly when using {@link DefaultSqlClientPoolConfiguration}
+ */
+public class DefaultPortTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void testDefaultPortIsSet() throws URISyntaxException {
+		DefaultSqlClientPoolConfiguration configuration = new DefaultSqlClientPoolConfiguration();
+		configuration.configure( requiredProperties() );
+		SqlConnectOptions sqlConnectOptions = configuration.connectOptions( new URI( scheme() + "://localhost/database" ) );
+		Assertions.assertThat( sqlConnectOptions.getPort() )
+				.as( "Default port not defined for " + dbType() )
+				.isEqualTo( dbType().getDefaultPort() );
+	}
+
+	@Test
+	public void testUnrecognizedSchemeException() throws URISyntaxException {
+		thrown.expect( IllegalArgumentException.class );
+
+		URI uri = new URI( "bogusScheme://localhost/database" );
+		new DefaultSqlClientPoolConfiguration().connectOptions( uri );
+	}
+
+	private static String scheme() {
+		if ( dbType() == DatabaseConfiguration.DBType.MARIA ) {
+			return "mariadb";
+		}
+		return dbType().name().toLowerCase( Locale.ROOT );
+	}
+
+	// Only set the required properties
+	// We are not connecting to a db so it doesn't matter
+	private Map requiredProperties() {
+		Map map = new HashMap();
+		map.put( Settings.USER, "BogusUser" );
+		return map;
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
@@ -18,18 +18,20 @@ public class DatabaseConfiguration {
 	public static final boolean USE_DOCKER = Boolean.getBoolean("docker");
 
 	public enum DBType {
-		DB2( DB2Database.INSTANCE ),
-		MYSQL( MySQLDatabase.INSTANCE ),
-		MARIA( MariaDatabase.INSTANCE, "mariadb" ),
-		POSTGRESQL( PostgreSQLDatabase.INSTANCE, "POSTGRES", "PG" );
+		DB2( DB2Database.INSTANCE, 50000 ),
+		MYSQL( MySQLDatabase.INSTANCE, 3306 ),
+		MARIA( MariaDatabase.INSTANCE, 3306, "mariadb" ),
+		POSTGRESQL( PostgreSQLDatabase.INSTANCE, 5432, "POSTGRES", "PG" );
 
 		private final TestableDatabase configuration;
+		private final int defaultPort;
 
 		// A list of alternative names that can be used to select the db
 		private final String[] aliases;
 
-		DBType(TestableDatabase configuration, String... aliases) {
+		DBType(TestableDatabase configuration, int defaultPort, String... aliases) {
 			this.configuration = configuration;
+			this.defaultPort = defaultPort;
 			this.aliases = aliases;
 		}
 
@@ -57,6 +59,10 @@ public class DatabaseConfiguration {
 			}
 			throw new IllegalArgumentException( "Unknown DB type '" + dbName + "' specified. Allowed values are: " + Arrays
 					.toString( DBType.values() ) );
+		}
+
+		public int getDefaultPort() {
+			return defaultPort;
 		}
 	}
 


### PR DESCRIPTION
Fixes #575 

This also throws an exception now if we don't have a default port for the scheme in the URI.

@gavinking I've noticed we still have the class [UriPoolConfiguration](https://github.com/hibernate/hibernate-reactive/blob/master/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UriPoolConfiguration.java) around.

I don't think we are using it now and if I remember correctly we plan to use it when they added some changes in Vert.x.
I'm wondering if we should remove it for now or at least add a Javadoc to it.