### PR TITLE
fix a bug in merge()

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
@@ -1,0 +1,278 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import org.hibernate.AssertionFailure;
+import org.hibernate.HibernateException;
+import org.hibernate.engine.spi.EntityKey;
+import org.hibernate.engine.spi.EntityUniqueKey;
+import org.hibernate.engine.spi.PersistenceContext;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.engine.spi.SessionImplementor;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
+import org.hibernate.reactive.session.ReactiveQueryExecutor;
+import org.hibernate.type.EntityType;
+import org.hibernate.type.OneToOneType;
+import org.hibernate.type.Type;
+import org.hibernate.type.TypeHelper;
+
+import java.io.Serializable;
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
+
+import static org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer.UNFETCHED_PROPERTY;
+import static org.hibernate.property.access.internal.PropertyAccessStrategyBackRefImpl.UNKNOWN;
+import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
+import static org.hibernate.reactive.util.impl.CompletionStages.loop;
+import static org.hibernate.reactive.util.impl.CompletionStages.nullFuture;
+
+public class EntityTypes {
+
+    /**
+     * Replacement for {@link EntityType#resolve(Object, SharedSessionContractImplementor, Object, Boolean)}
+     */
+    public static CompletionStage<Object> resolve(EntityType entityType, Object idOrUniqueKey, Object owner,
+                                           SharedSessionContractImplementor session) {
+        if ( idOrUniqueKey != null && !isNull( entityType, owner, session ) ) {
+            if ( entityType.isReferenceToPrimaryKey() ) {
+                return ((ReactiveQueryExecutor) session).reactiveInternalLoad(
+                        entityType.getAssociatedEntityName(),
+                        (Serializable) idOrUniqueKey,
+                        true,
+                        entityType.isNullable()
+                );
+            }
+            else {
+                return loadByUniqueKey( entityType, idOrUniqueKey, session );
+            }
+        }
+        else {
+            return null;
+        }
+    }
+
+    static boolean isNull(EntityType entityType, Object owner,
+                          SharedSessionContractImplementor session) {
+        if ( entityType instanceof OneToOneType) {
+            OneToOneType type = (OneToOneType) entityType;
+            String propertyName = type.getPropertyName();
+            if ( propertyName != null ) {
+                EntityPersister ownerPersister =
+                        session.getFactory().getMetamodel()
+                                .entityPersister( entityType.getAssociatedEntityName() );
+                Serializable id = session.getContextEntityIdentifier(owner);
+                EntityKey entityKey = session.generateEntityKey(id, ownerPersister);
+                return session.getPersistenceContextInternal().isPropertyNull( entityKey, propertyName);
+            }
+            else {
+                return false;
+            }
+        }
+        else {
+            return false;
+        }
+    }
+
+    /**
+     * Load an instance by a unique key that is not the primary key.
+     *
+     * @param entityType The {@link EntityType} of the association
+     * @param key The unique key property value.
+     * @param session The originating session.
+     *
+     * @return The loaded entity
+     *
+     * @throws HibernateException generally indicates problems performing the load.
+     */
+    static CompletionStage<Object> loadByUniqueKey(
+            EntityType entityType,
+            Object key,
+            SharedSessionContractImplementor session) throws HibernateException {
+        SessionFactoryImplementor factory = session.getFactory();
+        String entityName = entityType.getAssociatedEntityName();
+        String uniqueKeyPropertyName = entityType.getRHSUniqueKeyPropertyName();
+
+        ReactiveEntityPersister persister =
+                (ReactiveEntityPersister) factory.getMetamodel().entityPersister( entityName );
+
+        //TODO: implement 2nd level caching?! natural id caching ?! proxies?!
+
+        EntityUniqueKey euk = new EntityUniqueKey(
+                entityName,
+                uniqueKeyPropertyName,
+                key,
+                entityType.getIdentifierOrUniqueKeyType( factory ),
+                persister.getEntityMode(),
+                factory
+        );
+
+        PersistenceContext persistenceContext = session.getPersistenceContextInternal();
+        Object result = persistenceContext.getEntity( euk );
+        if ( result != null ) {
+            return completedFuture( persistenceContext.proxyFor( result ) );
+        }
+        else {
+            return persister.reactiveLoadByUniqueKey( uniqueKeyPropertyName, key, session )
+                    .thenApply( loaded -> {
+                        // If the entity was not in the Persistence Context, but was found now,
+                        // add it to the Persistence Context
+                        if ( loaded != null ) {
+                            persistenceContext.addEntity(euk, loaded);
+                        }
+                        return loaded;
+                    } );
+
+        }
+    }
+
+    /**
+     * @see TypeHelper#replace(Object[], Object[], Type[], SharedSessionContractImplementor, Object, Map)
+     */
+    public static CompletionStage<Object[]> replace(
+            final Object[] original,
+            final Object[] target,
+            final Type[] types,
+            final SessionImplementor session,
+            final Object owner,
+            final Map copyCache) {
+        Object[] copied = new Object[original.length];
+        for ( int i=0; i<types.length; i++ ) {
+            if ( original[i] == UNFETCHED_PROPERTY || original[i] == UNKNOWN ) {
+                copied[i] = target[i];
+            }
+            else {
+                if ( !(types[i] instanceof EntityType) ) {
+                    copied[i] = types[i].replace(
+                            original[i],
+                            target[i] == UNFETCHED_PROPERTY ? null : target[i],
+                            session,
+                            owner,
+                            copyCache
+                    );
+                }
+            }
+        }
+        return loop(0, types.length,
+                i -> original[i] != UNFETCHED_PROPERTY && original[i] != UNKNOWN
+                        && types[i] instanceof EntityType,
+                i -> replace(
+                        (EntityType) types[i],
+                        original[i],
+                        target[i] == UNFETCHED_PROPERTY ? null : target[i],
+                        session,
+                        owner,
+                        copyCache
+                ).thenAccept( copy -> copied[i] = copy )
+        ).thenApply(v -> copied );
+    }
+
+    /**
+     * @see EntityType#replace(Object, Object, SharedSessionContractImplementor, Object, Map)
+     */
+    private static CompletionStage<Object> replace(
+            EntityType entityType,
+            Object original,
+            Object target,
+            SessionImplementor session,
+            Object owner,
+            Map copyCache) {
+        if ( original == null ) {
+            return nullFuture();
+        }
+        Object cached = copyCache.get( original );
+        if ( cached != null ) {
+            return completedFuture(cached);
+        }
+        else {
+            if ( original == target ) {
+                return completedFuture(target);
+            }
+            if ( session.getContextEntityIdentifier( original ) == null ) {
+                return ForeignKeys.isTransient( entityType.getAssociatedEntityName(), original, false, session )
+                        .thenCompose( isTransient -> {
+                            if ( isTransient ) {
+                                // original is transient; it is possible that original is a "managed" entity that has
+                                // not been made persistent yet, so check if copyCache contains original as a "managed" value
+                                // that corresponds with some "merge" value.
+                                if ( copyCache.containsValue( original ) ) {
+                                    return completedFuture(original);
+                                }
+                                else {
+                                    // the transient entity is not "managed"; add the merge/managed pair to copyCache
+                                    final Object copy = session.getEntityPersister( entityType.getAssociatedEntityName(), original )
+                                            .instantiate( null, session );
+                                    copyCache.put( original, copy );
+                                    return completedFuture(copy);
+                                }
+                            }
+                            else {
+                                return resolveIdOrUniqueKey( entityType, original, session, owner, copyCache );
+                            }
+                        } );
+            }
+            else {
+                return resolveIdOrUniqueKey( entityType, original, session, owner, copyCache );
+            }
+        }
+    }
+
+    private static CompletionStage<Object> resolveIdOrUniqueKey(
+            EntityType entityType,
+            Object original,
+            SessionImplementor session,
+            Object owner,
+            Map copyCache) {
+        return getIdentifier( entityType, original, session )
+                .thenCompose( id -> {
+                    if ( id == null ) {
+                        throw new AssertionFailure(
+                                "non-transient entity has a null id: "
+                                        + original.getClass().getName()
+                        );
+                    }
+                    Object idOrUniqueKey =
+                            entityType.getIdentifierOrUniqueKeyType( session.getFactory() )
+                                    .replace( id, null, session, owner, copyCache);
+                    return resolve( entityType, idOrUniqueKey, owner, session );
+                } );
+    }
+
+    /**
+     * see EntityType#getIdentifier(Object, SharedSessionContractImplementor)
+     */
+    private static CompletionStage<Serializable> getIdentifier(EntityType entityType, Object value, SessionImplementor session) {
+        if ( entityType.isReferenceToPrimaryKey()
+            /*|| entityType.uniqueKeyPropertyName == null*/ //TODO: expose this in core
+        ) {
+            return ForeignKeys.getEntityIdentifierIfNotUnsaved(
+                    entityType.getAssociatedEntityName(),
+                    value,
+                    session
+            ); //tolerates nulls
+        }
+        else if ( value == null ) {
+            return nullFuture();
+        }
+        else {
+            throw new UnsupportedOperationException("unique key properties not yet supported in merge()");
+            //TODO: expose stuff in core
+//			EntityPersister entityPersister = entityType.getAssociatedEntityPersister( session.getFactory() );
+//			Object propertyValue = entityPersister.getPropertyValue( value, entityType.uniqueKeyPropertyName );
+//			// We now have the value of the property-ref we reference.  However,
+//			// we need to dig a little deeper, as that property might also be
+//			// an entity type, in which case we need to resolve its identifier
+//			Type type = entityPersister.getPropertyType( entityType.uniqueKeyPropertyName );
+//			if ( type.isEntityType() ) {
+//				propertyValue = ( (EntityType) type ).getIdentifier( propertyValue, session );
+//			}
+//
+//			return propertyValue;
+        }
+    }
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
@@ -215,7 +215,7 @@ public class DefaultReactiveMergeEventListener extends AbstractReactiveSaveEvent
 		final EventSource source = event.getSession();
 		final EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );
 
