### PR TITLE
Updates dependencies for JBang examples

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -26,7 +26,7 @@ dependencies {
     implementation "io.vertx:vertx-sql-client:${vertxVersion}"
 
     // Testing
-    testImplementation 'org.assertj:assertj-core:3.13.2'
+    testImplementation 'org.assertj:assertj-core:3.19.0'
     testImplementation "io.vertx:vertx-unit:${vertxVersion}"
 
     // Drivers

--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -3,7 +3,7 @@
   "aliases": {
     "example": {
       "script-ref": "tooling/jbang/Example.java",
-      "description": "An application example. Starts PostgreSQL using Testcontainers and Docker"
+      "description": "An application example. The database must be available before running it. See https://github.com/hibernate/hibernate-reactive/blob/main/podman.md"
     },
     "testcase": {
       "script-ref": "tooling/jbang/ReactiveTest.java",

--- a/tooling/jbang/Example.java
+++ b/tooling/jbang/Example.java
@@ -5,10 +5,6 @@
  */
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.0.CR2}
-//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.0.CR2}
-//DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.0.CR2}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:1.0.0.CR5}
 //DEPS org.testcontainers:postgresql:1.15.3
 //DEPS org.testcontainers:mysql:1.15.3
 //DEPS org.testcontainers:db2:1.15.3
@@ -21,6 +17,10 @@
 //DEPS mysql:mysql-connector-java:8.0.25
 //DEPS org.mariadb.jdbc:mariadb-java-client:2.7.3
 //
+//DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.0}
+//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.0}
+//DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.0}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:1.0.0.CR6}
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -5,13 +5,13 @@
  */
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.0.CR2}
-//DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.0.CR2}
-//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.0.CR2}
-//DEPS io.vertx:vertx-unit:${vertx.version:4.1.0.CR2}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:1.0.0.CR5}
-//DEPS org.assertj:assertj-core:3.13.2
-//DEPS junit:junit:4.12
+//DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.0}
+//DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.0}
+//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.0}
+//DEPS io.vertx:vertx-unit:${vertx.version:4.1.0}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:1.0.0.CR6}
+//DEPS org.assertj:assertj-core:3.19.0
+//DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:postgresql:1.15.3
 //DEPS org.testcontainers:mysql:1.15.3
 //DEPS org.testcontainers:db2:1.15.3


### PR DESCRIPTION
I think it's better if one example doesn't require testcontainer, even if it means starting a database manually.
The other example still uses docker.

It also updates assertJ