### PR TITLE
Remove duplicated close method in the Session

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1100,12 +1100,6 @@ public interface Mutiny {
 		Transaction currentTransaction();
 
 		/**
-		 * Close the reactive session and release the underlying database
-		 * connection.
-		 */
-		Uni<Void> close();
-
-		/**
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1101,12 +1101,6 @@ public interface Stage {
 		Transaction currentTransaction();
 
 		/**
-		 * Close the reactive session and release the underlying database
-		 * connection.
-		 */
-		CompletionStage<Void> close();
-
-		/**
 		 * @return false if {@link #close()} has been called
 		 */
 		boolean isOpen();


### PR DESCRIPTION
It's already defined in the Closable interface

Fixes #997 

@Sanne, can you confirm that it is ok to merge this before the final?