### PR TITLE
Support for PostgreSQL 14

### DIFF
--- a/documentation/src/main/asciidoc/reference/introduction.adoc
+++ b/documentation/src/main/asciidoc/reference/introduction.adoc
@@ -88,6 +88,7 @@ Optionally, you might also add any of the following additional features:
 | Hibernate Validator | `org.hibernate.validator:hibernate-validator` and `org.glassfish:jakarta.el`
 | Compile-time checking for your HQL queries | `org.hibernate:query-validator`
 | Second-level cache support via JCache and EHCache | `org.hibernate:hibernate-jcache` along with `org.ehcache:ehcache`
+| SCRAM authentication support for PostgreSQL | `com.ongres.scram:client:2.1`
 |===
 
 You might also add the Hibernate {enhancer}[bytecode enhancer] to your

--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -16,6 +16,9 @@ dependencies {
     // logging (optional)
     runtimeOnly "org.apache.logging.log4j:log4j-core:2.14.1"
 //    runtimeOnly 'org.slf4j:slf4j-log4j12:1.7.30'
+
+    // Allow authentication to PostgreSQL using SCRAM:
+    runtimeOnly 'com.ongres.scram:client:2.1'
 }
 
 buildscript {

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -17,6 +17,9 @@ dependencies {
     // logging (optional)
     runtimeOnly "org.apache.logging.log4j:log4j-core:2.14.1"
 //    runtimeOnly 'org.slf4j:slf4j-log4j12:1.7.30'
+
+    // Allow authentication to PostgreSQL using SCRAM:
+    runtimeOnly 'com.ongres.scram:client:2.1'
 }
 
 // All of the remaining configuration is only necessary to enable

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -37,6 +37,9 @@ dependencies {
     testImplementation "io.vertx:vertx-db2-client:${vertxVersion}"
     testImplementation "io.vertx:vertx-mssql-client:${vertxVersion}"
 
+    // Optional dependency of vertx-pg-client, essential when connecting via SASL SCRAM
+    testImplementation 'com.ongres.scram:client:2.1'
+
     // JDBC driver to test with ORM and PostgreSQL
     testRuntimeOnly "org.postgresql:postgresql:42.2.23"
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -11,7 +11,7 @@ class PostgreSQLDatabase implements TestableDatabase {
 
 	public static PostgreSQLDatabase INSTANCE = new PostgreSQLDatabase();
 
-	public final static String IMAGE_NAME = "postgres:13.3";
+	public final static String IMAGE_NAME = "postgres:14";
 
 	/**
 	 * Holds configuration for the PostgreSQL database container. If the build is run with <code>-Pdocker</code> then

--- a/podman.md
+++ b/podman.md
@@ -14,13 +14,13 @@ If you replace `podman` with `sudo docker`, they will also work with [Docker][do
 Example:
 
 ```
-podman run --rm --name HibernateTestingPGSQL postgres:13.0
+podman run --rm --name HibernateTestingPGSQL postgres:14.0
 ```
 
 becomes for Docker:
 
 ```
-sudo docker run --rm --name HibernateTestingPGSQL postgres:13.0
+sudo docker run --rm --name HibernateTestingPGSQL postgres:14.0
 ```
 ---
 
@@ -34,10 +34,11 @@ required credentials and schema to run the tests:
 
 [postgresql]:https://www.postgresql.org
 
+
 ```
 podman run --rm --name HibernateTestingPGSQL \
     -e POSTGRES_USER=hreact -e POSTGRES_PASSWORD=hreact -e POSTGRES_DB=hreact \
-    -p 5432:5432 postgres:13.3
+    -p 5432:5432 postgres:14.0
 ```
 
 When the database has started, you can run the tests on PostgreSQL with:
@@ -47,14 +48,13 @@ When the database has started, you can run the tests on PostgreSQL with:
 ```
 
 Optionally, you can connect to the database with the [PostgreSQL interactive terminal][psql](`psql`)
-using:
+using this one-liner:
 
 ```
-podman exec -it HibernateTestingPGSQL psql -U hreact -W -d hreact
+podman exec -e PGPASSWORD=hreact -it HibernateTestingPGSQL psql -U hreact -d hreact
 ```
-When asked for the password, type: `hreact`
 
-[psql]:https://www.postgresql.org/docs/9.6/app-psql.html
+[psql]:https://www.postgresql.org/docs/14/app-psql.html
 
 ## MariaDB
 

--- a/tooling/jbang/Example.java
+++ b/tooling/jbang/Example.java
@@ -56,7 +56,7 @@ import static javax.persistence.FetchType.LAZY;
  *             <pre>
  *                 podman run --rm --name HibernateTestingPGSQL \
  *                      -e POSTGRES_USER=hreact -e POSTGRES_PASSWORD=hreact -e POSTGRES_DB=hreact \
- *                      -p 5432:5432 postgres:13.3
+ *                      -p 5432:5432 postgres:14
  *              </pre>
  *         </dd>
  *         <dt>3. Run the example with JBang</dt>

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -58,7 +58,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class {baseName} {
 
 	@ClassRule
-	public final static PostgreSQLContainer<?> database = new PostgreSQLContainer<>( "postgres:13.3" );
+	public final static PostgreSQLContainer<?> database = new PostgreSQLContainer<>( "postgres:14" );
 
 	private Mutiny.SessionFactory sessionFactory;
 

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -227,7 +227,7 @@ public class ReactiveTest {
 	 * It's a wrapper around the testcontainers classes.
 	 */
 	enum Database {
-		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:13.3" ) ),
+		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:14" ) ),
 		MYSQL( () -> new MySQLContainer( "mysql:8.0.25" ) ),
 		DB2( () -> new Db2Container( "ibmcom/db2:11.5.5.1" ).acceptLicense() ),
 		MARIADB( () -> new MariaDBContainer( "mariadb:10.6.2" ) ),

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -6,6 +6,7 @@
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
 //DEPS io.vertx:vertx-pg-client:${vertx.version:4.1.4}
+//DEPS com.ongres.scram:client:2.1
 //DEPS io.vertx:vertx-db2-client:${vertx.version:4.1.4}
 //DEPS io.vertx:vertx-mysql-client:${vertx.version:4.1.4}
 //DEPS io.vertx:vertx-unit:${vertx.version:4.1.4}


### PR DESCRIPTION
No implementation changes needed, but the DB now is commonly configured to use SCARM SASL for authentication (that's the recommended default at least).

The vert.x sql client has an optional dependency to `com.ongres.scram:client:2.1` which is now necessary when this is enabled; so I've amended examples and documentation to mention this.