### PR TITLE
Allow filtering of tests with testAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,15 @@ MySQL, MariaDB, or Db2, you must explicitly specify `-Pdb=mysql`,
 
     ./gradlew test -Pdb=db2
     
+It's also possible to run all tests or only selected tests on
+all available databases:
+
+    ./gradlew testAll -PincludeTests=DefaultPortTest
+
+the property `includeTests` represents the name of the test to run
+and can contain the wildcard '*'. The property is optional but
+running all tests on all databases might take a lot of time.
+
 There are three ways to start the test database.
     
 #### If you have Docker installed

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -77,6 +77,13 @@ tasks.withType(Test) {
     }
     systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
     systemProperty 'org.hibernate.reactive.common.InternalStateAssertions.ENFORCE', 'true'
+
+    if ( project.hasProperty( 'includeTests' ) ) {
+        // Example: ./gradlew testAll -PincludeTests=DefaultPortTest
+        filter {
+            includeTestsMatching project.getProperty( 'includeTests' ) ?: '*'
+        }
+    }
 }
 
 // Example:


### PR DESCRIPTION
Sometimes I want to run only selected tests on all databases without running the whole suite.

Example:

```
./gradlew testAll [-Pdocker] -PincludeTests=DefaultPortTest 
```

I know that a task of type `Test` supports the `--tests` parameter
but, for some reason, it doesn't work in this case.