-		copyCache.put( entity, entity, true );  //before cas‘cade!
+		copyCache.put( entity, entity, true );  //before cascade!
 
 		return cascadeOnMerge( source, persister, entity, copyCache )
 				.thenCompose( v -> fetchAndCopyValues( persister, entity, entity, source, copyCache ) )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveResultSetProcessor.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.loader;
 
-import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -13,29 +12,20 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
-import org.hibernate.HibernateException;
 import org.hibernate.engine.internal.TwoPhaseLoad;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.EntityKey;
-import org.hibernate.engine.spi.EntityUniqueKey;
 import org.hibernate.engine.spi.PersistenceContext;
 import org.hibernate.engine.spi.QueryParameters;
-import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.PreLoadEvent;
 import org.hibernate.loader.plan.exec.query.spi.NamedParameterContext;
 import org.hibernate.loader.spi.AfterLoadAction;
-import org.hibernate.persister.entity.EntityPersister;
+import org.hibernate.reactive.engine.impl.EntityTypes;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
-import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
-import org.hibernate.reactive.session.ReactiveQueryExecutor;
-import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.transform.ResultTransformer;
-import org.hibernate.type.EntityType;
-import org.hibernate.type.OneToOneType;
 
-import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
+import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 /**
  * An interface intended to unify how a ResultSet is processed by
@@ -72,16 +62,16 @@ public interface ReactiveResultSetProcessor {
 				session,
 				(entityType, value, source, owner, overridingEager)
 						-> entityType.isEager( overridingEager )
-								? resolve( entityType, (Serializable) value, owner, source )
+								? EntityTypes.resolve( entityType, value, owner, source )
 								: entityType.resolve( value, source, owner, overridingEager )
 		);
 
 		final Object[] hydratedState = entityEntry.getLoadedState();
-		CompletionStage<Void> loop = CompletionStages.voidFuture();
+		CompletionStage<Void> loop = voidFuture();
 		for ( int i = 0; i < hydratedState.length; i++ ) {
 			final Object o = hydratedState[i];
 			if ( o instanceof CompletionStage ) {
-				final CompletionStage<?> c = (CompletionStage) o;
+				final CompletionStage<?> c = (CompletionStage<?>) o;
 				final int currentIndex = i;
 				loop = loop.thenCompose( v -> c.thenAccept( initializedEntity -> hydratedState[ currentIndex ] = initializedEntity ) );
 			}
@@ -95,102 +85,5 @@ public interface ReactiveResultSetProcessor {
 						preLoadEvent
 				)
 		);
-	}
-
-	/**
-	 * Replacement for {@link EntityType#resolve(Object, SharedSessionContractImplementor, Object, Boolean)}
-	 */
-	default CompletionStage<Object> resolve(EntityType entityType, Serializable value, Object owner,
-											SharedSessionContractImplementor session) {
-		if ( value != null && !isNull( entityType, owner, session ) ) {
-			if ( entityType.isReferenceToPrimaryKey() ) {
-				return ((ReactiveQueryExecutor) session).reactiveInternalLoad(
-						entityType.getAssociatedEntityName(),
-						value,
-						true,
-						entityType.isNullable()
-				);
-			}
-			else {
-				return loadByUniqueKey( entityType, value, session );
-			}
-		}
-		else {
-			return null;
-		}
-	}
-
-	default boolean isNull(EntityType entityType, Object owner,
-						   SharedSessionContractImplementor session) {
-		if ( entityType instanceof OneToOneType ) {
-			OneToOneType type = (OneToOneType) entityType;
-			String propertyName = type.getPropertyName();
-			if ( propertyName != null ) {
-				EntityPersister ownerPersister =
-						session.getFactory().getMetamodel()
-								.entityPersister( entityType.getAssociatedEntityName() );
-				Serializable id = session.getContextEntityIdentifier(owner);
-				EntityKey entityKey = session.generateEntityKey(id, ownerPersister);
-				return session.getPersistenceContextInternal().isPropertyNull( entityKey, propertyName);
-			}
-			else {
-				return false;
-			}
-		}
-		else {
-			return false;
-		}
-	}
-
-	/**
-	 * Load an instance by a unique key that is not the primary key.
-	 *
-	 * @param entityType The {@link EntityType} of the association
-	 * @param key The unique key property value.
-	 * @param session The originating session.
-	 *
-	 * @return The loaded entity
-	 *
-	 * @throws HibernateException generally indicates problems performing the load.
-	 */
-	default CompletionStage<Object> loadByUniqueKey(
-			EntityType entityType,
-			Object key,
-			SharedSessionContractImplementor session) throws HibernateException {
-		SessionFactoryImplementor factory = session.getFactory();
-		String entityName = entityType.getAssociatedEntityName();
-		String uniqueKeyPropertyName = entityType.getRHSUniqueKeyPropertyName();
-
-		ReactiveEntityPersister persister =
-				(ReactiveEntityPersister) factory.getMetamodel().entityPersister( entityName );
-
-		//TODO: implement 2nd level caching?! natural id caching ?! proxies?!
-
-		EntityUniqueKey euk = new EntityUniqueKey(
-				entityName,
-				uniqueKeyPropertyName,
-				key,
-				entityType.getIdentifierOrUniqueKeyType( factory ),
-				persister.getEntityMode(),
-				factory
-		);
-
-		PersistenceContext persistenceContext = session.getPersistenceContextInternal();
-		Object result = persistenceContext.getEntity( euk );
-		if ( result != null ) {
-			return completedFuture( persistenceContext.proxyFor( result ) );
-		}
-		else {
-			return persister.reactiveLoadByUniqueKey( uniqueKeyPropertyName, key, session )
-					.thenApply( loaded -> {
-						// If the entity was not in the Persistence Context, but was found now,
-						// add it to the Persistence Context
-						if ( loaded != null ) {
-							persistenceContext.addEntity(euk, loaded);
-						}
-						return loaded;
-					} );
-
-		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToOneMergeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToOneMergeTest.java
@@ -1,0 +1,167 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.io.Serializable;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+public class ManyToOneMergeTest extends BaseReactiveTest {
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( AcademicYearDetailsDBO.class );
+		configuration.addAnnotatedClass( CampusDBO.class );
+		return configuration;
+	}
+
+	@Before
+	public void populateDb(TestContext context) {
+		CampusDBO campusDBO2 = new CampusDBO();
+		campusDBO2.setId( 42 );
+		campusDBO2.setCampusName( "Kuchl" );
+
+		CampusDBO campusDBO = new CampusDBO();
+		campusDBO.setId( 66 );
+		campusDBO.setCampusName( "Qualunquelandia" );
+
+		AcademicYearDetailsDBO academicYearDetailsDBO = new AcademicYearDetailsDBO();
+		academicYearDetailsDBO.setId( 69 );
+		academicYearDetailsDBO.setCampusId( campusDBO );
+		academicYearDetailsDBO.setCreatedUsersId( 12 );
+		academicYearDetailsDBO.setRecordStatus( 'F' );
+		academicYearDetailsDBO.setModifiedUsersId( 66 );
+		test( context,
+			  getMutinySessionFactory().withTransaction( (session, transaction) -> session.persistAll(
+					  campusDBO, campusDBO2,
+					  academicYearDetailsDBO
+			  ) )
+		);
+	}
+
+	@Test
+	public void test(TestContext context) {
+		test( context, getMutinySessionFactory()
+				.withSession( session -> session
+						.createQuery( "select dbo from AcademicYearDetailsDBO dbo", AcademicYearDetailsDBO.class )
+						.getSingleResult() )
+				.chain( dbo -> {
+					dbo.setRecordStatus( 'A' );
+					System.out.println( dbo.getCampusId().getId() );//for example here campus id is 11
+					CampusDBO campusDBO = new CampusDBO();
+					campusDBO.setId( 5 );
+					dbo.setCampusId( campusDBO ); // need to update as 5
+					return getMutinySessionFactory()
+							.withTransaction( (session, transaction) -> {
+								dbo.setCampusId( session.getReference( CampusDBO.class, 42 ) );
+								return session.merge( dbo );
+							} );
+				} )
+		);
+	}
+
+	@Entity(name = "AcademicYearDetailsDBO")
+	@Table(name = "erp_academic_year_detail")
+	static class AcademicYearDetailsDBO implements Serializable {
+		@Id
+		@Column(name = "erp_academic_year_detail_id")
+		private Integer id;
+
+		// LAZY will work
+		@ManyToOne(fetch = FetchType.EAGER)
+		@JoinColumn(name = "erp_campus_id")
+		private CampusDBO campusId;
+
+		@Column(name = "record_status")
+		private char recordStatus;
+
+		@Column(name = "created_users_id")
+		private Integer createdUsersId;
+
+		@Column(name = "modified_users_id")
+		private Integer modifiedUsersId;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public CampusDBO getCampusId() {
+			return campusId;
+		}
+
+		public void setCampusId(CampusDBO campusId) {
+			this.campusId = campusId;
+		}
+
+		public char getRecordStatus() {
+			return recordStatus;
+		}
+
+		public void setRecordStatus(char recordStatus) {
+			this.recordStatus = recordStatus;
+		}
+
+		public Integer getCreatedUsersId() {
+			return createdUsersId;
+		}
+
+		public void setCreatedUsersId(Integer createdUsersId) {
+			this.createdUsersId = createdUsersId;
+		}
+
+		public Integer getModifiedUsersId() {
+			return modifiedUsersId;
+		}
+
+		public void setModifiedUsersId(Integer modifiedUsersId) {
+			this.modifiedUsersId = modifiedUsersId;
+		}
+	}
+
+	@Entity(name = "CampusDBO")
+	@Table(name = "erp_campus")
+	static class CampusDBO implements Serializable {
+		@Id
+		@Column(name = "erp_campus_id")
+		private Integer id;
+
+		@Column(name = "campus_name")
+		private String campusName;
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getCampusName() {
+			return campusName;
+		}
+
+		public void setCampusName(String campusName) {
+			this.campusName = campusName;
+		}
+	}
+}


### PR DESCRIPTION
fixes #951

Well, it fixes *one* overloaded version of `DefaultReactiveMergeEventListener.copyValues()`, which was enough to make the given test pass. I'm not sure if the same change needs to be made to the other one.
