### PR TITLE
Adds jbang template to create reproducers

### DIFF
--- a/jbang-catalog.json
+++ b/jbang-catalog.json
@@ -9,5 +9,12 @@
       "script-ref": "tooling/jbang/ReactiveTest.java",
       "description": "A Hibernate Reactive JUnit test using Docker, Testcontainers and Vert.x Unit"
     }
+  },
+  "templates": {
+    "reproducer": {
+      "file-refs": {
+        "{basename}.java": "tooling/jbang/ReactiveTestTemplate.java.qute"
+      }
+    }
   }
 }

--- a/tooling/jbang/Example.java
+++ b/tooling/jbang/Example.java
@@ -1,14 +1,15 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
 /* Hibernate, Relational Persistence for Idiomatic Java
  *
  * SPDX-License-Identifier: LGPL-2.1-or-later
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.0}
 //DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.0}
 //DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.0}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:1.0.0.CR6}
+//DEPS org.slf4j:slf4j-simple:1.7.30
 
 import java.time.LocalDate;
 import java.util.ArrayList;

--- a/tooling/jbang/ReactiveTestTemplate.java.qute
+++ b/tooling/jbang/ReactiveTestTemplate.java.qute
@@ -1,0 +1,250 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+
+//DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.1.0}
+//DEPS io.vertx:vertx-db2-client:$\{vertx.version:4.1.0}
+//DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.1.0}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.1.0}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:1.0.0.CR6}
+//DEPS org.assertj:assertj-core:3.19.0
+//DEPS junit:junit:4.13.2
+//DEPS org.testcontainers:postgresql:1.15.3
+//DEPS org.testcontainers:mysql:1.15.3
+//DEPS org.testcontainers:db2:1.15.3
+//DEPS org.testcontainers:mariadb:1.15.3
+//DEPS org.testcontainers:cockroachdb:1.15.3
+//DEPS org.slf4j:slf4j-simple:1.7.30
+//// Testcontainer needs the JDBC drivers to start the containers
+//// Hibernate Reactive doesn't use them
+//DEPS org.postgresql:postgresql:42.2.16
+//DEPS mysql:mysql-connector-java:8.0.25
+//DEPS org.mariadb.jdbc:mariadb-java-client:2.7.3
+//
+
+import java.util.function.Supplier;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder;
+import org.hibernate.reactive.provider.Settings;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.testcontainers.containers.CockroachContainer;
+import org.testcontainers.containers.Db2Container;
+import org.testcontainers.containers.JdbcDatabaseContainer;
+import org.testcontainers.containers.MariaDBContainer;
+import org.testcontainers.containers.MySQLContainer;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+//DESCRIPTION An example of a JUnit test class for Hibernate Reactive using
+//DESCRIPTION [Vert.x Unit](https://vertx.io/docs/vertx-unit/java) and
+//DESCRIPTION [Testcontainers](https://www.testcontainers.org)
+//DESCRIPTION that you can run using [JBang](JBang).
+//DESCRIPTION 
+//DESCRIPTION Before running the tests, Testcontainers will start the selected
+//DESCRIPTION Docker image with the required database created.
+//DESCRIPTION 
+//DESCRIPTION The `DATABASE` constant define which database to use and
+//DESCRIPTION it can be change to any of the values in `Database`.
+//DESCRIPTION 
+//DESCRIPTION Usage example:
+//DESCRIPTION   1. Use as jbang template `jbang init -t reproducer@hibernate/hibernate-reactive mytest.java`
+//DESCRIPTION   2. Run the test with JBang: `jbang mytest.java`
+//DESCRIPTION   3. (Optional) Edit the file (with IntelliJ IDEA for example):
+//DESCRIPTION             jbang edit --live --open=idea SampleIssueTest.java
+@RunWith(VertxUnitRunner.class)
+public class {baseName} {
+
+	/**
+	 * The database to use for the tests
+	 */
+	public final static Database DATABASE = Database.POSTGRESQL;
+
+	private static JdbcDatabaseContainer<?> container;
+
+	private Mutiny.SessionFactory sessionFactory;
+
+	@BeforeClass
+	public static void startContainer() {
+		container = DATABASE.startContainer();
+	}
+
+	/**
+	 * The {@link Configuration} for the {@link Mutiny.SessionFactory}.
+	 */
+	private Configuration createConfiguration() {
+		Configuration configuration = new Configuration();
+
+		// JDBC url
+		configuration.setProperty( Settings.URL, container.getJdbcUrl() );
+
+		// Credentials
+		configuration.setProperty( Settings.USER, container.getUsername() );
+		configuration.setProperty( Settings.PASS, container.getPassword() );
+
+		// Schema generation. Supported values are create, drop, create-drop, drop-create, none
+		configuration.setProperty( Settings.HBM2DDL_AUTO, "create" );
+
+		// Register new entity classes here
+		configuration.addAnnotatedClass( MyEntity.class );
+
+		// (Optional) Log the SQL queries
+		configuration.setProperty( Settings.SHOW_SQL, "true" );
+		configuration.setProperty( Settings.HIGHLIGHT_SQL, "true" );
+		configuration.setProperty( Settings.FORMAT_SQL, "true" );
+		return configuration;
+	}
+
+	/*
+	 * Create a new factory and a new schema before each test (see
+	 * property `hibernate.hbm2ddl.auto`).
+	 * This way each test will start with a clean database.
+	 *
+	 * The drawback is that, in a real case scenario with multiple tests,
+	 * it can slow down the whole test suite considerably. If that happens,
+	 * it's possible to make the session factory static and, if necessary,
+	 * delete the content of the tables manually (without dropping them).
+	 */
+	@Before
+	public void createSessionFactory() {
+		Configuration configuration = createConfiguration();
+		StandardServiceRegistryBuilder builder = new ReactiveServiceRegistryBuilder()
+				.applySettings( configuration.getProperties() );
+		StandardServiceRegistry registry = builder.build();
+
+		sessionFactory = configuration.buildSessionFactory( registry )
+				.unwrap( Mutiny.SessionFactory.class );
+	}
+
+	@Test
+	public void testInsertAndSelect(TestContext context) {
+		// the test will wait until async.complete or context.fail are called
+		Async async = context.async();
+
+		MyEntity entity = new MyEntity( "first entity", 1 );
+		sessionFactory
+				// insert the entity in the database
+				.withTransaction( (session, tx) -> session.persist( entity ) )
+				.chain( () -> sessionFactory
+						.withSession( session -> session
+								// look for the entity by id
+								.find( MyEntity.class, entity.getId() )
+								// assert that the returned entity is the right one
+								.invoke( foundEntity -> assertThat( foundEntity.getName() ).isEqualTo( entity.getName() ) ) ) )
+				.subscribe()
+				.with( res -> async.complete(), context::fail );
+	}
+
+	@After
+	public void closeFactory() {
+		if ( sessionFactory != null ) {
+			sessionFactory.close();
+		}
+	}
+
+	/**
+	 * Example of a class representing an entity.
+	 * <p>
+	 * If you create new entities, be sure to add them in {@link #createConfiguration()}.
+	 * For example:
+	 * <pre>
+	 * configuration.addAnnotatedClass( MyOtherEntity.class );
+	 * </pre>
+	 */
+	@Entity(name = "MyEntity")
+	public static class MyEntity {
+		@Id
+		public Integer id;
+
+		public String name;
+
+		public MyEntity() {
+		}
+
+		public MyEntity(String name, Integer id) {
+			this.name = name;
+			this.id = id;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		@Override
+		public String toString() {
+			return "MyEntity"
+					+ "\n\t id = " + id
+					+ "\n\t name = " + name;
+		}
+	}
+
+	/**
+	 * The only purpose of this class is to make it easier to switch among the available databases
+	 * for this unit test.
+	 * <p>
+	 * It's a wrapper around the testcontainers classes.
+	 */
+	enum Database {
+		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:13.2" ) ),
+		MYSQL( () -> new MySQLContainer( "mysql:8.0.25" ) ),
+		MARIADB( () -> new MariaDBContainer( "mariadb:10.5.10" ) ),
+		DB2( () -> new Db2Container( "ibmcom/db2:11.5.5.1" ).acceptLicense() ),
+		COCKROACHDB( () -> new CockroachContainer( "cockroachdb/cockroach:v21.1.1" ) );
+
+		private final Supplier<JdbcDatabaseContainer<?>> containerSupplier;
+
+		Database(Supplier<JdbcDatabaseContainer<?>> supplier) {
+			containerSupplier = supplier;
+		}
+
+		public JdbcDatabaseContainer<?> startContainer() {
+			JdbcDatabaseContainer<?> jdbcDatabaseContainer = containerSupplier.get();
+			jdbcDatabaseContainer
+					.withReuse( true )
+					.start();
+			return jdbcDatabaseContainer;
+		}
+	}
+
+	// This main class is only for JBang so that it can run the tests with `jbang ReactiveTest`
+	public static void main(String[] args) {
+		System.out.println( "Starting the test suite with " + DATABASE );
+
+		Result result = JUnitCore.runClasses( {baseName}.class );
+
+		for ( Failure failure : result.getFailures() ) {
+			System.out.println();
+			System.err.println( "Test " + failure.getTestHeader() + " FAILED!" );
+			System.err.println( "\t" + failure.getTrace() );
+		}
+
+		System.out.println();
+		System.out.print("Tests result summary: ");
+		System.out.println( result.wasSuccessful() ? "SUCCESS" : "FAILURE" );
+	}
+}


### PR DESCRIPTION
With this you just do `jbang init -t reproducer@hibernate/hibernate-reactive mytest`
and you will have a `mytest.java`. 

Advantage is you can create any number of reproducers and you get your own file rather than 
editing the file in jbang's internal cache.


Other fixes:
- move #! at top of file as otherwise it breaks ability to run it directly.
- add simple sl4j to get useful output rather than warnings. you can also use sl4fj-nop if you just want it quite.

