### PR TITLE
uncomment code in EntityTypes

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
@@ -309,6 +309,11 @@ public class EntityTypes {
                                         + original.getClass().getName()
                         );
                     }
+                    // For the special case of a @ManyToOne joined on a (non-primary) unique key,
+                    // the "id" class is actually the associated entity object itself, but treated
+                    // as a ComponentType. In the case that the entity is unfetched, we need to
+                    // explicitly fetch it here before calling replace(). (Note that in Hibernate
+                    // ORM this is unnecessary due to transparent lazy fetching.)
                     return ((ReactiveSessionImpl) session).reactiveFetch( id, true )
                             .thenCompose( fetched -> {
                                 Object idOrUniqueKey =

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ForeignKeys.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ForeignKeys.java
@@ -328,7 +328,7 @@ public final class ForeignKeys {
 	 *
 	 * @throws TransientObjectException if the entity is transient (does not yet have an identifier)
 	 */
-	public static CompletionStage<Serializable> getEntityIdentifierIfNotUnsaved(
+	public static CompletionStage<Object> getEntityIdentifierIfNotUnsaved(
 			final String entityName,
 			final Object object,
 			final SessionImplementor session) throws TransientObjectException {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
@@ -46,6 +46,31 @@ public class EagerUniqueKeyTest extends BaseReactiveTest {
                 ) );
     }
 
+
+    @Test
+    public void testMergeDetached(TestContext context) {
+        Bar bar = new Bar("unique2");
+        test(context, getSessionFactory()
+                .withTransaction( (session, tx) -> session.persist(bar) )
+                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
+                        -> session.merge( new Foo(bar) ) ) )
+                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
+                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique2", b.key ) )
+                ) ) );
+    }
+
+    @Test
+    public void testMergeReference(TestContext context) {
+        Bar bar = new Bar("unique3");
+        test(context, getSessionFactory()
+                .withTransaction( (session, tx) -> session.persist(bar) )
+                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
+                        -> session.merge( new Foo( session.getReference(Bar.class, bar.id) ) ) ) )
+                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
+                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique3", b.key ) )
+                ) ) );
+    }
+
     @Entity(name="Foo")
     static class Foo {
         Foo(Bar bar) {


### PR DESCRIPTION
This code was disabled because the needed operations in Hibernate ORM were
not exposed.

fixes #959