### PR TITLE
Upgrade to Hibernate ORM 5.6.0.Beta1

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Hibernate Reactive has been tested with:
 - Db2 11.5
 - CockroachDB 21.1
 - MS SQL Server 2019
-- [Hibernate ORM][] 5.5.5.Final
+- [Hibernate ORM][] 5.6.0.Beta1
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.1.2
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.1.2
 - [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.1.2

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.5.1-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '5.5.5.Final'
+        hibernateOrmVersion = '5.6.0.Beta1'
     }
     // For ORM, we need a parsed version (to get the family, ...)
 

--- a/documentation/src/main/asciidoc/reference/introduction.adoc
+++ b/documentation/src/main/asciidoc/reference/introduction.adoc
@@ -24,7 +24,7 @@ implementation of JPA. If you've never used JPA before, that's OK, but you
 might need to refer to the following sources of information at some points
 in this text:
 
-- the http://hibernate.org/orm/documentation/5.5/[documentation for Hibernate ORM],
+- the http://hibernate.org/orm/documentation/5.6/[documentation for Hibernate ORM],
 - the https://jcp.org/aboutJava/communityprocess/mrel/jsr338/index.html[JPA 2.2 specification], or
 - https://www.manning.com/books/java-persistence-with-hibernate-second-edition[Java Persistence with Hibernate],
   the latest edition of the book originally titled _Hibernate in Action_.


### PR DESCRIPTION
This version includes @gbadner 's https://github.com/hibernate/hibernate-orm/pull/4106 and some more internal efficiency fixes which I've identified necessary via HR benchmarking.

We can release 5.6.0.Final quickly (next week or just after?), just using the Beta so there's opportunity to drop a couple more things like I did with https://github.com/hibernate/hibernate-orm/pull/4171