### PR TITLE
[#1020] Remove uses of deprecated isEnhancementAsProxyEnabled

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
@@ -327,10 +327,6 @@ public class DefaultReactiveLoadEventListener implements LoadEventListener, Reac
 
 		final PersistenceContext persistenceContext = session.getPersistenceContextInternal();
 
-		final boolean allowBytecodeProxy = factory
-				.getSessionFactoryOptions()
-				.isEnhancementAsProxyEnabled();
-
 		final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 		final boolean entityHasHibernateProxyFactory = entityMetamodel
 				.getTuplizer()
@@ -338,7 +334,6 @@ public class DefaultReactiveLoadEventListener implements LoadEventListener, Reac
 
 		// Check for the case where we can use the entity itself as a proxy
 		if ( options.isAllowProxyCreation()
-				&& allowBytecodeProxy
 				&& entityMetamodel.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading() ) {
 			// if there is already a managed entity instance associated with the PC, return it
 			final Object managed = persistenceContext.getEntity( keyToLoad );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
@@ -378,8 +378,7 @@ public class DefaultReactiveMergeEventListener extends AbstractReactiveSaveEvent
 		}
 
 		if ( incoming instanceof PersistentAttributeInterceptable
-				&& persister.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading()
-				&& source.getSessionFactory().getSessionFactoryOptions().isEnhancementAsProxyEnabled() ) {
+				&& persister.getBytecodeEnhancementMetadata().isEnhancedForLazyLoading() ) {
 
 			final PersistentAttributeInterceptor incomingInterceptor = ( (PersistentAttributeInterceptable) incoming ).$$_hibernate_getInterceptor();
 			final PersistentAttributeInterceptor managedInterceptor = ( (PersistentAttributeInterceptable) managed ).$$_hibernate_getInterceptor();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -1068,8 +1068,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 	default boolean hasUnenhancedProxy() {
 		// skip proxy instantiation if entity is bytecode enhanced
 		return getEntityMetamodel().isLazy()
-				&& !( getEntityMetamodel().getBytecodeEnhancementMetadata().isEnhancedForLazyLoading()
-					&& getFactory().getSessionFactoryOptions().isEnhancementAsProxyEnabled() );
+				&& !getEntityMetamodel().getBytecodeEnhancementMetadata().isEnhancedForLazyLoading();
 	}
 
 	Object initializeLazyProperty(String fieldName, Object entity, SharedSessionContractImplementor session);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -81,7 +81,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final ReactiveConnection reactiveConnection;
-	private final boolean allowBytecodeProxy;
 
 	private final ReactiveStatelessSession batchingHelperSession;
 
@@ -93,7 +92,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
 			ReactiveConnection connection) {
 		super( factory, options );
 		reactiveConnection = connection;
-		allowBytecodeProxy = getFactory().getSessionFactoryOptions().isEnhancementAsProxyEnabled();
 		persistenceContext = new ReactivePersistenceContextAdapter( this );
 		batchingHelperSession = new ReactiveStatelessSessionImpl( factory, options, connection, persistenceContext );
 	}
@@ -110,7 +108,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
 		Integer batchSize = getConfiguredJdbcBatchSize();
 		reactiveConnection = batchSize == null || batchSize < 2 ? connection :
 				new BatchingConnection( connection, batchSize );
-		allowBytecodeProxy = getFactory().getSessionFactoryOptions().isEnhancementAsProxyEnabled();
 		this.persistenceContext = persistenceContext;
 		batchingHelperSession = this;
 	}
@@ -645,7 +642,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
 
 			EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
 			BytecodeEnhancementMetadata enhancementMetadata = entityMetamodel.getBytecodeEnhancementMetadata();
-			if ( allowBytecodeProxy && enhancementMetadata.isEnhancedForLazyLoading() ) {
+			if ( enhancementMetadata.isEnhancedForLazyLoading() ) {
 
 				// if the entity defines a HibernateProxy factory, see if there is an
 				// existing proxy associated with the PC - and if so, use it


### PR DESCRIPTION
(since 5.5) use of enhanced proxies is always enabled

Fixes #1020 