### PR TITLE
Issue 886

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -209,6 +209,9 @@ public interface Log extends BasicLogger {
 	@Message(id = 71, value= "No name provided and multiple persistence units found")
 	PersistenceException noNameProvidedAndMultiplePersistenceUnitsFound();
 
+	@Message(id = 72, value= "Cannot update an uninitialized proxy. Make sure to fetch the value before trying to update it: %1$s")
+	HibernateException uninitializedProxyUpdate(Object entity);
+
 	// Same method that exists in CoreMessageLogger
 	@LogMessage(level = WARN)
 	@Message(id = 104, value = "firstResult/maxResults specified with collection fetch; applying in memory!" )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessProxyUpdateTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessProxyUpdateTest.java
@@ -1,0 +1,215 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.HibernateException;
+import org.hibernate.LazyInitializationException;
+import org.hibernate.cfg.Configuration;
+
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Test the stateless update of a proxy.
+ * <p>
+ *     Note that it's required to update and read the values from the proxy using getter/setter and
+ *     there is no guarantee about this working otherwise.
+ * </p>
+ *
+ * @see org.hibernate.reactive.session.impl.ReactiveStatelessSessionImpl#reactiveUpdate(Object)
+ * @see ReactiveStatelessSessionTest
+ */
+public class ReactiveStatelessProxyUpdateTest extends BaseReactiveTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( SampleEntity.class );
+		configuration.addAnnotatedClass( SampleJoinEntity.class );
+		return configuration;
+	}
+
+	@After
+	public void cleanDb(TestContext context) {
+		test( context, deleteEntities( "SampleEntity", "SampleJoinEntity" ) );
+	}
+
+	@Test
+	public void testUnfetchedEntityException(TestContext context) {
+		thrown.expect( HibernateException.class );
+		thrown.expectMessage( "HR000072" );
+
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.sampleField = "test";
+
+		SampleJoinEntity sampleJoinEntity = new SampleJoinEntity();
+		sampleJoinEntity.sampleEntity = sampleEntity;
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persistAll( sampleEntity, sampleJoinEntity ) )
+
+				.chain( targetId -> getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session
+								.find( SampleJoinEntity.class, sampleJoinEntity.getId() ) )
+				)
+
+				.chain( joinEntityFromDatabase -> getMutinySessionFactory().withStatelessTransaction(
+						(s, t) -> {
+							SampleEntity entityFromDb = joinEntityFromDatabase.sampleEntity;
+							entityFromDb.sampleField = "updated field";
+							// We expect the update to fail because we haven't fetched the entity
+							// and therefore the proxy is uninitialized
+							return s.update( entityFromDb );
+						} )
+				)
+		);
+	}
+
+	@Test
+	public void testLazyInitializationException(TestContext context) {
+		thrown.expect( LazyInitializationException.class );
+
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.sampleField = "test";
+
+		SampleJoinEntity sampleJoinEntity = new SampleJoinEntity();
+		sampleJoinEntity.sampleEntity = sampleEntity;
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( (s, t) -> s.persistAll( sampleEntity, sampleJoinEntity ) )
+
+				.chain( targetId -> getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session
+								.find( SampleJoinEntity.class, sampleJoinEntity.getId() ) )
+				)
+
+				.chain( joinEntityFromDatabase -> getMutinySessionFactory().withStatelessTransaction(
+						(s, t) -> {
+							// LazyInitializationException here because we haven't fetched the entity
+							SampleEntity entityFromDb = joinEntityFromDatabase.getSampleEntity();
+							entityFromDb.setSampleField( "updated field" );
+							return s.update( entityFromDb );
+						} )
+				)
+		);
+	}
+
+	@Test
+	public void testUpdateWithInitializedProxy(TestContext context) {
+		SampleEntity sampleEntity = new SampleEntity();
+		sampleEntity.setSampleField( "test" );
+
+		SampleJoinEntity sampleJoinEntity = new SampleJoinEntity();
+		sampleJoinEntity.setSampleEntity( sampleEntity );
+
+		test( context, getMutinySessionFactory()
+					  .withTransaction( (s, t) -> s.persistAll( sampleEntity, sampleJoinEntity ) )
+
+					  .chain( targetId -> getMutinySessionFactory()
+							  .withTransaction( (session, transaction) -> session
+									  .find( SampleJoinEntity.class, sampleJoinEntity.getId() ) )
+					  )
+
+					  .chain( joinEntityFromDatabase -> getMutinySessionFactory().withStatelessTransaction(
+							  (s, t) -> s
+									  // The update of the associated entity should work if we fetch it first
+									  .fetch( joinEntityFromDatabase.getSampleEntity() )
+									  .chain( fetchedEntity -> {
+										  fetchedEntity.setSampleField( "updated field" );
+										  return s.update( fetchedEntity );
+									  } ) )
+					  )
+					  .chain( () -> getMutinySessionFactory().withSession( session -> session
+							  .createQuery( "from SampleEntity", SampleEntity.class )
+							  .getSingleResult()
+							  .onItem().invoke( result -> context.assertEquals( "updated field", result.getSampleField() ) ) )
+					  )
+		);
+	}
+
+	@Entity(name = "SampleEntity")
+	@Table(name = "sample_entities")
+	public static class SampleEntity implements Serializable {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		@Column(name = "sample_field")
+		private String sampleField;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public String getSampleField() {
+			return sampleField;
+		}
+
+		public void setSampleField(String sampleField) {
+			this.sampleField = sampleField;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + " ID: " + id + " sampleField: " + sampleField;
+		}
+	}
+
+	@Entity(name = "SampleJoinEntity")
+	@Table(name = "sample_join_entities")
+	public static class SampleJoinEntity implements Serializable {
+		@Id
+		@GeneratedValue(strategy = GenerationType.IDENTITY)
+		private Long id;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		@JoinColumn(name = "sample_entity_id", referencedColumnName = "id")
+		private SampleEntity sampleEntity;
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public SampleEntity getSampleEntity() {
+			return sampleEntity;
+		}
+
+		public void setSampleEntity(SampleEntity sampleEntity) {
+			this.sampleEntity = sampleEntity;
+		}
+
+		@Override
+		public String toString() {
+			return getClass().getSimpleName() + " ID: " + id + " sampleEntity: " + sampleEntity;
+		}
+	}
+}


### PR DESCRIPTION
Follows https://github.com/hibernate/hibernate-reactive/pull/900

I've tried to apply what we discussed in the previous PR, but there is still something that doesn't work.
I've added 4 tests, all of which updates the proxy:

-  :heavy_check_mark:  1. Unfetched  poxy and value is set using setter: Throws lazy initialization exception
-  :heavy_check_mark: 2. Unfetched  poxy and value is assigned to the field: Throws an exception about the value being unfetched
-  :heavy_check_mark: 3. Fetched proxy and  assign the new value to the field: It works as expected ( no errors and value gets updated)
-  :x: 4. Fetched proxy and  assign the value using setter: No exceptions but the value doesn't get udpated

I can't figure out why it doesn't work when using setter/getter (case 4). Any idea?
This is the test: https://github.com/hibernate/hibernate-reactive/compare/main...DavideD:issue-886?expand=1#diff-b4f970573d11d1e8b5616b5c7b8a93f89d8cdf37ae235d9648ec01145e1a9bb9R150