### PR TITLE
Create Implementor interface

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/spi/Implementor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/spi/Implementor.java
@@ -1,0 +1,19 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.common.spi;
+
+import org.hibernate.reactive.context.Context;
+import org.hibernate.service.ServiceRegistry;
+
+/**
+ * Allows access to object that can be useful for integrators
+ */
+public interface Implementor {
+
+	ServiceRegistry getServiceRegistry();
+
+	Context getContext();
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1735,14 +1735,6 @@ public interface Mutiny {
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();
-
-		/**
-		 * Return an object of the specified type to allow access to
-		 * internal components; this is meant to be used by integrators.
-		 * @param type the class of the object to be returned.
-		 * @return an instance of the specified class
-		 */
-		<T> T unwrap(Class<T> type);
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1736,14 +1736,6 @@ public interface Stage {
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();
-
-		/**
-		 * Return an object of the specified type to allow access to
-		 * internal components; this is meant to be used by integrators.
-		 * @param type the class of the object to be returned.
-		 * @return an instance of the specified class
-		 */
-		<T> T unwrap(Class<T> type);
 	}
 
 	/**


### PR DESCRIPTION
New interfaces that will make it easier for integrators
to access internal components. Similar to the SessionFactoryImplementor
interface in ORM.


@Sanne, we will have to update this line in Quarkus: https://github.com/DavideD/quarkus/blob/07c1037c07ace8b93dcb7a3f06ead6a35da965eb/extensions/hibernate-reactive/runtime/src/main/java/io/quarkus/hibernate/reactive/runtime/ReactiveSessionProducer.java#L30