### PR TITLE
Disable build for ORM 5.5 SNAPSHOTS

### DIFF
--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -1,18 +1,21 @@
 name: Latest ORM 5.x
 
-on:
+##
+# Disabled for now
+##
+  #on:
   # Trigger the workflow on push or pull request,
   # but only for the master branch
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
-  schedule:
+  #push:
+  #  branches:
+  #    - master
+  #pull_request:
+  #  branches:
+  #    - master
+  #schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every hour at minute 25
-    - cron: '25 * * * *'
+    #  - cron: '25 * * * *'
 
 jobs:
   # The examples test the Hibernate ORM Gradle plugin. We use it for bytecode enhancements.


### PR DESCRIPTION
It causes too many errors at the moment because of this commit in ORM: https://github.com/hibernate/hibernate-orm/commit/ed3bbf15e476b064b6a55a80ac0c1570a4287bf0

I think the solution would be to add similar changes to 5.4 but that requires to wait for the another release.

It's easier to disable it for now