### PR TITLE
Better way to disable 5.5 ORM Job

### DIFF
--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -1,21 +1,18 @@
 name: Latest ORM 5.x
 
-##
-# Disabled for now
-##
-  #on:
+on:
   # Trigger the workflow on push or pull request,
   # but only for the master branch
-  #push:
-  #  branches:
-  #    - master
-  #pull_request:
-  #  branches:
-  #    - master
-  #schedule:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
     # * is a special character in YAML so you have to quote this string
     # Run every hour at minute 25
-    #  - cron: '25 * * * *'
+    - cron: '25 * * * *'
 
 jobs:
   # The examples test the Hibernate ORM Gradle plugin. We use it for bytecode enhancements.

--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         example: [ 'example', 'example2' ]
-        orm-version: ['[5.4,5.5)', '[5.5,5.6)']
+        orm-version: ['[5.4,5.5)']
         db: ['MySQL', 'PostgreSQL']
         exclude:
           # 'example2' doesn't run on MySQL because it has native queries
@@ -77,7 +77,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        orm-version: ['[5.4,5.5)', '[5.5,5.6)']
+        orm-version: ['[5.4,5.5)']
         db: ['MariaDB', 'MySQL', 'PostgreSQL', 'DB2']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I've just realized that it is possible to disable the job on GitHub, so I've reverted the previous change and
added a comment to the original job.

We can decide later if we want to re-enable it. I will create an issue so that we don't forget.