### PR TITLE
Improve loop performance

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
@@ -32,7 +32,6 @@ import org.hibernate.type.ForeignKeyDirection;
 import org.hibernate.type.Type;
 
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -554,9 +553,10 @@ public final class Cascade<C> {
 		final Collection<?> orphans;
 		if ( pc.wasInitialized() ) {
 			final CollectionEntry ce = eventSource.getPersistenceContextInternal().getCollectionEntry( pc );
-			orphans = ce==null
-					? Collections.EMPTY_LIST
-					: ce.getOrphans( entityName, pc );
+			if ( ce == null ) {
+				return;
+			}
+			orphans = ce.getOrphans( entityName, pc );
 		}
 		else {
 			orphans = pc.getQueuedOrphans( entityName );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -14,7 +14,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
-import java.util.stream.IntStream;
 import javax.persistence.metamodel.Attribute;
 
 import org.hibernate.AssertionFailure;
@@ -502,16 +501,15 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 		}
 
 		Object[] state = loadedState;
-		return loop(
-				IntStream.iterate(span-1, (i) -> i-1 ).limit( span ),
-				table -> deleteReactive(
-						id,
-						version,
-						table,
-						deleteStrings[table],
-						session,
-						state
-				)
+		return loop( 0, span,
+					 table -> deleteReactive(
+							 id,
+							 version,
+							 span - table - 1,
+							 deleteStrings[span - table - 1],
+							 session,
+							 state
+					 )
 		);
 	}
 
@@ -729,8 +727,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 		}
 
 		// Now update only the tables with dirty properties (and the table with the version number)
