### PR TITLE
Use correct configuration with depenedencyInsight

### DIFF
--- a/.github/workflows/tracking-vertx-3.build.yml
+++ b/.github/workflows/tracking-vertx-3.build.yml
@@ -69,7 +69,7 @@ jobs:
           java-version: 1.8
         uses: actions/setup-java@v1
       - name: Print the effective Vert.x version used
-        run: ./gradlew :hibernate-reactive-core:dependencyInsight --dependency io.vertx -PvertxVersion='${{ matrix.vertx-version }}'
+        run: ./gradlew :${{ matrix.example }}:dependencyInsight --dependency io.vertx --configuration runtimeClasspath -PvertxVersion='${{ matrix.vertx-version }}'
       - name: Run examples in '${{ matrix.example }}' on ${{ matrix.db }}
         run: ./gradlew :${{ matrix.example }}:runAllExamplesOn${{ matrix.db }} -PvertxVersion='${{ matrix.vertx-version }}'
 


### PR DESCRIPTION
We couldn't see the right Vert.x version used because
we were checking the wrong configuration.