### PR TITLE
hibernate.jdbc.time_zone support for Time

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/PreparedStatementAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/PreparedStatementAdaptor.java
@@ -158,6 +158,11 @@ public class PreparedStatementAdaptor implements PreparedStatement {
 	}
 
 	@Override
+	public void setTime(int parameterIndex, Time x, Calendar cal) {
+		put( parameterIndex, x.toLocalTime() );
+	}
+
+	@Override
 	public void setTimestamp(int parameterIndex, Timestamp x) {
 		put( parameterIndex, x.toLocalDateTime() );
 	}
@@ -240,11 +245,6 @@ public class PreparedStatementAdaptor implements PreparedStatement {
 	@Override
 	public void setDate(int parameterIndex, Date x, Calendar cal) {
 		put( parameterIndex, x.toLocalDate() );
-	}
-
-	@Override
-	public void setTime(int parameterIndex, Time x, Calendar cal) {
-		throw new UnsupportedOperationException();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
@@ -152,6 +152,12 @@ public class ResultSetAdaptor implements ResultSet {
 	}
 
 	@Override
+	public Time getTime(int columnIndex, Calendar cal) {
+		LocalTime localTime = row.getLocalTime(columnIndex);
+		return (wasNull=localTime==null) ? null : Time.valueOf(localTime);
+	}
+
+	@Override
 	public Timestamp getTimestamp(int columnIndex) {
 		LocalDateTime localDateTime = row.getLocalDateTime(columnIndex);
 		return (wasNull=localDateTime==null) ? null : Timestamp.valueOf(localDateTime);
@@ -249,6 +255,12 @@ public class ResultSetAdaptor implements ResultSet {
 	public Time getTime(String columnLabel) {
 		LocalTime localTime = row.getLocalTime(columnLabel);
 		return (wasNull=localTime==null) ? null : Time.valueOf(localTime);
+	}
+
+	@Override
+	public Time getTime(String columnLabel, Calendar cal) {
+		LocalTime localTime = row.getLocalTime( columnLabel );
+		return ( wasNull = localTime == null ) ? null : Time.valueOf( localTime );
 	}
 
 	@Override
@@ -708,16 +720,6 @@ public class ResultSetAdaptor implements ResultSet {
 
 	@Override
 	public Date getDate(String columnLabel, Calendar cal) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Time getTime(int columnIndex, Calendar cal) {
-		throw new UnsupportedOperationException();
-	}
-
-	@Override
-	public Time getTime(String columnLabel, Calendar cal) {
 		throw new UnsupportedOperationException();
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/TimestampTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/TimestampTest.java
@@ -51,8 +51,9 @@ public class TimestampTest extends BaseReactiveTest {
 	private static void assertInstants(TestContext ctx, Record r) {
 		ctx.assertNotNull( r.created );
 		ctx.assertNotNull( r.updated );
+		// Sometimes, when the test suite is fast enough, they might be the same
 		ctx.assertTrue(
-				r.updated.isAfter( r.created ),
+				r.updated.compareTo( r.created ) >= 0,
 				"Updated instant is before created. Updated[" + r.updated + "], Created[" + r.created + "]"
 		);
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UTCTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UTCTest.java
@@ -5,53 +5,230 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.AvailableSettings;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.OffsetDateTime;
+import java.time.OffsetTime;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
-import java.time.OffsetDateTime;
-import java.time.ZoneOffset;
+
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 public class UTCTest extends BaseReactiveTest {
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.setProperty(AvailableSettings.JDBC_TIME_ZONE, "UTC");
-        configuration.addAnnotatedClass(Thing.class);
-        return configuration;
-    }
 
-    @Test
-    public void test(TestContext context) {
-        Thing thing = new Thing();
-        thing.dateTime = OffsetDateTime.of(2021, 3, 25, 12, 30, 0, 0, ZoneOffset.ofHours(5));
-        test(context, getMutinySessionFactory()
-                .withSession(session -> session.persist(thing).call(session::flush))
+	final Thing thing = new Thing();
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty( AvailableSettings.JDBC_TIME_ZONE, "UTC" );
+		configuration.addAnnotatedClass( Thing.class );
+		return configuration;
+	}
+
+	@Test
+	public void testDate(TestContext context) {
+		thing.date = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) )
+				.getTime();
+
+		testField(
+				context,
+				"dateType",
+				thing::getDate,
+				entity -> context.assertEquals( thing.date, entity.date )
+		);
+	}
+
+	@Test
+	public void testCalendar(TestContext context) {
+		thing.calendar = Calendar.getInstance( TimeZone.getTimeZone( "UTC" ) );
+
+		testField(
+				context,
+				"calendarType",
+				thing::getCalendar,
+				entity -> context.assertEquals( thing.calendar.toInstant(), entity.calendar.toInstant() )
+		);
+	}
+
+	@Test
+	public void testLocalDate(TestContext context) {
+		thing.localDate = LocalDate.now();
+
+		testField(
+				context,
+				"localDateType",
+				thing::getLocalDate,
+				entity -> context.assertEquals( thing.localDate, entity.localDate )
+		);
+	}
+
+	@Test
+	public void testLocalTime(TestContext context) {
+		thing.localTime = LocalTime.MAX.truncatedTo( ChronoUnit.SECONDS );
+
+		testField(
+				context,
+				"localTimeType",
+				thing::getLocalTime,
+				entity -> context.assertEquals( thing.localTime, entity.localTime )
+		);
+	}
+
+	@Test
+	public void testLocalDateTime(TestContext context) {
+		thing.localDateTime = LocalDateTime.now()
+				.truncatedTo( ChronoUnit.MILLIS );
+
+		testField(
+				context,
+				"localDateTimeType",
+				thing::getLocalDateTime,
+				entity -> context.assertEquals( thing.localDateTime, entity.localDateTime )
+		);
+	}
+
+	@Test
+	public void testOffsetDateTime(TestContext context) {
+		final ZoneOffset zoneOffset = ZoneOffset.ofHours( 5 );
+		LocalDateTime dateTime = LocalDateTime.of( 2021, 3, 25, 12, 30 );
+		thing.offsetDateTime = OffsetDateTime.of( dateTime, zoneOffset );
+
+		testField(
+				context,
+				"offsetDateTimeType",
+				thing::getOffsetDateTime,
+				entity -> {
+					context.assertEquals( entity.offsetDateTime.getOffset(), ZoneOffset.UTC );
+					context.assertEquals( thing.offsetDateTime,
+										  entity.offsetDateTime.toInstant().atZone( zoneOffset ).toOffsetDateTime() );
+				}
+		);
+	}
+
+	@Test
+	public void testOffsetTime(TestContext context) {
+		thing.offsetTime = OffsetTime.now( ZoneOffset.ofHours( 7 ) )
+				.truncatedTo( ChronoUnit.SECONDS );
+
+		testField(
+				context,
+				"offsetTimeType",
+				thing::getOffsetTime,
+				entity -> context.assertEquals( thing.offsetTime.toLocalTime(), entity.offsetTime.toLocalTime() )
+		);
+	}
+
+	@Test
+	public void testZonedDateTime(TestContext context) {
+		final ZoneOffset zoneOffset = ZoneOffset.ofHours( 7 );
+		thing.zonedDateTime = ZonedDateTime.now( zoneOffset );
+
+		testField(
+				context,
+				"zonedDateTimeType",
+				thing::getZonedDateTime,
+				// The equals fails on JDK 15+ without the truncated
+				entity -> context.assertEquals(
+						thing.zonedDateTime.truncatedTo( ChronoUnit.MILLIS ),
+						entity.zonedDateTime.withZoneSameInstant( zoneOffset ).truncatedTo( ChronoUnit.MILLIS ) )
+		);
+	}
+
+    private void testField(TestContext context, String columnName, Supplier<?> fieldValue, Consumer<Thing> assertion) {
+        test( context, getMutinySessionFactory()
+                .withSession( session -> session.persist( thing ).call( session::flush ).invoke( session::clear ) )
                 .chain( () -> getMutinySessionFactory()
-                        .withSession(session -> session.find(Thing.class, thing.id))
-                        .invoke(t -> {
-                            context.assertNotNull(t);
-                            context.assertTrue( thing.dateTime.isEqual(t.dateTime) );
-                        })
+                        .withSession( session -> session.find( Thing.class, thing.id ) )
+                        .invoke( t -> {
+                            context.assertNotNull( t );
+                            assertion.accept( t );
+                        } )
                 )
                 .chain( () -> getMutinySessionFactory()
-                        .withSession(session -> session.createQuery("from ThingInUTC where dateTime=:dt")
-                                .setParameter("dt", thing.dateTime).getSingleResult())
-                        .invoke(context::assertNotNull)
+                        .withSession( session -> session.createQuery( "from ThingInUTC where " + columnName + "=:dt", Thing.class )
+                                .setParameter( "dt", fieldValue.get() ).getSingleResult() )
+                        .invoke( assertion )
                 )
         );
     }
 
-    @Entity(name="ThingInUTC")
-    static class Thing {
-        @Id
-        @GeneratedValue
-        long id;
+	@Entity(name = "ThingInUTC")
+	static class Thing {
+		@Id
+		@GeneratedValue
+		long id;
 
-        OffsetDateTime dateTime;
+		@Column(name = "dateType")
+		Date date;
+
+		@Column(name = "calendarType")
+		Calendar calendar;
+
+		@Column(name = "offsetDateTimeType")
+		OffsetDateTime offsetDateTime;
+
+		@Column(name = "offsetTimeType")
+		OffsetTime offsetTime;
+
+		@Column(name = "zonedDateTimeType")
+		ZonedDateTime zonedDateTime;
+
+		@Column(name = "localDateType")
+		LocalDate localDate;
+
+		@Column(name = "localTimeType")
+		LocalTime localTime;
+
+		@Column(name = "localDateTimeType")
+		LocalDateTime localDateTime;
+
+		public Date getDate() {
+			return date;
+		}
+
+		public Calendar getCalendar() {
+			return calendar;
+		}
+
+		public OffsetDateTime getOffsetDateTime() {
+			return offsetDateTime;
+		}
+
+		public OffsetTime getOffsetTime() {
+			return offsetTime;
+		}
+
+		public ZonedDateTime getZonedDateTime() {
+			return zonedDateTime;
+		}
+
+		public LocalDate getLocalDate() {
+			return localDate;
+		}
+
+		public LocalTime getLocalTime() {
+			return localTime;
+		}
+
+		public LocalDateTime getLocalDateTime() {
+			return localDateTime;
+		}
     }
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/BasicTypesAndCallbacksForAllDBsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/BasicTypesAndCallbacksForAllDBsTest.java
@@ -20,6 +20,8 @@ import java.net.URL;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.time.Duration;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -371,6 +373,30 @@ public class BasicTypesAndCallbacksForAllDBsTest extends BaseReactiveTest {
 	}
 
 	@Test
+	public void testDuration(TestContext context) {
+		Basic basic = new Basic();
+		basic.duration = Duration.ofMillis( 1894657L );
+
+		testField( context, basic, found -> {
+			context.assertTrue( found.duration instanceof Duration );
+			context.assertEquals( basic.duration, found.duration );
+		} );
+	}
+
+	@Test
+	public void testInstant(TestContext context) {
+		Basic basic = new Basic();
+		basic.instant = Instant.now();
+
+		testField( context, basic, found -> {
+			context.assertTrue( found.instant instanceof Instant );
+			// Without the truncated it fails with JDK 15+
+			context.assertEquals( basic.instant.truncatedTo( ChronoUnit.MILLIS ),
+								  found.instant.truncatedTo( ChronoUnit.MILLIS ) );
+		} );
+	}
+
+	@Test
 	public void testCallbacksAndVersioning(TestContext context) {
 		Basic parent = new Basic( "Parent" );
 		Basic basik = new Basic( "Hello World" );
@@ -564,6 +590,10 @@ public class BasicTypesAndCallbacksForAllDBsTest extends BaseReactiveTest {
 		private LocalTime localTime;
 		@Temporal(TemporalType.TIME)
 		Date dateAsTime;
+
+		Instant instant;
+
+		Duration duration;
 
 		@Transient
 		boolean prePersisted;


### PR DESCRIPTION
Fixes #856 ... sort of

This is what I would do and it seems consistent to what happens with ORM and MySQL (after a quick test).

I think OffsetTime is the one that's weird, because when we return the value it won't match the original Timezone.