-		return loop(
-				IntStream.range(0, span).filter( i-> tableUpdateNeeded[i] ),
+		return loop( 0, span, i-> tableUpdateNeeded[i],
 				table -> updateOrInsertReactive(
 						id,
 						fields,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -5,21 +5,25 @@
  */
 package org.hibernate.reactive.util.impl;
 
-import com.ibm.asyncutil.iteration.AsyncIterator;
-import com.ibm.asyncutil.iteration.AsyncTrampoline;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import java.util.function.IntPredicate;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+
 import org.hibernate.internal.CoreLogging;
 import org.hibernate.internal.CoreMessageLogger;
 
-import java.util.Arrays;
-import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-import java.util.function.Supplier;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
+import com.ibm.asyncutil.iteration.AsyncIterator;
+
+import static com.ibm.asyncutil.iteration.AsyncTrampoline.asyncWhile;
 
 public class CompletionStages {
 
@@ -31,6 +35,22 @@ public class CompletionStages {
 	private static final CompletionStage<Integer> ZERO = completedFuture( 0 );
 	private static final CompletionStage<Boolean> TRUE = completedFuture( true );
 	private static final CompletionStage<Boolean> FALSE = completedFuture( false );
+
+	private static <T> boolean alwaysTrue(T o, int index) {
+		return true;
+	}
+
+	private static boolean alwaysTrue(int index) {
+		return true;
+	}
+
+	private static boolean alwaysTrue(Object o) {
+		return true;
+	}
+
+	private static CompletionStage<Boolean> alwaysContinue(Object ignored) {
+		return TRUE;
+	}
 
 	public static CompletionStage<Void> voidFuture(Object ignore) {
 		return voidFuture();
@@ -101,7 +121,7 @@ public class CompletionStages {
 	 * }
 	 * </pre>
 	 */
-	public static <T> CompletionStage<Integer> total(int start, int end, Function<Integer,CompletionStage<Integer>> consumer) {
+	public static CompletionStage<Integer> total(int start, int end, IntFunction<CompletionStage<Integer>> consumer) {
 		return AsyncIterator.range( start, end )
 				.thenCompose( i -> consumer.apply( i.intValue() ) )
 				.fold( 0, Integer::sum );
@@ -131,7 +151,7 @@ public class CompletionStages {
 	 * }
 	 * </pre>
 	 */
-	public static <T> CompletionStage<Integer> total(T[] array, Function<T,CompletionStage<Integer>> consumer) {
+	public static <T> CompletionStage<Integer> total(T[] array, Function<T, CompletionStage<Integer>> consumer) {
 		return total( 0, array.length, index -> consumer.apply( array[index] ) );
 	}
 
@@ -143,36 +163,119 @@ public class CompletionStages {
 	 * }
 	 * </pre>
 	 */
-	public static <T> CompletionStage<Void> loop(T[] array, Function<T,CompletionStage<?>> consumer) {
-		return loop( Arrays.stream(array), consumer );
+	public static <T> CompletionStage<Void> loop(T[] array, Function<T, CompletionStage<?>> consumer) {
+		return loop( 0, array.length, index -> consumer.apply( array[index] ) );
 	}
 
 	/**
 	 * Equivalent to:
 	 * <pre>
-	 * while( iterator.hasNext() ) {
-	 *   consumer.apply( iterator.next() );
+	 * for ( int i = start; i < end; i++ ) {
+	 *   if ( filter.test(i) )  {
+	 *   	consumer.apply( i );
+	 *   }
 	 * }
 	 * </pre>
 	 */
-	public static <T> CompletionStage<Void> loop(Iterator<T> iterator, BiFunction<T,Integer,CompletionStage<?>> consumer) {
-		if ( iterator.hasNext() ) {
-			AtomicInteger index = new AtomicInteger( 0 );
-			return AsyncTrampoline.asyncWhile( () -> consumer.apply( iterator.next(), index.getAndIncrement() )
-					.thenApply( r -> iterator.hasNext() ));
-		}
-		else {
-			return voidFuture();
-		}
+	public static <T> CompletionStage<Void> loop(T[] array, IntPredicate filter, IntFunction<CompletionStage<?>> consumer) {
+		return loop( 0, array.length, filter, consumer );
 	}
 
-	public static <T> CompletionStage<Void> loop(Iterator<T> iterator, Function<T,CompletionStage<?>> consumer) {
+	/**
+	 * Equivalent to:
+	 * <pre>
+	 * int index = 0
+	 * while( iterator.hasNext() ) {
+	 *   consumer.apply( iterator.next(), index++ );
+	 * }
+	 * </pre>
+	 */
+	public static <T> CompletionStage<Void> loop(Iterator<T> iterator, IntBiFunction<T, CompletionStage<?>> consumer) {
+		return loop( iterator, CompletionStages::alwaysTrue, consumer );
+	}
+	/**
+	 * Equivalent to:
+	 * <pre>
+	 * int index = -1
+	 * while( iterator.hasNext() ) {
+	 *   index++
+	 *   T next = iterator.next();
+	 *   if (filter.test( next, index ) {
+	 *     consumer.apply( next, index );
+	 *   }
+	 * }
+	 * </pre>
+	 */
+	public static <T> CompletionStage<Void> loop(Iterator<T> iterator, IntBiPredicate<T> filter, IntBiFunction<T, CompletionStage<?>> consumer) {
 		if ( iterator.hasNext() ) {
-			return AsyncTrampoline.asyncWhile( () -> consumer.apply( iterator.next() )
-					.thenApply( r -> iterator.hasNext() ));
+			final IndexedIteratorLoop<T> loop = new IndexedIteratorLoop<>( iterator, filter, consumer );
+			return asyncWhile( loop::next );
 		}
-		else {
-			return voidFuture();
+		return voidFuture();
+	}
+
+	/**
+	 * It represents a loop on an iterator that requires
+	 * an index of the current element.
+	 * <p>
+	 * Equivalent to:
+	 * <pre>
+	 *   int index = -1
+	 * 	 while( iterator.hasNext() ) {
+	 * 	   index++
+	 * 	   T next = iterator.next();
+	 * 	   if (filter.test( next, index ) {
+	 * 	     consumer.apply( next, index );
+	 * 	   }
+	 * 	 }
+	 * </pre>
+	 * </p>
+	 * <p>
+	 * This class keeps track of the state of the loop, allowing us to
+	 * use an {@code AsyncTrampoline#asyncWhile} via method reference.
+	 * </p>
+	 * @see com.ibm.asyncutil.iteration.AsyncTrampoline
+	 * @param <T> the class of the elements in the iterator
+	 */
+	private static class IndexedIteratorLoop<T> {
+		private final IntBiPredicate<T> filter;
+		private final IntBiFunction<T, CompletionStage<?>> consumer;
+		private final Iterator<T> iterator;
+		private int currentIndex = -1;
+		private T currentEntry;
+
+		public IndexedIteratorLoop(Iterator<T> iterator, IntBiPredicate<T> filter, IntBiFunction<T, CompletionStage<?>> consumer) {
+			this.iterator = iterator;
+			this.filter = filter;
+			this.consumer = consumer;
+		}
+
+		public CompletionStage<Boolean> next() {
+			if ( hasNext() ) {
+				final T entry = currentEntry;
+				final int index = currentIndex;
+				return consumer.apply( entry, index )
+						.thenCompose( CompletionStages::alwaysContinue );
+			}
+			return FALSE;
+		}
+
+		// Skip all the indexes not matching the filter
+		private boolean hasNext() {
+			int index = currentIndex;
+			T next = currentEntry;
+			boolean hasNext = false;
+			while ( iterator.hasNext() ) {
+				next = iterator.next();
+				index++;
+				if ( filter.test( next, index ) ) {
+					hasNext = true;
+					break;
+				}
+			}
+			this.currentEntry = next;
+			this.currentIndex = index;
+			return hasNext;
 		}
 	}
 
@@ -184,34 +287,35 @@ public class CompletionStages {
 	 * }
 	 * </pre>
 	 */
-	public static <T> CompletionStage<Void> loop(Iterable<T> iterable, Function<T,CompletionStage<?>> consumer) {
-		return loop( iterable.iterator(), consumer );
+	public static <T> CompletionStage<Void> loop(Collection<T> collection, Function<T, CompletionStage<?>> consumer) {
+		return loop( collection, CompletionStages::alwaysTrue, consumer );
 	}
 
 	/**
-	 * Equivalent to:
-	 * <pre>
-	 * Iterator iterator = stream.iterator();
-	 * while( iterator.hasNext()) {
-	 *   consumer.apply( iterator.next() );
-	 * }
-	 * </pre>
+	 * @deprecated always prefer the variants which use a List rather than a Collection
 	 */
-	public static <T> CompletionStage<Void> loop(Stream<T> stream, Function<T,CompletionStage<?>> consumer) {
-		return loop( stream.iterator(), consumer );
+	@Deprecated
+	public static <T> CompletionStage<Void> loop(Collection<T> collection, Predicate<T> filter, Function<T, CompletionStage<?>> consumer) {
+		if ( collection instanceof List ) {
+			//This is true in almost all known cases, so a good optimisation in practice.
+			return loop( (List<T>) collection, filter, consumer );
+		}
+		else {
+			final List<T> list = new ArrayList<>( collection );
+			return loop( list, filter, consumer );
+		}
 	}
 
-	/**
-	 * Equivalent to:
-	 * <pre>
-	 * Iterator iterator = inStream.iterator();
-	 * while( iterator.hasNext()) {
-	 *   consumer.apply( iterator.next() );
-	 * }
-	 * </pre>
-	 */
-	public static CompletionStage<Void> loop(IntStream stream, Function<Integer,CompletionStage<?>> consumer) {
-		return loop( stream.iterator(), consumer );
+	public static <T> CompletionStage<Void> loop(List<T> list, Function<T, CompletionStage<?>> consumer) {
+		return loop( list, CompletionStages::alwaysTrue, consumer );
+	}
+
+	public static <T> CompletionStage<Void> loop(List<T> list, Predicate<T> filter, Function<T,CompletionStage<?>> consumer) {
+		return loop( 0, list.size(), index -> filter.test( list.get( index ) ), index -> consumer.apply( list.get( index ) ) );
+	}
+
+	public static <T> CompletionStage<Void> loop(Queue<T> queue, Function<T, CompletionStage<?>> consumer) {
+		return loop( queue.iterator(), CompletionStages::alwaysTrue , (value, integer) -> consumer.apply( value ) );
 	}
 
 	/**
@@ -222,8 +326,80 @@ public class CompletionStages {
 	 * }
 	 * </pre>
 	 */
-	public static CompletionStage<Void> loop(int start, int end, Function<Integer,CompletionStage<?>> consumer) {
-		return loop( IntStream.range(start, end), consumer );
+	public static CompletionStage<Void> loop(int start, int end, IntFunction<CompletionStage<?>> consumer) {
+		return loop( start, end, CompletionStages::alwaysTrue, consumer );
+	}
+
+	/**
+	 * Equivalent to:
+	 * <pre>
+	 * for ( int i = start; i < end; i++ ) {
+	 *   if ( filter.test(i) ) {
+	 *   	consumer.apply( i );
+	 *   }
+	 * }
+	 * </pre>
+	 */
+	public static CompletionStage<Void> loop(int start, int end, IntPredicate filter, IntFunction<CompletionStage<?>> consumer) {
+		if ( start < end ) {
+			final ArrayLoop loop = new ArrayLoop( start, end, filter, consumer);
+			return asyncWhile( loop::next );
+		}
+		return voidFuture();
+	}
+
+	/**
+	 * The status of a loop over an array.
+	 * <p>
+	 * Equivalent to:
+	 * <pre>
+	 * for ( int i = start; i < end; i++ ) {
+	 *   if ( filter.test( i ) ) {
+	 *   	consumer.apply( i );
+	 *   }
+	 * }
+	 * </pre>
+	 * </p>
+	 * <p>
+	 * This class keeps track of the state of the loop, allowing us to
+	 * use an {@code AsyncTrampoline#asyncWhile} via method reference.
+	 * </p>
+	 */
+	private static class ArrayLoop {
+
+		private final IntPredicate filter;
+		private final IntFunction<CompletionStage<?>> consumer;
+		private final int end;
+		private int current;
+
+		public ArrayLoop(int start, int end, IntPredicate filter, IntFunction<CompletionStage<?>> consumer) {
+			this.end = end;
+			this.filter = filter;
+			this.consumer = consumer;
+			this.current = start;
+		}
+
+		public CompletionStage<Boolean> next() {
+			current = next( current );
+			if ( current < end ) {
+				final int index = current++;
+				return consumer.apply( index )
+						.thenCompose( CompletionStages::alwaysContinue );
+			}
+			return FALSE;
+		}
+
+		/**
+		 * @param start the first index to test
+		 * @return the next valid index
+		 */
+		private int next(int start) {
+			int index = start;
+			while ( index < end && !filter.test( index ) ) {
+				index++;
+			}
+			return index;
+		}
 	}
 
 	public static CompletionStage<Void> applyToAll(Function<Object, CompletionStage<?>> op, Object[] entity) {
@@ -232,17 +408,5 @@ public class CompletionStages {
 			case 1: return op.apply( entity[0] ).thenCompose( CompletionStages::voidFuture );
 			default: return CompletionStages.loop( entity, op );
 		}
-	}
-
-	/**
-	 * Same as {@link #loop(Iterator, Function)} but doesn't use the trampoline pattern
-	 */
-	public static <T> CompletionStage<Void> loopWithoutTrampoline(Iterator<T> iterator, Function<T, CompletionStage<?>> consumer) {
-		CompletionStage<?> loopStage = voidFuture();
-		while ( iterator.hasNext() ) {
-			final T next = iterator.next();
-			loopStage = loopStage.thenCompose( v -> consumer.apply( next ) );
-		}
-		return loopStage.thenCompose( CompletionStages::voidFuture );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/IntBiFunction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/IntBiFunction.java
@@ -1,0 +1,18 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.util.impl;
+
+/**
+ * Similar to a {@link java.util.function.BiFunction}
+ * but one of the arguments is a primitive integer.
+ *
+ * @param <T> the type of the first argument of the function
+ * @param <R> the result the function
+ */
+@FunctionalInterface
+public interface IntBiFunction<T, R> {
+	R apply(T value, int integer);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/IntBiPredicate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/IntBiPredicate.java
@@ -1,0 +1,17 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: LGPL-2.1-or-later
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.util.impl;
+
+/**
+ * Similar to a {@link java.util.function.BiPredicate}
+ * but one of the arguments is a primitive integer.
+ *
+ * @param <T> the type of the first argument of the function
+ */
+@FunctionalInterface
+public interface IntBiPredicate<T> {
+	boolean test(T value, int integer);
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrphanRemovalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrphanRemovalTest.java
@@ -78,7 +78,13 @@ public class OrphanRemovalTest extends BaseReactiveTest {
         public Version(Product product) {
             this.product = product;
         }
+
         Version() {}
+
+        @Override
+        public String toString() {
+            return Version.class.getSimpleName() + ":" + id + ":" + product;
+        }
     }
 
     @Entity(name = "Product")
@@ -104,6 +110,11 @@ public class OrphanRemovalTest extends BaseReactiveTest {
         public void addVersion(Version version) {
             versions.add(version);
         }
+
+        @Override
+        public String toString() {
+            return Product.class.getSimpleName() + ":" + id + ":" + name + ":" + shop;
+        }
     }
 
     @Entity(name = "Shop")
@@ -124,6 +135,11 @@ public class OrphanRemovalTest extends BaseReactiveTest {
 
         public void addProduct(Product product) {
             products.add(product);
+        }
+
+        @Override
+        public String toString() {
+            return Shop.class.getSimpleName() + ":" + id + ":" + name;
         }
     }
 


### PR DESCRIPTION
Fixes #836 

I still need to add a couple of test cases but otherwise the PR is ready for a review:

* It removes the AtomicInteger
* Avoid chaining emtpy CompletionStages when possible
* Avoid InStream
* Avoid casting arrays to Stream
* Avoid iterators where possible

