### PR TITLE
Track latest available ORM 5.6.x

### DIFF
--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -1,3 +1,5 @@
+# Run the build using the latest ORM 5.x snapshots
+# so that we can spot integration issues early
 name: Latest ORM 5.x
 
 on:
@@ -22,7 +24,7 @@ jobs:
     strategy:
       matrix:
         example: [ 'session-example', 'native-sql-example' ]
-        orm-version: [ '5.6.0.Beta1' ]
+        orm-version: [ '[5.6,5.7)' ]
         db: ['MySQL', 'PostgreSQL']
         exclude:
           # 'native-sql-example' doesn't run on MySQL because it has native queries
@@ -77,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        orm-version: [ '5.6.0.Beta1' ]
+        orm-version: [ '[5.6,5.7)' ]
         db: ['MariaDB', 'MySQL', 'PostgreSQL', 'DB2', 'CockroachDB', 'MSSQLServer']
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
The purpose of the build with 5 is to track the latest available ORM 5 (that's why it was an interval). Any particular reason for it to be set to 5.6.0.Beta1? I'm assuming @gbadner needed that version while working on the schema issue.

@Sanne Do we care about other minors (like 5.5.x or 5.4.x)?