### PR TITLE
Introduce an unwrap() capability on the reactive SessionFactory implementations

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1735,6 +1735,14 @@ public interface Mutiny {
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();
+
+		/**
+		 * Return an object of the specified type to allow access to
+		 * internal components; this is meant to be used by integrators.
+		 * @param type the class of the object to be returned.
+		 * @return an instance of the specified class
+		 */
+		<T> T unwrap(Class<T> type);
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -15,6 +15,8 @@ import javax.persistence.metamodel.Metamodel;
 
 import org.hibernate.Cache;
 import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.SessionCreationOptions;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.reactive.context.Context;
@@ -258,5 +260,22 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory {
 	@Override
 	public boolean isOpen() {
 		return delegate.isOpen();
+	}
+
+	@Override
+	public <T> T unwrap(Class<T> type) {
+		if ( type.isAssignableFrom( SessionFactory.class ) ) {
+			return type.cast( delegate );
+		}
+
+		if ( type.isAssignableFrom( SessionFactoryImplementor.class ) ) {
+			return type.cast( delegate );
+		}
+
+		if ( type.isAssignableFrom( SessionFactoryImpl.class ) ) {
+			return type.cast( delegate );
+		}
+
+		throw new HibernateException( "Hibernate cannot unwrap as type '" + type.getName() + "'" );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1736,6 +1736,14 @@ public interface Stage {
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();
+
+		/**
+		 * Return an object of the specified type to allow access to
+		 * internal components; this is meant to be used by integrators.
+		 * @param type the class of the object to be returned.
+		 * @return an instance of the specified class
+		 */
+		<T> T unwrap(Class<T> type);
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
@@ -14,6 +14,9 @@ import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.metamodel.Metamodel;
 
 import org.hibernate.Cache;
+import org.hibernate.HibernateException;
+import org.hibernate.SessionFactory;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.SessionCreationOptions;
 import org.hibernate.internal.SessionFactoryImpl;
 import org.hibernate.reactive.context.Context;
@@ -263,4 +266,22 @@ public class StageSessionFactoryImpl implements Stage.SessionFactory {
 	public boolean isOpen() {
 		return delegate.isOpen();
 	}
+
+	@Override
+	public <T> T unwrap(Class<T> type) {
+		if ( type.isAssignableFrom( SessionFactory.class ) ) {
+			return type.cast( delegate );
+		}
+
+		if ( type.isAssignableFrom( SessionFactoryImplementor.class ) ) {
+			return type.cast( delegate );
+		}
+
+		if ( type.isAssignableFrom( SessionFactoryImpl.class ) ) {
+			return type.cast( delegate );
+		}
+
+		throw new HibernateException( "Hibernate cannot unwrap as type '" + type.getName() + "'" );
+	}
+
 }


### PR DESCRIPTION

From integration code, I need to be able to unwrap `Stage.SessionFactory` and `Mutiny.SessionFactory` instances to access the serviceregistry and the `SessionFactoryImpl` delegate.