### PR TITLE
Upgrade JDK 18 tests to JDK 18+ea9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -138,7 +138,7 @@ jobs:
           - { name: "16", java_version_numeric: 16 }
           - { name: "17-ea", java_version_numeric: 17 }
           - { name: "18-ea", java_version_numeric: 18,
-              download_url: "https://download.java.net/java/early_access/jdk18/4/GPL/openjdk-18-ea+4_linux-x64_bin.tar.gz" }
+              download_url: "https://download.java.net/java/early_access/jdk18/9/GPL/openjdk-18-ea+9_linux-x64_bin.tar.gz" }
     steps:
     - uses: actions/checkout@v2
     - name: Get year/month for cache key


### PR DESCRIPTION
Because JDK 18  ea4 is no longer available for download.