### PR TITLE
fix hibernate#1001 

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/vertx/impl/DefaultVertxInstance.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/vertx/impl/DefaultVertxInstance.java
@@ -49,14 +49,11 @@ public final class DefaultVertxInstance implements VertxInstance, Stoppable, Sta
 
     @Override
     public void start() {
-        Context currentContext = Vertx.currentContext();
-        // if null, create Vertx instance
-        if ( currentContext != null && currentContext.owner() != null ) {
-            vertx = currentContext.owner();
-        } else {
-            vertx = Vertx.vertx();
-            vertxCreator = true;
-        }
+        final Context context = Vertx.currentContext();
+        vertxCreator = context == null || context.owner() == null;
+        vertx = vertxCreator
+                ? Vertx.vertx() // Create a new one
+                : context.owner(); // Get the existing one
     }
 
 }


### PR DESCRIPTION
fixes #1001.
```DefaultVertxInstance``` creates ```Vertx``` instance only if current vertx is null when ```start()``` invokes, and stop vertx only if it created by ```start()```.