### PR TITLE
Modify parameters for CockroachDB

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     testImplementation "org.testcontainers:mysql:${testcontainersVersion}"
     testImplementation "org.testcontainers:mariadb:${testcontainersVersion}"
     testImplementation "org.testcontainers:db2:${testcontainersVersion}"
+    testImplementation "org.testcontainers:cockroachdb:${testcontainersVersion}"
 }
 
 // Print a summary of the results of the tests (number of failures, successes and skipped)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
@@ -180,6 +180,8 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
                 return 3306;
             case "db2":
                 return 50000;
+            case "cockroachdb":
+                return 26257;
             default:
                 throw new IllegalArgumentException( "Unknown default port for scheme: " + scheme );
         }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/Parameters.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/Parameters.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive.pool.impl;
 
+import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.dialect.PostgreSQL9Dialect;
 
@@ -36,7 +37,7 @@ public class Parameters {
 	};
 
 	public static Parameters instance(Dialect dialect) {
-		return dialect instanceof PostgreSQL9Dialect
+		return dialect instanceof PostgreSQL9Dialect || dialect instanceof CockroachDB192Dialect
 				? INSTANCE
 				: NO_PARSING;
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
@@ -19,7 +19,6 @@ import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
 
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
 public class BatchQueryOnConnectionTest extends BaseReactiveTest {
@@ -56,7 +55,7 @@ public class BatchQueryOnConnectionTest extends BaseReactiveTest {
 
 	public List<List<Object[]>> doBatchInserts(TestContext context, int nEntities, int nEntitiesMultiple) {
 		final String insertSql = "insert into DataPoint (description, x, y, id) values ";
-		final String sql = dbType() == DBType.POSTGRESQL
+		final String sql = dbType().speaksPostgresWireProtocol()
 				? insertSql + "($1, $2, $3, $4)"
 				: insertSql + "(?, ?, ?, ?)";
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomSqlTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomSqlTest.java
@@ -22,12 +22,13 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
 
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 
 public class CustomSqlTest extends BaseReactiveTest {
 
     @Rule
-    public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
+    public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL, COCKROACHDB );
 
     @Override
     protected Configuration constructConfiguration() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
@@ -28,6 +28,7 @@ import org.junit.Test;
 import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.CurrentUser.LoggedUserGenerator;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 import static org.hibernate.reactive.testing.DatabaseSelectionRule.runOnlyFor;
 
@@ -38,7 +39,7 @@ public class GeneratedPropertySingleTableTest extends BaseReactiveTest {
 
 	// It requires native queries so we only test this on Postgres
 	@Rule
-	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL );
+	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL, COCKROACHDB );
 
 	@Override
 	protected Configuration constructConfiguration() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyUnionSubclassesTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyUnionSubclassesTest.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.CurrentUser.LoggedUserGenerator;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 import static org.hibernate.reactive.testing.DatabaseSelectionRule.runOnlyFor;
 
@@ -42,7 +43,7 @@ public class GeneratedPropertyUnionSubclassesTest extends BaseReactiveTest {
 
 	// It requires native queries so we only test this on Postgres
 	@Rule
-	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL );
+	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL, COCKROACHDB );
 
 	@Override
 	protected Configuration constructConfiguration() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ORMReactivePersistenceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ORMReactivePersistenceTest.java
@@ -27,6 +27,7 @@ import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
 
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 
@@ -37,7 +38,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 public class ORMReactivePersistenceTest extends BaseReactiveTest {
 
 	@Rule
-	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
+	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL, COCKROACHDB );
 
 	private SessionFactory ormFactory;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UriConfigTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UriConfigTest.java
@@ -8,10 +8,7 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.MariaDB103Dialect;
-import org.hibernate.dialect.MySQL8Dialect;
-import org.hibernate.dialect.PostgreSQL10Dialect;
+import org.hibernate.dialect.*;
 import org.hibernate.reactive.containers.DatabaseConfiguration;
 import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
@@ -32,6 +29,7 @@ public class UriConfigTest extends BaseReactiveTest {
         Class<? extends Dialect> dialect;
         switch ( DatabaseConfiguration.dbType() ) {
             case POSTGRESQL: dialect = PostgreSQL10Dialect.class; break;
+            case COCKROACHDB: dialect = CockroachDB201Dialect.class; break;
             case MYSQL: dialect = MySQL8Dialect.class; break;
             case MARIA: dialect = MariaDB103Dialect.class; break;
             case DB2:
@@ -49,6 +47,7 @@ public class UriConfigTest extends BaseReactiveTest {
         String sql;
         switch ( DatabaseConfiguration.dbType() ) {
             case POSTGRESQL:
+            case COCKROACHDB:
                 sql = "select cast(current_timestamp as varchar)"; break;
             case MYSQL:
             case MARIA:

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
@@ -1,0 +1,69 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.containers;
+
+import org.testcontainers.containers.CockroachContainer;
+
+class CockroachDBDatabase implements TestableDatabase {
+
+	public static CockroachDBDatabase INSTANCE = new CockroachDBDatabase();
+
+	public final static String IMAGE_NAME = "cockroachdb/cockroach:v20.2.5";
+
+	/**
+	 * Holds configuration for the CockroachDB database container. If the build is run with <code>-Pdocker</code> then
+	 * Testcontainers+Docker will be used.
+	 * <p>
+	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
+	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
+	 */
+	public static final CockroachContainer cockroachDb = new CockroachContainer( IMAGE_NAME ).withReuse( true );
+
+	private String getRegularJdbcUrl() {
+		return "jdbc:postgresql://localhost:26257/" + cockroachDb.getDatabaseName();
+	}
+
+	@Override
+	public String getJdbcUrl() {
+		String address;
+		if ( DatabaseConfiguration.USE_DOCKER ) {
+			// Calling start() will start the container (if not already started)
+			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port
+			cockroachDb.start();
+			address = cockroachDb.getJdbcUrl();
+		}
+		else {
+			address = getRegularJdbcUrl();
+		}
+		return buildJdbcUrlWithCredentials( address + "?sslmode=disable" );
+	}
+
+	@Override
+	public String getUri() {
+		String address;
+		if ( DatabaseConfiguration.USE_DOCKER ) {
+			// Calling start() will start the container (if not already started)
+			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port
+			cockroachDb.start();
+			address = cockroachDb.getJdbcUrl();
+		}
+		else {
+			address = getRegularJdbcUrl();
+		}
+		return buildUriWithCredentials( address + "?sslmode=disable" );
+	}
+
+	private static String buildJdbcUrlWithCredentials(String jdbcUrl) {
+		return jdbcUrl + "&user=" + cockroachDb.getUsername() + "&password=" + cockroachDb.getPassword();
+	}
+
+	private static String buildUriWithCredentials(String jdbcUrl) {
+		return "postgresql://" + cockroachDb.getUsername() + "@" + jdbcUrl.substring(18);
+	}
+
+	private CockroachDBDatabase() {
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
@@ -21,7 +21,8 @@ public class DatabaseConfiguration {
 		DB2( DB2Database.INSTANCE, 50000 ),
 		MYSQL( MySQLDatabase.INSTANCE, 3306 ),
 		MARIA( MariaDatabase.INSTANCE, 3306, "mariadb" ),
-		POSTGRESQL( PostgreSQLDatabase.INSTANCE, 5432, "POSTGRES", "PG" );
+		POSTGRESQL( PostgreSQLDatabase.INSTANCE, 5432, "POSTGRES", "PG" ),
+		COCKROACHDB( CockroachDBDatabase.INSTANCE, 26257, "COCKROACH" );
 
 		private final TestableDatabase configuration;
 		private final int defaultPort;
@@ -63,6 +64,10 @@ public class DatabaseConfiguration {
 
 		public int getDefaultPort() {
 			return defaultPort;
+		}
+
+		public boolean speaksPostgresWireProtocol() {
+			return this == DBType.POSTGRESQL || this == DBType.COCKROACHDB;
 		}
 	}
 


### PR DESCRIPTION
CockroachDB uses a very similar dialect to Postgres, and requires the same modification of ?, ? -> $1, $2 for hibernate-reactive to work with it.

I was trying to follow the CockroachDB Hibernate tutorial using hibernate-reactive (as we use Vert.x 4) and came across this blocker for us. I don't believe there are any easy extension points that would allow us to change this behaviour at runtime, please correct me if I'm wrong!