### PR TITLE
[POC] New strategy to fire events

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.4.32-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '5.4.31.Final'
+        hibernateOrmVersion = '5.5.0-SNAPSHOT'
     }
     // For ORM, we need a parsed version (to get the family, ...)
 
@@ -120,7 +120,7 @@ subprojects {
 
     repositories {
         // Only enable these for local development, never push it:
-        // mavenLocal()
+        mavenLocal()
         // jcenter()
         // Example: ./gradlew build -PenableSonatypeOpenSourceSnapshotsRep
         if ( project.hasProperty('enableSonatypeOpenSourceSnapshotsRep') ) {

--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -20,7 +20,7 @@ dependencies {
 
 buildscript {
     repositories {
-//        mavenLocal()
+        mavenLocal()
         mavenCentral()
 
         // Example: ./gradlew build -PenableJBossSnapshotsRep

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -25,7 +25,7 @@ dependencies {
 
 buildscript {
     repositories {
-//        mavenLocal()
+        mavenLocal()
         mavenCentral()
 
         // Example: ./gradlew build -PenableJBossSnapshotsRep

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/QueryParametersAdaptor.java
@@ -11,7 +11,11 @@ import org.hibernate.param.ParameterSpecification;
 import org.hibernate.type.Type;
 
 
-public class QueryParametersAdaptor {
+public final class QueryParametersAdaptor {
+
+	private QueryParametersAdaptor() {
+		//do not construct
+	}
 
 	public static Object[] arguments(QueryParameters queryParameters,
 									 SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoaderBasedResultSetProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoaderBasedResultSetProcessor.java
@@ -14,12 +14,9 @@ import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.RowSelection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.event.spi.EventType;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PreLoadEvent;
-import org.hibernate.event.spi.PreLoadEventListener;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.loader.plan.exec.query.spi.NamedParameterContext;
@@ -47,16 +44,9 @@ public class ReactiveLoaderBasedResultSetProcessor implements ReactiveResultSetP
 	protected static final CoreMessageLogger LOG = CoreLogging.messageLogger(ReactiveLoaderBasedResultSetProcessor.class);
 
 	private final ReactiveLoaderBasedLoader loader;
-	private final Iterable<PreLoadEventListener> listeners;
 
 	public ReactiveLoaderBasedResultSetProcessor(ReactiveLoaderBasedLoader loader) {
 		this.loader = loader;
-		this.listeners = loader
-				.getFactory()
-				.getServiceRegistry()
-				.getService(EventListenerRegistry.class)
-				.getEventListenerGroup(EventType.PRE_LOAD)
-				.listeners();
 	}
 
 	/**
@@ -149,7 +139,7 @@ public class ReactiveLoaderBasedResultSetProcessor implements ReactiveResultSetP
 
 			stage = CompletionStages.loop(
 					hydratedObjects,
-					hydratedObject -> initializeEntity( hydratedObject, readOnly, session, pre, listeners )
+					hydratedObject -> initializeEntity( hydratedObject, readOnly, session, pre )
 			);
 		}
 		else {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
@@ -16,7 +16,6 @@ import org.hibernate.engine.spi.QueryParameters;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.PreLoadEvent;
-import org.hibernate.event.spi.PreLoadEventListener;
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 import org.hibernate.loader.plan.exec.query.spi.NamedParameterContext;
@@ -60,8 +59,7 @@ public interface ReactiveResultSetProcessor {
 			final Object entity,
 			final boolean readOnly,
 			final SharedSessionContractImplementor session,
-			final PreLoadEvent preLoadEvent,
-			Iterable<PreLoadEventListener> listeners) {
+			final PreLoadEvent preLoadEvent) {
 		final PersistenceContext persistenceContext = session.getPersistenceContext();
 		final EntityEntry entityEntry = persistenceContext.getEntry(entity);
 		if (entityEntry == null) {
@@ -94,8 +92,7 @@ public interface ReactiveResultSetProcessor {
 						entityEntry,
 						readOnly,
 						session,
-						preLoadEvent,
-						listeners
+						preLoadEvent
 				)
 		);
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/entity/impl/ReactivePlanEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/entity/impl/ReactivePlanEntityLoader.java
@@ -241,7 +241,7 @@ public class ReactivePlanEntityLoader extends AbstractLoadPlanBasedEntityLoader
 			? getStaticLoadQuery().getSqlStatement()
 			: processedSQL;
 
-		return doReactiveQueryAndInitializeNonLazyCollections( sql, (SharedSessionContractImplementor) session, parameters )
+		return doReactiveQueryAndInitializeNonLazyCollections( sql, session, parameters )
 				.thenApply( results -> extractEntityResult( results, id ) )
 				.handle( (list, err) -> {
 					logSqlException( err,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/entity/impl/ReactivePlanEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/entity/impl/ReactivePlanEntityLoader.java
@@ -15,7 +15,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.event.spi.PostLoadEvent;
 import org.hibernate.event.spi.PreLoadEvent;
-import org.hibernate.event.spi.PreLoadEventListener;
 import org.hibernate.loader.entity.plan.AbstractLoadPlanBasedEntityLoader;
 import org.hibernate.loader.plan.exec.internal.EntityLoadQueryDetails;
 import org.hibernate.loader.plan.exec.process.internal.AbstractRowReader;
@@ -437,20 +436,13 @@ public class ReactivePlanEntityLoader extends AbstractLoadPlanBasedEntityLoader
 
 			final SharedSessionContractImplementor session = context.getSession();
 
-			final Iterable<PreLoadEventListener> listeners = session
-					.getFactory()
-					.getFastSessionServices()
-					.eventListenerGroup_PRE_LOAD
-					.listeners();
-
 			return CompletionStages.loop(
 					hydratedEntityRegistrations,
 					registration -> resultSetProcessor.initializeEntity(
 							registration.getInstance(),
 							false,
 							session,
-							preLoadEvent,
-							listeners
+							preLoadEvent
 					)
 			);
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveEventGroup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveEventGroup.java
@@ -1,0 +1,2 @@
+package org.hibernate.reactive.session.impl;public class ReactiveEventGroup {
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveEventGroup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveEventGroup.java
@@ -1,2 +1,0 @@
-package org.hibernate.reactive.session.impl;public class ReactiveEventGroup {
-}


### PR DESCRIPTION

also requires changes in ORM core: https://github.com/hibernate/hibernate-orm/commit/17ef565fa6db5a5045bfdbd64598ba47a314c521

This gets Hibernate Reactive to use a similar optimisation as we recently did for ORM core, which is to delegate the details of iteration to the implementation of the `EventListenerGroup`.

This reduces the runtime overhead significantly; as it:
- needs no lookup of the right ListenerGroups by type
- doesn't need enumerating / iterating on each listener list
- doesn't need defensive copies of such iterators, yet encapsulates safely
- allows to skip creating the Event object for empty listener groups (useful for some groups only)
- less code :)