### PR TITLE
[#780] Fix driver discovery issue

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -174,6 +174,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 					if ( "db2".equalsIgnoreCase( scheme ) ) {
 						return d;
 					}
+					break;
 				case "io.vertx.mysqlclient.spi.MySQLDriver":
 					if ( "mysql".equalsIgnoreCase( scheme ) ) {
 						return d;
@@ -181,6 +182,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 					if ( "mariadb".equalsIgnoreCase( scheme ) ) {
 						return d;
 					}
+					break;
 				case "io.vertx.pgclient.spi.PgDriver":
 					if ( "postgre".equalsIgnoreCase( scheme ) ||
 							"postgres".equalsIgnoreCase( scheme ) ||
@@ -190,6 +192,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 					if ( "cockroachdb".equalsIgnoreCase( scheme ) ) {
 						return d;
 					}
+					break;
 			}
 		}
 		throw new ConfigurationException( "No suitable drivers found for URI scheme: " + scheme, originalError );


### PR DESCRIPTION
Fixes #780 

If there are multiple drivers in the classpath,
we sometimes select the wrong one.

We didn't notice before because it might not happen
if the drivers are discovered in the right order.

