### PR TITLE
[#487] One SessionFactory per test class

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -26,10 +26,6 @@ dependencies {
     implementation "io.vertx:vertx-sql-client:${vertxVersion}"
 
     // Testing
-    testImplementation 'org.junit.jupiter:junit-jupiter-api:5.6.0'
-    testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine'
-    testRuntimeOnly 'org.junit.vintage:junit-vintage-engine'
-
     testImplementation 'org.assertj:assertj-core:3.13.2'
     testImplementation "io.vertx:vertx-unit:${vertxVersion}"
 
@@ -94,9 +90,6 @@ tasks.withType(Test) {
 // Example:
 // gradle test -Pdb=MySQL
 test {
-    // Enable JUnit 5
-    useJUnitPlatform()
-
     def selectedDb = project.hasProperty( 'db' )
             ? project.getProperty( 'db' )
             : 'PostgreSQL'

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -32,6 +32,7 @@ import org.hibernate.reactive.vertx.VertxInstance;
 import org.hibernate.tool.schema.spi.SchemaManagementTool;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
@@ -59,8 +60,8 @@ public abstract class BaseReactiveTest {
 	@Rule
 	public Timeout rule = Timeout.seconds( 5 * 60 );
 
-	@Rule
-	public RunTestOnContext vertxContextRule = new RunTestOnContext( () -> {
+	@ClassRule
+	public static RunTestOnContext vertxContextRule = new RunTestOnContext( () -> {
 		VertxOptions options = new VertxOptions();
 		options.setBlockedThreadCheckInterval( 5 );
 		options.setBlockedThreadCheckIntervalUnit( TimeUnit.MINUTES );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -6,6 +6,8 @@
 package org.hibernate.reactive;
 
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.RunTestOnContext;
@@ -34,6 +36,7 @@ import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
@@ -57,7 +60,14 @@ public abstract class BaseReactiveTest {
 	public Timeout rule = Timeout.seconds( 5 * 60 );
 
 	@Rule
-	public RunTestOnContext vertxContextRule = new RunTestOnContext();
+	public RunTestOnContext vertxContextRule = new RunTestOnContext( () -> {
+		VertxOptions options = new VertxOptions();
+		options.setBlockedThreadCheckInterval( 5 );
+		options.setBlockedThreadCheckIntervalUnit( TimeUnit.MINUTES );
+		Vertx vertx = Vertx.vertx( options );
+		return vertx;
+	} );
+
 
 	private AutoCloseable session;
 	private ReactiveConnection connection;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -5,15 +5,10 @@
  */
 package org.hibernate.reactive;
 
-import io.smallrye.mutiny.Uni;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.VertxOptions;
-import io.vertx.ext.unit.Async;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.RunTestOnContext;
-import io.vertx.ext.unit.junit.Timeout;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.Arrays;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
 import org.hibernate.SessionFactory;
 import org.hibernate.boot.registry.StandardServiceRegistry;
@@ -40,10 +35,15 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.runner.RunWith;
 
-import java.util.Arrays;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.Timeout;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 import static org.hibernate.reactive.util.impl.CompletionStages.loop;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -82,8 +82,13 @@ public abstract class BaseReactiveTest {
 	private ReactiveConnection connection;
 
 	protected static void test(TestContext context, CompletionStage<?> work) {
-		// this will be added to TestContext in the next vert.x release
-		Async async = context.async();
+		test( context.async(), context, work );
+	}
+
+	/**
+	 * For when we need to create the {@link Async} in advance
+	 */
+	protected static void test(Async async, TestContext context, CompletionStage<?> work) {
 		work.whenComplete( (res, err) -> {
 			if ( res instanceof Stage.Session ) {
 				Stage.Session s = (Stage.Session) res;
@@ -101,7 +106,13 @@ public abstract class BaseReactiveTest {
 	}
 
 	protected static void test(TestContext context, Uni<?> uni) {
-		Async async = context.async();
+		test( context.async(), context, uni );
+	}
+
+	/**
+	 * For when we need to create the {@link Async} in advance
+	 */
+	protected static void test(Async async, TestContext context, Uni<?> uni) {
 		uni.subscribe().with(
 				res -> {
 					if ( res instanceof Mutiny.Session) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchFetchTest.java
@@ -10,6 +10,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.LockMode;
 import org.hibernate.annotations.BatchSize;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.CascadeType;
@@ -43,6 +45,13 @@ public class BatchFetchTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Node.class );
 		configuration.addAnnotatedClass( Element.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.createQuery( "delete from Element" ).executeUpdate()
+						.thenCompose( v -> s.createQuery( "delete from Node" ).executeUpdate() ) ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
@@ -15,6 +15,7 @@ import javax.persistence.Id;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.pool.ReactiveConnection;
 
+import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -23,6 +24,11 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
 public class BatchQueryOnConnectionTest extends BaseReactiveTest {
 	private static final int BATCH_SIZE = 20;
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "DataPoint" ) );
+	}
 
 	@Test
 	public void testBatchInsertSizeEqMultiple(TestContext context) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
@@ -9,6 +9,8 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.annotations.Cache;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Cacheable;
@@ -30,6 +32,11 @@ public class CacheTest extends BaseReactiveTest {
         configuration.setProperty( "hibernate.javax.cache.provider", "org.ehcache.jsr107.EhcacheCachingProvider" );
         configuration.setProperty( "hibernate.javax.cache.uri", "/ehcache.xml" );
         return configuration;
+    }
+
+    @After
+    public void cleanDB(TestContext context) {
+        getSessionFactory().close();
     }
 
     @Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompletionStagesTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompletionStagesTest.java
@@ -11,14 +11,6 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.IntStream;
 
-
-import static java.util.Arrays.asList;
-import static java.util.Arrays.stream;
-import static org.hibernate.reactive.util.impl.CompletionStages.*;
-import static org.hibernate.reactive.util.impl.CompletionStages.total;
-import static org.hibernate.reactive.util.impl.CompletionStages.loop;
-import static org.hibernate.reactive.util.impl.CompletionStages.loopWithoutTrampoline;
-
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -26,7 +18,14 @@ import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 
+import static java.util.Arrays.asList;
+import static java.util.Arrays.stream;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
+import static org.hibernate.reactive.util.impl.CompletionStages.loop;
+import static org.hibernate.reactive.util.impl.CompletionStages.loopWithoutTrampoline;
+import static org.hibernate.reactive.util.impl.CompletionStages.total;
+import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 /**
  * Tests the utility methods in {@link org.hibernate.reactive.util.impl.CompletionStages}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -59,6 +60,11 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 
 		Mutiny.Session session = openMutinySession();
 		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -16,8 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.Table;
 
 import org.hibernate.cfg.Configuration;
-import org.hibernate.reactive.mutiny.Mutiny;
-import org.hibernate.reactive.stage.Stage;
 
 import org.junit.After;
 import org.junit.Before;
@@ -58,8 +56,7 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 		List<String> phones = Arrays.asList( "999-999-9999", "111-111-1111", "123-456-7890" );
 		thePerson = new Person( 7242000, "Claude", phones );
 
-		Mutiny.Session session = openMutinySession();
-		test( context, session.persist( thePerson ).call( session::flush ) );
+		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( thePerson ) ) );
 	}
 
 	@After
@@ -69,382 +66,306 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 
 	@Test
 	public void persistWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
 		Person johnny = new Person( 999, "Johnny English", Arrays.asList( "888", "555" ) );
 
-		test (
-				context,
-				session.persist( johnny )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, johnny.getId() ) )
-						.invoke( found -> assertPhones( context, found, "888", "555" ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persist( johnny ) )
+				.chain( () -> openMutinySession().find( Person.class, johnny.getId() ) )
+				.invoke( found -> assertPhones( context, found, "888", "555" ) )
 		);
 	}
 
 	@Test
 	public void findEntityWithElementCollectionWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId() )
-						.thenAccept( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		test( context, openSession()
+				.find( Person.class, thePerson.getId() )
+				.thenAccept( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
 		);
 	}
 
 	@Test
 	public void findEntityWithElementCollectionWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId() )
-						.invoke( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		test( context, openMutinySession()
+				.find( Person.class, thePerson.getId() )
+				.invoke( found -> assertPhones( context, found, "999-999-9999", "111-111-1111", "123-456-7890" ) )
 		);
 	}
 
 	@Test
 	public void persistCollectionWithDuplicatesWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
 		Person thomas = new Person( 7, "Thomas Reaper", Arrays.asList( "111", "111", "111", "111" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
-						.thenAccept( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
+				.thenAccept( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
 		);
 	}
 
 	@Test
 	public void persistCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
 		Person thomas = new Person( 567, "Thomas Reaper", Arrays.asList( "111", "111", "111", "111" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
-						.invoke( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+				.invoke( found -> assertPhones( context, found, "111", "111", "111", "111" ) )
 		);
 	}
 
 	@Test
 	public void updateCollectionWithDuplicatesWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
 		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> {
-							Stage.Session newSession = openSession();
-							return newSession.find( Person.class, thomas.getId() )
-									// Change one of the element in the collection
-								.thenAccept( found -> {
-									found.getPhones().set( 1, "47" );
-									found.getPhones().set( 3, "47" );
-								} )
-								.thenCompose( ignore -> newSession.flush() )
-								.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
-								.thenAccept( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
-						} )
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.thenCompose( v -> getSessionFactory().withTransaction( (s, t) -> s
+						.find( Person.class, thomas.getId() )
+						// Change one of the element in the collection
+						.thenAccept( found -> {
+							found.getPhones().set( 1, "47" );
+							found.getPhones().set( 3, "47" );
+						} ) ) )
+				.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
+				.thenAccept( found -> assertPhones( context, found, "000", "47", "000", "47" ) )
 		);
 	}
 
 	@Test
 	public void updateCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
 		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.call( session::flush )
-						.chain( () -> {
-							Mutiny.Session newSession = openMutinySession();
-							return newSession.find( Person.class, thomas.getId() )
-									// Change a couple of the elements in the collection
-									.invoke( found -> {
-										found.getPhones().set( 1, "47" );
-										found.getPhones().set( 3, "47" );
-									} )
-									.call( newSession::flush )
-									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
-									.invoke( found -> assertPhones( context, found, "000", "47", "000", "47" ) );
-						} )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.chain( () -> getMutinySessionFactory()
+						.withTransaction( (session, tx) -> session
+								.find( Person.class, thomas.getId() )
+								// Change a couple of the elements in the collection
+								.invoke( found -> {
+									found.getPhones().set( 1, "47" );
+									found.getPhones().set( 3, "47" );
+								} ) )
+				)
+				.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
+				.invoke( found -> assertPhones( context, found, "000", "47", "000", "47" ) )
 		);
 	}
 
 	@Test
 	public void deleteElementsFromCollectionWithDuplicatesWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
 		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> {
-							Stage.Session newSession = openSession();
-							return newSession.find( Person.class, thomas.getId() )
-									// Change one of the element in the collection
-									.thenAccept( found -> {
-										// it doesn't matter which elements are deleted because they are all equal
-										found.getPhones().remove( 1 );
-										found.getPhones().remove( 2 );
-									} )
-									.thenCompose( ignore -> newSession.flush() )
-									.thenCompose( ignore -> openSession().find( Person.class, thomas.getId() ) )
-									.thenAccept( found -> assertPhones( context, found, "000", "000" ) );
-						} )
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.thenCompose( v -> getSessionFactory()
+						.withTransaction( (session, tx) -> session
+								.find( Person.class, thomas.getId() )
+								// Change one of the element in the collection
+								.thenAccept( found -> {
+									// it doesn't matter which elements are deleted because they are all equal
+									found.getPhones().remove( 1 );
+									found.getPhones().remove( 2 );
+								} )
+						)
+				)
+				.thenCompose( v -> openSession().find( Person.class, thomas.getId() ) )
+				.thenAccept( found -> assertPhones( context, found, "000", "000" ) )
 		);
 	}
 
 	@Test
 	public void deleteElementsFromCollectionWithDuplicatesWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
 		Person thomas = new Person( 47, "Thomas Reaper", Arrays.asList( "000", "000", "000", "000" ) );
 
-		test(
-				context,
-				session.persist( thomas )
-						.call( session::flush )
-						.chain( () -> {
-							Mutiny.Session newSession = openMutinySession();
-							return newSession.find( Person.class, thomas.getId() )
-									// Change one of the element in the collection
-									.invoke( found -> {
-										// it doesn't matter which elements are deleted because they are all equal
-										found.getPhones().remove( 1 );
-										found.getPhones().remove( 2 );
-									} )
-									.call( newSession::flush )
-									.chain( () -> openMutinySession().find( Person.class, thomas.getId() ) )
-									.invoke( found -> assertPhones( context, found, "000", "000" ) );
-						} )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persist( thomas ) )
+				.chain( () -> getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session
+								.find( Person.class, thomas.getId() )
+								// Change one of the element in the collection
+								.invoke( found -> {
+									// it doesn't matter which elements are deleted because they are all equal
+									found.getPhones().remove( 1 );
+									found.getPhones().remove( 2 );
+								} )
+						)
+				)
+				.chain( () -> getMutinySessionFactory().withSession( session -> session.find( Person.class, thomas.getId() ) ) )
+				.invoke( found -> assertPhones( context, found, "000", "000" ) )
 		);
 	}
 
 	@Test
 	public void addOneElementWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						// Remove one element from the collection
-						.thenAccept( foundPerson -> foundPerson.getPhones().add( "000" ) )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-						.thenAccept( updatedPerson ->
-											 assertPhones(
-													 context,
-													 updatedPerson,
-													 "999-999-9999", "111-111-1111", "123-456-7890", "000"
-											 ) )
+						.thenAccept( foundPerson -> foundPerson.getPhones().add( "000" ) ) )
+				.thenCompose( v -> getSessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.thenAccept( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "111-111-1111", "123-456-7890", "000" ) )
 		);
 	}
 
 	@Test
 	public void addOneElementWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, tx) -> session
+						.find( Person.class, thePerson.getId() )
 						// Remove one element from the collection
-						.invoke( foundPerson -> foundPerson.getPhones().add( "000" ) )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( updatedPerson ->
-										 assertPhones(
-												 context,
-												 updatedPerson,
-												 "999-999-9999", "111-111-1111", "123-456-7890", "000"
-										 ) )
+						.invoke( foundPerson -> foundPerson.getPhones().add( "000" ) ) )
+				.chain( () -> getMutinySessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "111-111-1111", "123-456-7890", "000" ) )
 		);
 	}
 
 	@Test
 	public void removeOneElementWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getSessionFactory()
+				.withTransaction( (s, tx) -> s
+						.find( Person.class, thePerson.getId() )
 						// Remove one element from the collection
-						.thenAccept( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-						.thenAccept( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+						.thenAccept( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) ) )
+				.thenCompose( v -> getSessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.thenAccept( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
 		);
 	}
 
 	@Test
 	public void removeOneElementWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, tx) -> s
+						.find( Person.class, thePerson.getId() )
 						// Remove one element from the collection
 						.invoke( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+				)
+				.chain( () -> getMutinySessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
 		);
 	}
 
 	@Test
 	public void clearCollectionOfElementsWithStageAPI(TestContext context){
-		Stage.Session session = openSession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( foundPerson -> {
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.getPhones().clear();
 						} )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() )
-						.thenAccept( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
 				)
+				.thenCompose( v -> getSessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.thenAccept( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
 		);
 	}
 
 	@Test
 	public void clearCollectionOfElementsWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.invoke( foundPerson -> {
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.getPhones().clear();
 						} )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+				)
+				.chain( () -> getMutinySessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
 		);
 	}
 
 	@Test
 	public void removeAndAddElementWithStageAPI(TestContext context){
-		Stage.Session session = openSession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId())
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( foundPerson -> {
-										 context.assertNotNull( foundPerson );
-										 foundPerson.getPhones().remove( "111-111-1111" );
-										 foundPerson.getPhones().add( "000" );
-									 } )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
+							context.assertNotNull( foundPerson );
+							foundPerson.getPhones().remove( "111-111-1111" );
+							foundPerson.getPhones().add( "000" );
+						} )
+				)
+				.thenCompose( v -> getSessionFactory().withSession( session -> session.find( Person.class, thePerson.getId() ) ) )
+				.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
 		);
 	}
 
 	@Test
-	public void removeAndAddElementWithMutinyAPI(TestContext context){
-		Mutiny.Session session = openMutinySession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId())
+	public void removeAndAddElementWithMutinyAPI(TestContext context) {
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.invoke( foundPerson -> {
 							context.assertNotNull( foundPerson );
 							foundPerson.getPhones().remove( "111-111-1111" );
 							foundPerson.getPhones().add( "000" );
 						} )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
+				)
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
 		);
 	}
 
 	@Test
-	public void setNewElementCollectionWithStageAPI(TestContext context){
-		Stage.Session session = openSession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId())
+	public void setNewElementCollectionWithStageAPI(TestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( foundPerson -> {
 							context.assertNotNull( foundPerson );
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.setPhones( Arrays.asList( "555" ) );
 						} )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId()) )
-						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+				)
+				.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+				.thenAccept( changedPerson -> assertPhones( context, changedPerson, "555" ) )
 		);
 	}
 
 	@Test
 	public void setNewElementCollectionWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.invoke( foundPerson -> {
 							context.assertNotNull( foundPerson );
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.setPhones( Arrays.asList( "555" ) );
 						} )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( changedPerson -> assertPhones( context, changedPerson, "555" ) )
+				)
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( changedPerson -> assertPhones( context, changedPerson, "555" ) )
 		);
 	}
 
 	@Test
 	public void removePersonWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						// remove thePerson entity and flush
 						.thenCompose( foundPerson -> session.remove( foundPerson ) )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-						.thenAccept( nullPerson -> context.assertNull( nullPerson ) )
-						// Check with native query that the table is empty
-						.thenCompose( v -> selectFromPhonesWithStage( thePerson ) )
-						.thenAccept( resultList -> context.assertTrue( resultList.isEmpty() ) )
+				)
+				.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+				.thenAccept( nullPerson -> context.assertNull( nullPerson ) )
+				// Check with native query that the table is empty
+				.thenCompose( v -> selectFromPhonesWithStage( thePerson ) )
+				.thenAccept( resultList -> context.assertTrue( resultList.isEmpty() ) )
 		);
 	}
 
 	@Test
 	public void removePersonWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, tx) -> session
+						.find( Person.class, thePerson.getId() )
 						.call( session::remove )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( nullPerson -> context.assertNull( nullPerson ) )
-						// Check with native query that the table is empty
-						.chain( () -> selectFromPhonesWithMutiny( thePerson ) )
-						.invoke( resultList -> context.assertTrue( resultList.isEmpty() ) )
+				)
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( nullPerson -> context.assertNull( nullPerson ) )
+				// Check with native query that the table is empty
+				.chain( () -> selectFromPhonesWithMutiny( thePerson ) )
+				.invoke( resultList -> context.assertTrue( resultList.isEmpty() ) )
 		);
 	}
 
@@ -452,17 +373,14 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistAnotherPersonWithStageAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
 
-		Stage.Session session = openSession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .thenCompose( v -> session.flush() )
-					  // Check new person collection
-					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
-					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
-					  // Check initial person collection hasn't changed
-					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+				.thenAccept( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+				// Check initial person collection hasn't changed
+				.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+				.thenAccept( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
 		);
 	}
 
@@ -470,17 +388,14 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistAnotherPersonWithMutinyAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( "222-222-2222", "333-333-3333" ) );
 
-		Mutiny.Session session = openMutinySession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .call( session::flush )
-					  // Check new person collection
-					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
-					  .invoke( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
-					  // Check initial person collection hasn't changed
-					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-					  .invoke( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+				.invoke( foundPerson -> assertPhones( context, foundPerson, "222-222-2222", "333-333-3333" ) )
+				// Check initial person collection hasn't changed
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( foundPerson -> assertPhones( context, foundPerson, "999-999-9999", "111-111-1111", "123-456-7890" ) )
 		);
 	}
 
@@ -488,15 +403,12 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistCollectionOfNullsWithStageAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
 
-		Stage.Session session = openSession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .thenCompose( v -> session.flush() )
-					  // Check new person collection
-					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
-					  // Null values don't get persisted
-					  .thenAccept( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+				// Null values don't get persisted
+				.thenAccept( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
 		);
 	}
 
@@ -504,15 +416,12 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistCollectionOfNullsWithMutinyAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, null ) );
 
-		Mutiny.Session session = openMutinySession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .call( session::flush )
-					  // Check new person collection
-					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
-					  // Null values don't get persisted
-					  .invoke( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+				// Null values don't get persisted
+				.invoke( foundPerson -> context.assertTrue( foundPerson.getPhones().isEmpty() ) )
 		);
 	}
 
@@ -520,15 +429,12 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistCollectionWithNullsWithStageAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
 
-		Stage.Session session = openSession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .thenCompose( v -> session.flush() )
-					  // Check new person collection
-					  .thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
-					  // Null values don't get persisted
-					  .thenAccept( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.thenCompose( v -> openSession().find( Person.class, secondPerson.getId() ) )
+				// Null values don't get persisted
+				.thenAccept( foundPerson -> assertPhones( context, foundPerson, "567" ) )
 		);
 	}
 
@@ -536,47 +442,42 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 	public void persistCollectionWithNullsWithMutinyAPI(TestContext context) {
 		Person secondPerson = new Person( 9910000, "Kitty", Arrays.asList( null, "567", null ) );
 
-		Mutiny.Session session = openMutinySession();
-
-		test( context,
-			  session.persist( secondPerson )
-					  .call( session::flush )
-					  // Check new person collection
-					  .chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
-					  // Null values don't get persisted
-					  .invoke( foundPerson -> assertPhones( context, foundPerson, "567" ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session.persist( secondPerson ) )
+				// Check new person collection
+				.chain( () -> openMutinySession().find( Person.class, secondPerson.getId() ) )
+				// Null values don't get persisted
+				.invoke( foundPerson -> assertPhones( context, foundPerson, "567" ) )
 		);
 	}
 
 	@Test
 	public void setCollectionToNullWithStageAPI(TestContext context) {
-		Stage.Session session = openSession();
-
-		test( context,
-			  session.find( Person.class, thePerson.getId() )
-					  .thenAccept( found -> {
-						context.assertFalse( found.getPhones().isEmpty() );
-						found.setPhones( null );
-					  } )
-					  .thenCompose( v -> session.flush() )
-					  .thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-					  .thenAccept( foundPerson -> assertPhones( context, foundPerson ) )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
+						.thenAccept( found -> {
+							context.assertFalse( found.getPhones().isEmpty() );
+							found.setPhones( null );
+						} )
+				)
+				.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+				.thenAccept( foundPerson -> assertPhones( context, foundPerson ) )
 		);
 	}
 
 	@Test
 	public void setCollectionToNullWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test( context,
-			  session.find( Person.class, thePerson.getId() )
-					  .invoke( found -> {
-						  context.assertFalse( found.getPhones().isEmpty() );
-						  found.setPhones( null );
-					  } )
-					  .call( session::flush )
-					  .chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-					  .invoke( foundPerson -> assertPhones( context, foundPerson ) )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
+						.invoke( found -> {
+							context.assertFalse( found.getPhones().isEmpty() );
+							found.setPhones( null );
+						} )
+				)
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( foundPerson -> assertPhones( context, foundPerson ) )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.Collectors;
 import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -26,7 +25,8 @@ import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
-import org.assertj.core.api.Assertions;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests @{@link ElementCollection} on a {@link List} of basic types.
@@ -602,21 +602,9 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 				.getResultList();
 	}
 
-	/**
-	 * Utility method to check the content of the collection of elements.
-	 * It sorts the expected and actual phones before comparing.
-	 */
 	private static void assertPhones(TestContext context, Person person, String... expectedPhones) {
 		context.assertNotNull( person );
-		String[] sortedExpected = Arrays.stream( expectedPhones ).sorted()
-				.sorted( String.CASE_INSENSITIVE_ORDER )
-				.collect( Collectors.toList() )
-				.toArray( new String[expectedPhones.length] );
-		List<String> sortedActual = person.getPhones().stream()
-				.sorted( String.CASE_INSENSITIVE_ORDER )
-				.collect( Collectors.toList() );
-		Assertions.assertThat( sortedActual )
-				.containsExactly( sortedExpected );
+		assertThat( person.getPhones() ).containsExactlyInAnyOrder( expectedPhones );
 	}
 
 	@Entity(name = "Person")

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -57,6 +58,11 @@ public class EagerElementCollectionForBasicTypeMapTest extends BaseReactiveTest 
 
 		Mutiny.Session session = openMutinySession();
 		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -23,6 +23,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -62,6 +63,11 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 
 		Mutiny.Session session = openMutinySession();
 		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -165,32 +165,27 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 
 	@Test
 	public void removeOneElementWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						// Remove one element from the collection
-						.invoke( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
+						.invoke( foundPerson -> foundPerson.getPhones().remove( "111-111-1111" ) ) )
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( updatedPerson -> assertPhones( context, updatedPerson, "999-999-9999", "123-456-7890" ) )
 		);
 	}
 
 	@Test
 	public void clearCollectionOfElementsWithStageAPI(TestContext context){
-		Stage.Session session = openSession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( foundPerson -> {
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.getPhones().clear();
-						} )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() )
+						} ) )
+				.thenCompose( v -> openSession()
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
 				)
 		);
@@ -198,54 +193,45 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 
 	@Test
 	public void clearCollectionOfElementsWithMutinyAPI(TestContext context) {
-		Mutiny.Session session = openMutinySession();
-
-		test(
-				context,
-				session.find( Person.class, thePerson.getId() )
+		test( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.invoke( foundPerson -> {
 							context.assertFalse( foundPerson.getPhones().isEmpty() );
 							foundPerson.getPhones().clear();
-						} )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
+						} ) )
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( changedPerson -> context.assertTrue( changedPerson.getPhones().isEmpty() ) )
 		);
 	}
 
 	@Test
-	public void removeAndAddElementWithStageAPI(TestContext context){
-		Stage.Session session = openSession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId())
+	public void removeAndAddElementWithStageAPI(TestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.thenAccept( foundPerson -> {
 							context.assertNotNull( foundPerson );
 							foundPerson.getPhones().remove( "111-111-1111" );
 							foundPerson.getPhones().add( "000" );
-						} )
-						.thenCompose( v -> session.flush() )
-						.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
-						.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
+						} ) )
+				.thenCompose( v -> openSession().find( Person.class, thePerson.getId() ) )
+				.thenAccept( changedPerson -> assertPhones( context, changedPerson, "999-999-9999", "123-456-7890", "000" ) )
 		);
 	}
 
 	@Test
 	public void removeAndAddElementWithMutinyAPI(TestContext context){
-		Mutiny.Session session = openMutinySession();
-
-		test (
-				context,
-				session.find( Person.class, thePerson.getId())
+		test ( context, getMutinySessionFactory()
+				.withTransaction( (session, transaction) -> session
+						.find( Person.class, thePerson.getId() )
 						.invoke( foundPerson -> {
 							context.assertNotNull( foundPerson );
 							foundPerson.getPhones().remove( "111-111-1111" );
 							foundPerson.getPhones().add( "000" );
-						} )
-						.call( session::flush )
-						.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
-						.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
+						} ) )
+				.chain( () -> openMutinySession().find( Person.class, thePerson.getId() ) )
+				.invoke( person -> assertPhones( context, person, "999-999-9999", "123-456-7890", "000" ) )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
@@ -21,6 +21,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,6 +46,11 @@ public class EagerElementCollectionForEmbeddableEntityTypeMapTest extends BaseRe
 
 		Mutiny.Session session = openMutinySession();
 		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
@@ -20,6 +20,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,6 +70,11 @@ public class EagerElementCollectionForEmbeddableTypeListTest extends BaseReactiv
 		test( context, session.persist( thePerson )
 				.thenCompose( v -> session.flush() )
 		);
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
@@ -10,6 +10,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
+import java.util.stream.Collectors;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
@@ -26,6 +27,8 @@ import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Tests @{@link ElementCollection} on a {@link java.util.Set} of basic types.
@@ -689,10 +692,11 @@ public class EagerElementCollectionForEmbeddableTypeListTest extends BaseReactiv
 
 	private static void assertPhones(TestContext context, Person person, String... phones) {
 		context.assertNotNull( person );
-		context.assertEquals( phones.length, person.getPhones().size() );
-		for (int i=0; i<phones.length; i++) {
-			context.assertEquals( phones[i], person.getPhones().get(i).getNumber() );
-		}
+		context.assertNotNull( person.getPhones() );
+		List<String> personPhones = person.getPhones()
+				.stream().map( phone -> phone.getNumber() ).collect( Collectors.toList() );
+
+		assertThat( personPhones ).containsExactlyInAnyOrder( phones );
 	}
 
 	@Entity(name = "Person")

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
@@ -21,6 +21,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -46,6 +47,11 @@ public class EagerElementCollectionForEmbeddedEmbeddableMapTest extends BaseReac
 
 		Mutiny.Session session = openMutinySession();
 		test( context, session.persist( thePerson ).call( session::flush ) );
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
@@ -21,6 +21,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -69,6 +70,11 @@ public class EagerElementCollectionForEmbeddedEmbeddableTest extends BaseReactiv
 		test( context, session.persist( thePerson )
 				.thenCompose( v -> session.flush() )
 		);
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerManyToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerManyToOneAssociationTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -23,6 +25,11 @@ public class EagerManyToOneAssociationTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Book.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( Book.class, Author.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
 import org.junit.Test;
 
@@ -13,6 +12,10 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+
+import org.junit.After;
+
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
@@ -24,6 +27,11 @@ public class EagerOneToManyAssociationTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Book.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( Author.class, Book.class ) );
 	}
 //
 //	private CompletionStage<Integer> populateDB(Book... books) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
@@ -97,13 +97,13 @@ public class EagerOneToManyAssociationTest extends BaseReactiveTest {
 
 		test(
 				context,
-				completedFuture( getSessionFactory().openStatelessSession() )
+				completedFuture( openStatelessSession() )
 						.thenCompose( s -> voidFuture()
 								.thenCompose( v -> s.insert(goodOmens) )
 								.thenCompose( v -> s.insert(neilGaiman) )
 								.thenCompose( v -> s.insert(terryPratchett) )
 						)
-						.thenApply( v -> getSessionFactory().openStatelessSession() )
+						.thenApply( v -> openStatelessSession() )
 						.thenCompose( s -> s.get( Book.class, goodOmens.getId() ) )
 						.thenAccept( optionalBook -> {
 							context.assertNotNull( optionalBook );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToOneAssociationTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -22,6 +24,11 @@ public class EagerOneToOneAssociationTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Book.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( Book.class, Author.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
@@ -10,6 +10,8 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -68,6 +70,11 @@ public class EagerOrderedElementCollectionForEmbeddableTypeListTest extends Base
 		test( context, session.persist( thePerson )
 				.thenCompose( v -> session.flush() )
 		);
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerTest.java
@@ -10,6 +10,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.CascadeType;
@@ -44,6 +46,13 @@ public class EagerTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass(Node.class);
 		configuration.addAnnotatedClass(Element.class);
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.createQuery( "delete from Element" ).executeUpdate()
+						.thenCompose( v -> s.createQuery( "delete from Node" ).executeUpdate() ) ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EmptyCompositeCollectionKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EmptyCompositeCollectionKeyTest.java
@@ -22,6 +22,7 @@ import org.hibernate.cfg.Environment;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -38,6 +39,11 @@ public class EmptyCompositeCollectionKeyTest extends BaseReactiveTest {
 		configuration.getProperties().put( Environment.CREATE_EMPTY_COMPOSITES_ENABLED, "true" );
 		configuration.addAnnotatedClass( Family.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Family" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
@@ -10,6 +10,8 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -28,6 +30,13 @@ public class FetchModeSubselectEagerTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass(Node.class);
 		configuration.addAnnotatedClass(Element.class);
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( (s, t) -> s.createQuery( "delete from Element" ).executeUpdate()
+						.thenCompose( v -> s.createQuery( "delete from Node" ).executeUpdate() ) ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
@@ -8,6 +8,8 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.annotations.Filter;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -28,6 +30,14 @@ public class FilterTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass(Node.class);
 		configuration.addAnnotatedClass(Element.class);
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Element" )
+				.thenCompose( v -> getSessionFactory()
+						.withTransaction( (s, t) -> s
+								.createQuery( "delete from Node" ).executeUpdate() ) ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyJoinedTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyJoinedTableTest.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.GeneratorType;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -48,6 +49,11 @@ public class GeneratedPropertyJoinedTableTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( GeneratedWithIdentity.class );
 		configuration.addAnnotatedClass( GeneratedRegular.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "GeneratedWithIdentity", "GeneratedRegular" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
@@ -22,6 +22,7 @@ import org.hibernate.annotations.GeneratorType;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -46,6 +47,11 @@ public class GeneratedPropertySingleTableTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( GeneratedWithIdentity.class );
 		configuration.addAnnotatedClass( GeneratedRegular.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( GeneratedWithIdentity.class, GeneratedRegular.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyUnionSubclassesTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyUnionSubclassesTest.java
@@ -23,6 +23,7 @@ import org.hibernate.annotations.GeneratorType;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -50,6 +51,11 @@ public class GeneratedPropertyUnionSubclassesTest extends BaseReactiveTest {
 		Configuration configuration = super.constructConfiguration();
 		configuration.addAnnotatedClass( GeneratedRegular.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( GeneratedRegular.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentifierGenerationTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentifierGenerationTypeTest.java
@@ -16,6 +16,7 @@ import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
+import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -34,6 +35,11 @@ public class IdentifierGenerationTypeTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( IntegerEntity.class );
 		configuration.addAnnotatedClass( ShortEntity.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( LongEntity.class, IntegerEntity.class, ShortEntity.class ) );
 	}
 
 	/*

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
@@ -9,7 +9,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
-import javax.persistence.PersistenceException;
 import javax.persistence.Table;
 
 import org.hibernate.cfg.AvailableSettings;
@@ -69,7 +68,7 @@ public class IdentityGeneratorTypeForCockroachDBTest extends BaseReactiveTest {
 		LongTypeEntity entity = new LongTypeEntity();
 
 		test( context, getMutinySessionFactory()
-				.withSession( s -> s.persist( entity ).call( s::flush ) )
+				.withTransaction( (s, tx) -> s.persist( entity ) )
 				.invoke( () -> {
 					context.assertNotNull( entity );
 					context.assertTrue( entity.id > 0 );
@@ -79,23 +78,21 @@ public class IdentityGeneratorTypeForCockroachDBTest extends BaseReactiveTest {
 
 	@Test
 	public void integerIdentityType(TestContext context) {
-		thrown.expect( PersistenceException.class );
 		thrown.expectMessage( "too big" );
 		thrown.expectMessage( "Integer" );
 
 		test( context, getMutinySessionFactory()
-				.withSession( s -> s.persist( new IntegerTypeEntity() ).call( s::flush ) )
+				.withTransaction( (s, tx) -> s.persist( new IntegerTypeEntity() ) )
 		);
 	}
 
 	@Test
 	public void shortIdentityType(TestContext context) {
-		thrown.expect( PersistenceException.class );
 		thrown.expectMessage( "too big" );
 		thrown.expectMessage( "Short" );
 
 		test( context, getMutinySessionFactory()
-				.withSession( s -> s.persist( new ShortTypeEntity() ).call( s::flush ) )
+				.withTransaction( (s, tx) -> s.persist( new ShortTypeEntity() ) )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
@@ -15,6 +15,7 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -60,6 +61,11 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( LongTypeEntity.class );
 		configuration.addAnnotatedClass( ShortTypeEntity.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( IntegerTypeEntity.class, ShortTypeEntity.class, LongTypeEntity.class ) );
 	}
 
 	private <U extends Number, T extends TypeIdentity<U>> void assertType(

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassIdentityTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassIdentityTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -24,6 +26,11 @@ public class JoinedSubclassIdentityTest extends BaseReactiveTest {
         configuration.addAnnotatedClass(GeneratedWithIdentityParent.class);
         configuration.addAnnotatedClass(GeneratedWithIdentity.class);
         return configuration;
+    }
+
+    @After
+    public void cleanDb(TestContext context) {
+        test( context, deleteEntities( "GeneratedWithIdentityParent", "GeneratedWithIdentity" ) );
     }
 
     @Test public void testParent(TestContext context) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassInheritanceTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -24,6 +26,11 @@ public class JoinedSubclassInheritanceTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( SpellBook.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
 	}
 
 	@Test
@@ -254,7 +261,7 @@ public class JoinedSubclassInheritanceTest extends BaseReactiveTest {
 		}
 	}
 
-	@Entity
+	@Entity(name = "Author")
 	@Table(name = "Author")
 	public static class Author {
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyManyToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyManyToOneAssociationTest.java
@@ -9,6 +9,8 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.DiscriminatorValue;
@@ -33,6 +35,11 @@ public class LazyManyToOneAssociationTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Book.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( Book.class, Author.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.FetchProfile;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -35,6 +37,11 @@ public class LazyOneToManyAssociationWithFetchTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( Book.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Writer", "Tome" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
@@ -246,12 +246,12 @@ public class LazyOneToManyAssociationWithFetchTest extends BaseReactiveTest {
 
 		test(
 				context,
-				completedFuture( getSessionFactory().openStatelessSession() )
+				completedFuture( openStatelessSession() )
 						.thenCompose(s -> s.insert(goodOmens)
 								.thenCompose(v -> s.insert(neilGaiman))
 								.thenCompose(v -> s.insert(terryPratchett))
 						)
-						.thenApply( v -> getSessionFactory().openStatelessSession() )
+						.thenApply( v -> openStatelessSession() )
 						.thenCompose( s -> s.get(Book.class, goodOmens.getId())
 								.thenCompose(
 										book -> s.fetch( book.getAuthors() )
@@ -276,7 +276,7 @@ public class LazyOneToManyAssociationWithFetchTest extends BaseReactiveTest {
 
 		test(
 				context,
-				completedFuture( getSessionFactory().openStatelessSession() )
+				completedFuture( openStatelessSession() )
 						.thenCompose(s -> s.insert(goodOmens)
 								.thenCompose(v -> s.insert(neilGaiman))
 								.thenCompose(v -> s.insert(terryPratchett))

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOrderedElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOrderedElementCollectionForEmbeddableTypeListTest.java
@@ -9,6 +9,8 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -50,6 +52,11 @@ public class LazyOrderedElementCollectionForEmbeddableTypeListTest extends BaseR
 		Configuration configuration = super.constructConfiguration();
 		configuration.addAnnotatedClass( Person.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Before

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultipleContextTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultipleContextTest.java
@@ -5,29 +5,44 @@
  */
 package org.hibernate.reactive;
 
-import java.util.concurrent.CompletionException;
+import java.util.concurrent.CompletableFuture;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.Rule;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Context;
 import io.vertx.core.Vertx;
+import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import org.assertj.core.api.Assertions;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
+import static org.hibernate.reactive.testing.DatabaseSelectionRule.runOnlyFor;
 
 /**
  * It's currently considered an error to share a Session between multiple reactive streams,
  * so we should detect that condition and throw an exception.
+ * <p>
+ * WARNING: Because we are running the code to test inside a function, we must create the {@link Async}
+ * in advance. Otherwise the test will end successfully because the async has not been created yet.
+ * </p>
  */
 public class MultipleContextTest extends BaseReactiveTest {
 
 	private static final String ERROR_MESSAGE = "Detected use of the reactive Session from a different Thread";
+
+	// These tests will fail before touching the database, so there is no reason
+	// to run them on all databases
+	@Rule
+	public DatabaseSelectionRule rule = runOnlyFor( POSTGRESQL );
 
 	@Override
 	protected Configuration constructConfiguration() {
@@ -37,98 +52,91 @@ public class MultipleContextTest extends BaseReactiveTest {
 	}
 
 	@Test
-	public void testPersistWithStage(TestContext testContext) throws Exception {
+	public void testPersistWithStage(TestContext testContext) {
+		Async async = testContext.async();
 		Stage.Session session = openSession();
 		Context testVertxContext = Vertx.currentContext();
 
 		// Create a different new context
-		Vertx vertx = Vertx.vertx();
-		Context newContext = vertx.getOrCreateContext();
+		Context newContext = Vertx.vertx().getOrCreateContext();
 		Assertions.assertThat( testVertxContext ).isNotEqualTo( newContext );
 
 		// Run test in the new context
-		newContext.runOnContext( event ->
-			test( testContext, session
-					.persist( new Competition( "Cheese Rolling" ) )
-					.handle( (v, e) -> {
-						testContext.assertNotNull( e );
-						testContext.assertEquals( CompletionException.class, e.getClass() );
-						testContext.assertEquals( IllegalStateException.class, e.getCause().getClass() );
-						testContext.assertTrue( e.getMessage().contains( ERROR_MESSAGE ) );
-						return null;
-					} ) )
+		newContext.runOnContext( event -> test( async, testContext, session
+				.persist( new Competition( "Cheese Rolling" ) )
+				.thenCompose( v -> session.flush() )
+				.handle( (v, e) -> assertExceptionThrown( e ).join() ) )
 		);
 	}
 
-
 	@Test
-	public void testFindWithStage(TestContext testContext) throws Exception {
+	public void testFindWithStage(TestContext testContext) {
+		Async async = testContext.async();
 		Stage.Session session = openSession();
 		Context testVertxContext = Vertx.currentContext();
 
 		// Create a different new context
-		Vertx vertx = Vertx.vertx();
-		Context newContext = vertx.getOrCreateContext();
+		Context newContext = Vertx.vertx().getOrCreateContext();
 		Assertions.assertThat( testVertxContext ).isNotEqualTo( newContext );
 
 		// Run test in the new context
-		newContext.runOnContext( event ->
-			 test( testContext, session
-					 .find( Competition.class, "Chess boxing" )
-					 .handle( (v, e) -> {
-						 testContext.assertNotNull( e );
-						 testContext.assertEquals( CompletionException.class, e.getClass() );
-						 testContext.assertEquals( IllegalStateException.class, e.getCause().getClass() );
-						 testContext.assertTrue( e.getMessage().contains( ERROR_MESSAGE ) );
-						 return null;
-					 } ) )
+		newContext.runOnContext( event -> test( async, testContext, session
+				.find( Competition.class, "Chess boxing" )
+				.handle( (v, e) -> assertExceptionThrown( e ).join() ) )
 		);
 	}
 
 	@Test
-	public void testOnPersistWithMutiny(TestContext testContext) throws Exception {
+	public void testOnPersistWithMutiny(TestContext testContext) {
+		Async async = testContext.async();
 		Mutiny.Session session = openMutinySession();
 		Context testVertxContext = Vertx.currentContext();
 
 		// Create a different new context
-		Vertx vertx = Vertx.vertx();
-		Context newContext = vertx.getOrCreateContext();
+		Context newContext = Vertx.vertx().getOrCreateContext();
 		Assertions.assertThat( testVertxContext ).isNotEqualTo( newContext );
 
 		// Run test in the new context
-		newContext.runOnContext( event ->
-			 test( testContext, session
-					 .persist( new Competition( "Cheese Rolling" ) )
-					 .onItem().invoke( v -> testContext.fail( "We were expecting an exception" ) )
-					 .onFailure().recoverWithUni( e -> {
-						 testContext.assertEquals( IllegalStateException.class, e.getClass() );
-						 testContext.assertTrue( e.getMessage().contains( ERROR_MESSAGE ) );
-						 return Uni.createFrom().voidItem();
-					 } ) )
+		newContext.runOnContext( event -> test( async, testContext, session
+				.persist( new Competition( "Cheese Rolling" ) )
+				.call( session::flush )
+				.onItemOrFailure()
+				.transformToUni( (unused, e) -> Uni.createFrom().completionStage( assertExceptionThrown( e ) ) ) )
 		);
 	}
 
 	@Test
-	public void testFindWithMutiny(TestContext testContext) throws Exception {
+	public void testFindWithMutiny(TestContext testContext) {
+		Async async = testContext.async();
 		Mutiny.Session session = openMutinySession();
 		Context testVertxContext = Vertx.currentContext();
 
 		// Create a different new context
-		Vertx vertx = Vertx.vertx();
-		Context newContext = vertx.getOrCreateContext();
+		Context newContext = Vertx.vertx().getOrCreateContext();
 		Assertions.assertThat( testVertxContext ).isNotEqualTo( newContext );
 
 		// Run test in the new context
-		newContext.runOnContext(event ->
-			 test( testContext, session
-					 .find( Competition.class, "Chess boxing" )
-					 .onItem().invoke( v -> testContext.fail( "We were expecting an exception" ) )
-					 .onFailure().recoverWithUni( e -> {
-						 testContext.assertEquals( IllegalStateException.class, e.getClass() );
-						 testContext.assertTrue( e.getMessage().contains( ERROR_MESSAGE ) );
-						 return Uni.createFrom().nullItem();
-					 } ) )
+		newContext.runOnContext( event -> test( async, testContext, session
+				.find( Competition.class, "Chess boxing" )
+				.onItemOrFailure()
+				.transformToUni( (unused, e) -> Uni.createFrom().completionStage( assertExceptionThrown( e ) ) ) )
 		);
+	}
+
+	// Check that at least one exception has the expected message
+	private static CompletableFuture<Void> assertExceptionThrown(Throwable e) {
+		CompletableFuture<Void> result = new CompletableFuture<>();
+		Throwable t = e;
+		while ( t != null ) {
+			if ( t.getClass().equals( IllegalStateException.class )
+					&& t.getMessage().contains( ERROR_MESSAGE ) ) {
+				result.complete( null );
+				return result;
+			}
+			t = t.getCause();
+		}
+		result.completeExceptionally( new AssertionError( "Expected exception not thrown. Exception thrown: " + e ) );
+		return result;
 	}
 
 	@Entity

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
@@ -9,6 +9,8 @@ import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.LockMode;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -26,6 +28,11 @@ public class MutinySessionTest extends BaseReactiveTest {
 		Configuration configuration = super.constructConfiguration();
 		configuration.addAnnotatedClass( GuineaPig.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "GuineaPig" ) );
 	}
 
 	private Uni<Void> populateDB() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
@@ -22,6 +22,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -41,6 +42,11 @@ public class OrderedEmbeddableCollectionTest extends BaseReactiveTest {
         configuration.addAnnotatedClass( Book.class );
         configuration.addAnnotatedClass( Author.class );
         return configuration;
+    }
+
+    @After
+    public void cleanDb(TestContext context) {
+        test( context, deleteEntities( "Author" ) );
     }
 
     @Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
@@ -39,7 +39,6 @@ public class OrderedEmbeddableCollectionTest extends BaseReactiveTest {
     @Override
     protected Configuration constructConfiguration() {
         Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
         configuration.addAnnotatedClass( Author.class );
         return configuration;
     }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
@@ -8,6 +8,8 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.containers.DatabaseConfiguration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.ColumnResult;
@@ -47,6 +49,11 @@ public class QueryTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass(Author.class);
 		configuration.addAnnotatedClass(Book.class);
 		return configuration;
+	}
+
+	@After
+	public void cleanDB(TestContext context) {
+		test( context, deleteEntities( "Book", "Author" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -11,6 +11,8 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.common.AffectedEntities;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -48,15 +50,9 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				.withSession( session -> session.createQuery( "delete GuineaPig" ).executeUpdate() );
 	}
 
-	public void after(TestContext context) {
-		test( context,
-			  cleanDB()
-				.whenComplete( (res, err) -> {
-					// in case cleanDB() fails we
-					// still have to close the factory
-					super.after( context );
-				} )
-		);
+	@After
+	public void cleanDB(TestContext context) {
+		test( context, deleteEntities( "GuineaPig" ) );
 	}
 
 	private CompletionStage<String> selectNameFromId(Integer id) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
@@ -8,6 +8,8 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -26,6 +28,11 @@ public class ReactiveStatelessSessionTest extends BaseReactiveTest {
 		Configuration configuration = super.constructConfiguration();
 		configuration.addAnnotatedClass( GuineaPig.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "GuineaPig" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
@@ -38,7 +38,7 @@ public class ReactiveStatelessSessionTest extends BaseReactiveTest {
 	@Test
 	public void testStatelessSession(TestContext context) {
 		GuineaPig pig = new GuineaPig("Aloi");
-		Stage.StatelessSession ss = getSessionFactory().openStatelessSession();
+		Stage.StatelessSession ss = openStatelessSession();
 		test(
 				context,
 				ss.insert(pig)
@@ -135,6 +135,7 @@ public class ReactiveStatelessSessionTest extends BaseReactiveTest {
 						.thenAccept( rows -> context.assertEquals(1, rows) )
 						.thenCompose( v -> ss.createQuery(delete).executeUpdate() )
 						.thenAccept( rows -> context.assertEquals(1, rows) )
+						.thenAccept( v -> ss.close() )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SecondaryTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SecondaryTableTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -23,6 +25,11 @@ public class SecondaryTableTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( SecondaryTableTest.Book.class );
 		configuration.addAnnotatedClass( SecondaryTableTest.Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( Book.class, Author.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SingleTableInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SingleTableInheritanceTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -25,6 +27,11 @@ public class SingleTableInheritanceTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( SingleTableInheritanceTest.SpellBook.class );
 		configuration.addAnnotatedClass( SingleTableInheritanceTest.Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
 	}
 
 	@Test
@@ -271,7 +278,7 @@ public class SingleTableInheritanceTest extends BaseReactiveTest {
 		}
 	}
 
-	@Entity
+	@Entity(name="Author")
 	@Table(name = Author.TABLE)
 	public static class Author {
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectElementCollectionForEmbeddableTypeListTest.java
@@ -11,6 +11,8 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -71,6 +73,11 @@ public class SubselectElementCollectionForEmbeddableTypeListTest extends BaseRea
 		test( context, session.persist( p1, p2, p3 )
 				.thenCompose( v -> session.flush() )
 		);
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnionSubclassInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnionSubclassInheritanceTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
@@ -24,6 +26,11 @@ public class UnionSubclassInheritanceTest extends BaseReactiveTest {
 		configuration.addAnnotatedClass( SpellBook.class );
 		configuration.addAnnotatedClass( Author.class );
 		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
 	}
 
 	@Test
@@ -254,7 +261,7 @@ public class UnionSubclassInheritanceTest extends BaseReactiveTest {
 		}
 	}
 
-	@Entity
+	@Entity(name = "Author")
 	@Table(name = "AuthorUS")
 	public static class Author {
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SessionFactoryManager.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SessionFactoryManager.java
@@ -1,0 +1,53 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.testing;
+
+import java.util.function.Supplier;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.reactive.pool.ReactiveConnectionPool;
+
+/**
+ * Managed the creation of a {@link SessionFactory} that can shared among tests.
+ */
+public class SessionFactoryManager {
+
+	private SessionFactory sessionFactory;
+	private ReactiveConnectionPool poolProvider;
+
+	public SessionFactoryManager() {
+	}
+
+	private boolean needsStart() {
+		return sessionFactory == null || sessionFactory.isClosed();
+	}
+
+	public void start(Supplier<SessionFactory> supplier) {
+		if ( needsStart() ) {
+			sessionFactory = supplier.get();
+			poolProvider = sessionFactory
+					.unwrap( SessionFactoryImplementor.class )
+					.getServiceRegistry().getService( ReactiveConnectionPool.class );
+		}
+	}
+
+	public SessionFactory getHibernateSessionFactory() {
+		return sessionFactory;
+	}
+
+	public ReactiveConnectionPool getReactiveConnectionPool() {
+		return poolProvider;
+	}
+
+	public void stop() {
+		if ( sessionFactory != null && sessionFactory.isOpen() ) {
+			sessionFactory.close();
+		}
+		poolProvider = null;
+		sessionFactory = null;
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JoinColumnsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JoinColumnsTest.java
@@ -43,11 +43,7 @@ public class JoinColumnsTest extends BaseReactiveTest {
 
 	@After
 	public void cleanDB(TestContext context) {
-		test( context, getMutinySessionFactory()
-				.withSession( session -> session
-						.createQuery( "delete SampleJoinEntity" ).executeUpdate()
-						.invoke( ignore -> session
-								.createQuery( "delete SampleEntity" ).executeUpdate() ) ) );
+		test( context, deleteEntities( "SampleJoinEntity", "SampleEntity" ) );
 	}
 
 	@Test


### PR DESCRIPTION
Fixes #487

Work on this with @blafond.

Now the test will create the factory once per test class. This saves some time with dbs like Db2 or CockroachDB.
The only issues I had is that some times tests get stuck but I couldn't figure out why. Refactoring some tests so that they now
use transaction solved the issues most of time.

> If you do this, make sure that you recreate the factory after any test failure. Otherwise, the failure of one test method would have a cascading effect on all the other tests in that class (because its data won't be cleaned up).

@gavinking. do we really need to do this? The `cleanDb` method is called even when there is a failure. I suppose we could reset the factory if there is a problem deleting the entities but we don't have that many tests in a single class so I don't think it would be a problem. The reason I would prefer not to do it is because the only place I could do something like this is after the `deleteEntities` method has been called. I might thinkg of a better solution later.

For some reasons, this test doesn't work with Db2: https://github.com/hibernate/hibernate-reactive/compare/main...DavideD:487-sf-per-class?expand=1#diff-659762d6654e6fae801ebfcf7577499a86f6799bd9ce7948922726acc994fbab
Unless I recreate the factory each time.

I've also removed JUnit 5, in the end we don't need it and having both dependencies on the classpath might only causes issues.
I might add it back in the future if they add an extension that's now missing in vertx-junit-5