### PR TITLE
#667 - Fix java.lang.UnsupportedOperationException org.hibernate.reac…

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
@@ -695,7 +695,7 @@ public class ResultSetAdaptor implements ResultSet {
 
 	@Override
 	public Timestamp getTimestamp(String columnLabel, Calendar cal) {
-		throw new UnsupportedOperationException();
+		return getTimestamp(columnLabel);
 	}
 
 	@Override


### PR DESCRIPTION
Exception thrown when hibernate tries to map OffsetDateTime. #667 provides the details of the exception 
```
java.lang.UnsupportedOperationException
at org.hibernate.reactive.adaptor.impl.ResultSetAdaptor.getTimestamp(ResultSetAdaptor.java:698)
```
