### PR TITLE
add StatelessSession.fetch()

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
@@ -82,7 +82,7 @@ public interface ReactiveLoader {
 									forcedResultTransformer,
 									afterLoadActions
 							);
-				})
+				} )
 				.whenComplete( (list, e) -> persistenceContext.afterLoad() )
 				.thenCompose( list ->
 						// only initialize non-lazy collections after everything else has been refreshed

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveCollectionLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/collection/impl/ReactiveCollectionLoader.java
@@ -76,7 +76,7 @@ public class ReactiveCollectionLoader extends CollectionLoader
 	}
 
 	protected CompletionStage<List<Object>> doReactiveQueryAndInitializeNonLazyCollections(
-			final SessionImplementor session,
+			final SharedSessionContractImplementor session,
 			final QueryParameters queryParameters,
 			final boolean returnProxies) {
 		return doReactiveQueryAndInitializeNonLazyCollections(
@@ -99,14 +99,14 @@ public class ReactiveCollectionLoader extends CollectionLoader
 
 	@Override
 	public CompletionStage<Void> reactiveInitialize(Serializable id, SharedSessionContractImplementor session) throws HibernateException {
-		return reactiveLoadCollection( (SessionImplementor) session, id, getKeyType() );
+		return reactiveLoadCollection( session, id, getKeyType() );
 	}
 
 	/**
 	 * Called by subclasses that initialize collections
 	 */
 	public CompletionStage<Void> reactiveLoadCollection(
-			final SessionImplementor session,
+			final SharedSessionContractImplementor session,
 			final Serializable id,
 			final Type type) throws HibernateException {
 		if ( LOG.isDebugEnabled() ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1250,6 +1250,24 @@ public interface Mutiny {
 		Uni<StatelessSession> refresh(Object entity, LockMode lockMode);
 
 		/**
+		 * Asynchronously fetch an association that's configured for lazy loading.
+		 *
+		 * <pre>
+		 * {@code session.fetch(author.getBook()).thenAccept(book -> print(book.getTitle()))}
+		 * </pre>
+		 *
+		 * Warning: this operation in a stateless session is quite sensitive to
+		 * data aliasing effects and should be used with great care.
+		 *
+		 * @param association a lazy-loaded association
+		 *
+		 * @return the fetched association, via a {@code CompletionStage}
+		 *
+		 * @see org.hibernate.Hibernate#initialize(Object)
+		 */
+		<T> Uni<T> fetch(T association);
+
+		/**
 		 * Obtain a native SQL result set mapping defined via the annotation
 		 * {@link javax.persistence.SqlResultSetMapping}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -94,6 +94,11 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
     }
 
     @Override
+    public <T> Uni<T> fetch(T association) {
+        return uni( () -> delegate.reactiveFetch(association, false) );
+    }
+
+    @Override
     public <T> ResultSetMapping<T> getResultSetMapping(Class<T> resultType, String mappingName) {
         return delegate.getResultSetMapping( resultType, mappingName );
     }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
@@ -47,6 +47,8 @@ public interface ReactiveStatelessSession extends ReactiveQueryExecutor {
 
     <T> ReactiveNativeQuery<T> createReactiveNativeQuery(String sqlString, String resultSetMapping);
 
+    <T> CompletionStage<T> reactiveFetch(T association, boolean unproxy);
+
     boolean isOpen();
 
     void close();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -260,7 +260,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 				return reactiveInitializeCollection( persistentCollection, false )
 						// don't reassociate the collection instance, because
 						// its owner isn't associated with this session
-						.thenApply( pc -> association );
+						.thenApply( v -> association );
 			}
 		}
 		else {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -12,6 +12,7 @@ import org.hibernate.UnresolvableObjectException;
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.bytecode.spi.BytecodeEnhancementMetadata;
 import org.hibernate.cache.spi.access.EntityDataAccess;
+import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.query.spi.HQLQueryPlan;
@@ -27,6 +28,8 @@ import org.hibernate.jpa.spi.NativeQueryTupleTransformer;
 import org.hibernate.loader.custom.CustomQuery;
 import org.hibernate.loader.custom.sql.SQLCustomQuery;
 import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.proxy.LazyInitializer;
 import org.hibernate.query.ParameterMetadata;
 import org.hibernate.query.Query;
 import org.hibernate.query.internal.ParameterMetadataImpl;
@@ -34,6 +37,7 @@ import org.hibernate.reactive.common.ResultSetMapping;
 import org.hibernate.reactive.engine.impl.ReactivePersistenceContextAdapter;
 import org.hibernate.reactive.id.impl.IdentifierGeneration;
 import org.hibernate.reactive.loader.custom.impl.ReactiveCustomLoader;
+import org.hibernate.reactive.persister.collection.impl.ReactiveCollectionPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.session.ReactiveNativeQuery;
@@ -47,6 +51,7 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import static org.hibernate.reactive.id.impl.IdentifierGeneration.assignIdIfNecessary;
+import static org.hibernate.reactive.session.impl.SessionUtil.checkEntityFound;
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 
 /**
@@ -491,6 +496,62 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
         persistenceContext.beforeLoad();
         return this.<Object>reactiveGet( persister.getMappedClass(), id )
                 .whenComplete( (r, e) -> persistenceContext.afterLoad()  );
+    }
+
+    @Override @SuppressWarnings("unchecked")
+    public <T> CompletionStage<T> reactiveFetch(T association, boolean unproxy) {
+        checkOpen();
+        PersistenceContext persistenceContext = getPersistenceContext();
+        if ( association instanceof HibernateProxy) {
+            LazyInitializer initializer = ((HibernateProxy) association).getHibernateLazyInitializer();
+            if ( !initializer.isUninitialized() ) {
+                return completedFuture( unproxy ? (T) initializer.getImplementation() : association );
+            }
+            else {
+                String entityName = initializer.getEntityName();
+                Serializable id = initializer.getIdentifier();
+                ReactiveEntityPersister persister = (ReactiveEntityPersister)
+                        getFactory().getMetamodel().entityPersister(entityName);
+                initializer.setSession(this);
+                persistenceContext.beforeLoad();
+                return persister.reactiveLoad( id, initializer.getImplementation(), LockOptions.NONE, this )
+                        .whenComplete( (v,e) -> {
+                            persistenceContext.afterLoad();
+                            if ( persistenceContext.isLoadFinished() ) {
+                                persistenceContext.clear();
+                            }
+                        } )
+                        .thenApply( entity -> {
+                            checkEntityFound( this, entityName, id, entity );
+                            initializer.setImplementation( entity );
+                            initializer.unsetSession();
+                            return unproxy ? (T) entity : association;
+                        } );
+            }
+        }
+        else if ( association instanceof PersistentCollection) {
+            PersistentCollection persistentCollection = (PersistentCollection) association;
+            if ( persistentCollection.wasInitialized() ) {
+                return completedFuture( association );
+            }
+            else {
+                ReactiveCollectionPersister persister = (ReactiveCollectionPersister)
+                        getFactory().getMetamodel().collectionPersister( persistentCollection.getRole() );
+                Serializable key = persistentCollection.getKey();
+                persistenceContext.addUninitializedCollection( persister, persistentCollection, key );
+                persistentCollection.setCurrentSession(this);
+                return persister.reactiveInitialize( key, this )
+                        .whenComplete( (v,e) -> {
+                            if ( persistenceContext.isLoadFinished() ) {
+                                persistenceContext.clear();
+                            }
+                        } )
+                        .thenApply( v -> association );
+            }
+        }
+        else {
+            return completedFuture( association );
+        }
     }
 
     @Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/SessionUtil.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/SessionUtil.java
@@ -5,17 +5,17 @@
  */
 package org.hibernate.reactive.session.impl;
 
-import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
 import java.io.Serializable;
 
 public class SessionUtil {
 
-	public static void throwEntityNotFound(SessionImplementor session, String entityName, Serializable identifier) {
+	public static void throwEntityNotFound(SharedSessionContractImplementor session, String entityName, Serializable identifier) {
 		session.getFactory().getEntityNotFoundDelegate().handleEntityNotFound( entityName, identifier );
 	}
 
-	public static void checkEntityFound(SessionImplementor session, String entityName, Serializable identifier, Object optional) {
+	public static void checkEntityFound(SharedSessionContractImplementor session, String entityName, Serializable identifier, Object optional) {
 		if ( optional==null ) {
 			throwEntityNotFound(session, entityName, identifier);
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1236,6 +1236,24 @@ public interface Stage {
 		CompletionStage<StatelessSession> refresh(Object entity, LockMode lockMode);
 
 		/**
+		 * Asynchronously fetch an association that's configured for lazy loading.
+		 *
+		 * <pre>
+		 * {@code session.fetch(author.getBook()).thenAccept(book -> print(book.getTitle()))}
+		 * </pre>
+		 *
+		 * Warning: this operation in a stateless session is quite sensitive to
+		 * data aliasing effects and should be used with great care.
+		 *
+		 * @param association a lazy-loaded association
+		 *
+		 * @return the fetched association, via a {@code CompletionStage}
+		 *
+		 * @see org.hibernate.Hibernate#initialize(Object)
+		 */
+		<T> CompletionStage<T> fetch(T association);
+
+		/**
 		 * Obtain a native SQL result set mapping defined via the annotation
 		 * {@link javax.persistence.SqlResultSetMapping}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -93,6 +93,11 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
     }
 
     @Override
+    public <T> CompletionStage<T> fetch(T association) {
+        return stage( w -> delegate.reactiveFetch(association, false) );
+    }
+
+    @Override
     public <T> ResultSetMapping<T> getResultSetMapping(Class<T> resultType, String mappingName) {
         return delegate.getResultSetMapping( resultType, mappingName );
     }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
@@ -229,6 +229,36 @@ public class LazyOneToManyAssociationWithFetchTest extends BaseReactiveTest {
 
 	}
 
+	@Test
+	public void getBookWithFetchAuthors(TestContext context) {
+		final Book goodOmens = new Book(7242353, "Good Omens: The Nice and Accurate Prophecies of Agnes Nutter, Witch");
+		final Author neilGaiman = new Author(21426321, "Neil Gaiman", goodOmens);
+		final Author terryPratchett = new Author(2132511, "Terry Pratchett", goodOmens);
+		goodOmens.getAuthors().add(neilGaiman);
+		goodOmens.getAuthors().add(terryPratchett);
+
+		test(
+				context,
+				completedFuture( getSessionFactory().openStatelessSession() )
+						.thenCompose(s -> s.insert(goodOmens)
+								.thenCompose(v -> s.insert(neilGaiman))
+								.thenCompose(v -> s.insert(terryPratchett))
+						)
+						.thenApply( v -> getSessionFactory().openStatelessSession() )
+						.thenCompose( s -> s.get(Book.class, goodOmens.getId())
+								.thenCompose(
+										book -> s.fetch( book.getAuthors() )
+								) )
+						.thenAccept(optionalAssociation -> {
+							context.assertTrue( Hibernate.isInitialized(optionalAssociation) );
+							context.assertNotNull(optionalAssociation);
+							context.assertTrue(optionalAssociation.contains(neilGaiman));
+							context.assertTrue(optionalAssociation.contains(terryPratchett));
+						})
+		);
+
+	}
+
 	@FetchProfile(name = "withAuthors",
 			fetchOverrides = @FetchProfile.FetchOverride(
 					entity = Book.class, association = "authors",


### PR DESCRIPTION
`StatelessSession` in core doesn't do lazy fetching, because with it being transparent, it's just a bit too dangerous.

But with it being a explicit operation in HR, I think it's safe enough to add.