### PR TITLE
Switch from Java 8 to Java 11 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Learn more at <http://hibernate.org/reactive>.
 
 Hibernate Reactive has been tested with:
 
-- Java 8
+- Java 11, 16 and 17
 - PostgreSQL 13
 - MySQL 8
 - MariaDB 10


### PR DESCRIPTION
We will continue to test with Java 8 for the time being
but at least we don't commit to it for the future.

And we are aligned to the base version used by the products.

Fixes #969

I will update the website before the release