### PR TITLE
Additional schema update and validation tests  

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/adaptor/impl/ResultSetAdaptor.java
@@ -142,7 +142,7 @@ public class ResultSetAdaptor implements ResultSet {
 	@Override
 	public Date getDate(int columnIndex) {
 		LocalDate localDate = row.getLocalDate( columnIndex - 1 );
-		return (wasNull=localDate==null) ? null : java.sql.Date.valueOf(localDate);
+		return (wasNull=localDate==null) ? null : Date.valueOf(localDate);
 	}
 
 	@Override
@@ -269,7 +269,7 @@ public class ResultSetAdaptor implements ResultSet {
 	@Override
 	public Date getDate(String columnLabel) {
 		LocalDate localDate = row.getLocalDate(columnLabel);
-		return (wasNull=localDate==null) ? null : java.sql.Date.valueOf(localDate);
+		return (wasNull=localDate==null) ? null : Date.valueOf(localDate);
 	}
 
 	@Override
@@ -721,7 +721,12 @@ public class ResultSetAdaptor implements ResultSet {
 
 	@Override
 	public Blob getBlob(String columnLabel) {
-		Buffer buffer = (Buffer) row.getValue( columnLabel );
+		final Object value = row.getValue( columnLabel );
+		// Vertx MySQL client is currently returning a row value of String
+		// Checking for instanceof String else assume Buffer value
+		Buffer buffer = value instanceof String
+				? Buffer.buffer( (String) value )
+				: (Buffer) value;
 		wasNull = buffer == null;
 		return wasNull ? null : BlobProxy.generateProxy( buffer.getBytes() );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/AbstractReactiveInformationSchemaBasedExtractorImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/AbstractReactiveInformationSchemaBasedExtractorImpl.java
@@ -5,14 +5,21 @@
  */
 package org.hibernate.reactive.provider.service;
 
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.StringTokenizer;
 
+import org.hibernate.boot.model.TruthValue;
+import org.hibernate.boot.model.naming.DatabaseIdentifier;
 import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.tool.schema.extract.internal.AbstractInformationExtractorImpl;
+import org.hibernate.tool.schema.extract.internal.ColumnInformationImpl;
+import org.hibernate.tool.schema.extract.spi.ColumnInformation;
 import org.hibernate.tool.schema.extract.spi.ExtractionContext;
 import org.hibernate.tool.schema.extract.spi.InformationExtractor;
+import org.hibernate.tool.schema.extract.spi.TableInformation;
 
 /**
  * An implementation of {@link InformationExtractor} that obtains metadata
@@ -240,8 +247,12 @@ public abstract class AbstractReactiveInformationSchemaBasedExtractorImpl extend
 		final StringBuilder sb = new StringBuilder()
 				.append( "select table_name as " ).append( getResultSetTableNameLabel() )
 				.append( ", column_name as " ).append( getResultSetColumnNameLabel() )
-				.append( ", " ).append( getInformationSchemaColumnsDataTypeColumn() )
-				.append( " as " ).append( getResultSetTypeNameLabel() )
+				.append( ", " ).append( " case when " )
+				.append( getInformationSchemaColumnsDataTypeColumn() )
+				.append( " = 'bpchar' then 'CHAR' else " )
+				.append( getInformationSchemaColumnsDataTypeColumn() )
+				.append( " end as ")
+				.append( getResultSetTypeNameLabel() )
 				.append( ", null as " ).append( getResultSetColumnSizeLabel() )
 				// Column size is fairly complicated to get out of information_schema
 				// and likely to be DB-dependent. Currently, Hibernate ORM does not use
@@ -331,5 +342,38 @@ public abstract class AbstractReactiveInformationSchemaBasedExtractorImpl extend
 	 */
 	protected String getDatabaseSchemaColumnName(String catalogColumnName, String schemaColumnName ) {
 		return schemaColumnName;
+	}
+
+	@Override
+	protected void addExtractedColumnInformation(
+			TableInformation tableInformation, ResultSet resultSet) throws SQLException {
+		final String typeName = new StringTokenizer( resultSet.getString( getResultSetTypeNameLabel() ), "() " ).nextToken();
+		final ColumnInformation columnInformation = new ColumnInformationImpl(
+				tableInformation,
+				DatabaseIdentifier.toIdentifier( resultSet.getString( getResultSetColumnNameLabel() ) ),
+				dataTypeCode( typeName ),
+				typeName,
+				resultSet.getInt( getResultSetColumnSizeLabel() ),
+				resultSet.getInt( getResultSetDecimalDigitsLabel() ),
+				interpretTruthValue( resultSet.getString( getResultSetIsNullableLabel() ) )
+		);
+		tableInformation.addColumn( columnInformation );
+	}
+
+	/**
+	 * Return a JDBC Type code for the given type name
+	 */
+	protected int dataTypeCode(String typeName) {
+		return 0;
+	}
+
+	private TruthValue interpretTruthValue(String nullable) {
+		if ( "yes".equalsIgnoreCase( nullable ) ) {
+			return TruthValue.TRUE;
+		}
+		else if ( "no".equalsIgnoreCase( nullable ) ) {
+			return TruthValue.FALSE;
+		}
+		return TruthValue.UNKNOWN;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/SqlServerReactiveInformationExtractorImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/SqlServerReactiveInformationExtractorImpl.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive.provider.service;
 
 import java.sql.SQLException;
+import java.sql.Types;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -249,4 +250,16 @@ public class SqlServerReactiveInformationExtractorImpl extends AbstractReactiveI
 
 		return getExtractionContext().getQueryResults( sb.toString(), parameters.toArray(), processor );
 	}
+
+	@Override
+	protected int dataTypeCode(String typeName) {
+		// SQL Server only supports "float" sql type for double precision
+		// so return code for double for both double and float column types
+		if ( typeName.equalsIgnoreCase( "float" ) ||
+				typeName.toLowerCase().startsWith( "double" ) ) {
+			return Types.DOUBLE;
+		}
+		return super.dataTypeCode( typeName );
+	}
+
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
@@ -12,7 +12,7 @@ import org.testcontainers.containers.Container;
 
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.isNotBlank;
 
-class CockroachDBDatabase implements TestableDatabase {
+class CockroachDBDatabase extends PostgreSQLDatabase {
 
 	public static CockroachDBDatabase INSTANCE = new CockroachDBDatabase();
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -5,6 +5,9 @@
  */
 package org.hibernate.reactive.containers;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 import org.testcontainers.containers.Db2Container;
 
 class DB2Database implements TestableDatabase {
@@ -12,6 +15,51 @@ class DB2Database implements TestableDatabase {
 	public static DB2Database INSTANCE = new DB2Database();
 
 	public final static String IMAGE_NAME = "ibmcom/db2:11.5.5.1";
+
+	String findTypeForColumnBaseQuery =
+			"SELECT TYPENAME FROM SYSCAT.COLUMNS where TABNAME = '" + TABLE_PARAM + "' and COLNAME = '" + COLUMN_PARAM + "'";
+
+	String selectColumnsOnlyQuery
+			= "SELECT COLNAME FROM SYSCAT.COLUMNS where TABNAME = '" + TABLE_PARAM + "'";
+
+	public static Map<DataType, String> expectedDBTypeForEntityType = new EnumMap<DataType, String>( DataType.class);
+	static {{
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_PRIMITIVE, "SMALLINT");
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_FIELD, "SMALLINT");
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_NUMERIC, "INTEGER");
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_TRUE_FALSE, "CHARACTER");
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_YES_NO, "CHARACTER");
+		expectedDBTypeForEntityType.put( DataType.INT_PRIMITIVE, "INTEGER");
+		expectedDBTypeForEntityType.put( DataType.INTEGER_FIELD, "INTEGER");
+		expectedDBTypeForEntityType.put( DataType.LONG_PRIMITIVE, "BIGINT");
+		expectedDBTypeForEntityType.put( DataType.LONG_FIELD, "BIGINT");
+		expectedDBTypeForEntityType.put( DataType.FLOAT_PRIMITIVE, "DOUBLE");
+		expectedDBTypeForEntityType.put( DataType.FLOAT_FIELD, "DOUBLE");
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_PRIMITIVE, "DOUBLE");
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_FIELD, "DOUBLE");
+		expectedDBTypeForEntityType.put( DataType.BYTE_PRIMITIVE, "SMALLINT");
+		expectedDBTypeForEntityType.put( DataType.BYTE_FIELD, "SMALLINT");
+		expectedDBTypeForEntityType.put( DataType.BYTES_PRIMITIVE, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.URL, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.TIMEZONE, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.DATE_TEMPORAL_TYPE, "DATE");
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIMESTAMP_TEMPORAL_TYPE, "TIMESTAMP");
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIME_TEMPORAL_TYPE, "TIME");
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_DATE_TEMPORAL_TYPE, "DATE");
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_TIMESTAMP_TEMPORAL_TYPE, "TIMESTAMP");
+		expectedDBTypeForEntityType.put( DataType.LOCALDATE, "DATE");
+		expectedDBTypeForEntityType.put( DataType.LOCALTIME, "TIME");
+		expectedDBTypeForEntityType.put( DataType.LOCALDATETIME, "TIMESTAMP");
+		expectedDBTypeForEntityType.put( DataType.BIGINTEGER, "DECIMAL");
+		expectedDBTypeForEntityType.put( DataType.BIGDECIMAL, "DECIMAL");
+		expectedDBTypeForEntityType.put( DataType.SERIALIZABLE, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.UUID, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.INSTANT, "TIMESTAMP");
+		expectedDBTypeForEntityType.put( DataType.DURATION, "BIGINT");
+		expectedDBTypeForEntityType.put( DataType.CHARACTER, "CHARACTER");
+		expectedDBTypeForEntityType.put( DataType.TEXT, "VARCHAR");
+		expectedDBTypeForEntityType.put( DataType.STRING, "VARCHAR");
+	}}
 
 	/**
 	 * Holds configuration for the DB2 database container. If the build is run with <code>-Pdocker</code> then
@@ -39,6 +87,21 @@ class DB2Database implements TestableDatabase {
 	@Override
 	public String getUri() {
 		return buildUriWithCredentials( address() );
+	}
+
+	@Override
+	public String getNativeDatatypeQuery(String tableName, String columnName) {
+		if( columnName == null ) {
+			return selectColumnsOnlyQuery.replace(TABLE_PARAM, tableName.toUpperCase() );
+		}
+		return findTypeForColumnBaseQuery.replace(
+				TABLE_PARAM, tableName.toUpperCase() ).replace(
+				COLUMN_PARAM, columnName.toUpperCase() );
+	}
+
+	@Override
+	public String getExpectedNativeDatatype(DataType dataType) {
+		return expectedDBTypeForEntityType.get(dataType);
 	}
 
 	private String address() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DatabaseConfiguration.java
@@ -91,6 +91,14 @@ public class DatabaseConfiguration {
 		return dbType().configuration.getUri();
 	}
 
+	public static String getDatatypeQuery(String tableName, String columnName) {
+		return dbType().configuration.getNativeDatatypeQuery( tableName, columnName );
+	}
+
+	public static String getExpectedDatatype(TestableDatabase.DataType dataType) {
+		return dbType().configuration.getExpectedNativeDatatype( dataType );
+	}
+
 	private DatabaseConfiguration() {
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
@@ -6,11 +6,59 @@
 package org.hibernate.reactive.containers;
 
 
-class MariaDatabase implements TestableDatabase {
+import java.util.EnumMap;
+import java.util.Map;
+
+class MariaDatabase extends MySQLDatabase {
 
 	static MariaDatabase INSTANCE = new MariaDatabase();
 
 	public final static String IMAGE_NAME = "mariadb:10.6.4";
+
+	String findTypeForColumnBaseQuery =
+			"select data_type from information_schema.columns where table_name = '" + TABLE_PARAM + "'  and column_name = '" + COLUMN_PARAM + "'";
+
+	String selectColumnsOnlyQuery
+			= "select column_name from information_schema.columns where table_name = '" + TABLE_PARAM + "'";
+
+	public static Map<DataType, String> expectedDBTypeForEntityType = new EnumMap<DataType, String>( DataType.class);
+	static {{
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_PRIMITIVE, "bit" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_FIELD, "bit" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_NUMERIC, "int" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_TRUE_FALSE, "char" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_YES_NO, "char" );
+		expectedDBTypeForEntityType.put( DataType.INT_PRIMITIVE, "int" );
+		expectedDBTypeForEntityType.put( DataType.INTEGER_FIELD, "int" );
+		expectedDBTypeForEntityType.put( DataType.LONG_PRIMITIVE, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.LONG_FIELD, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.FLOAT_PRIMITIVE, "float" );
+		expectedDBTypeForEntityType.put( DataType.FLOAT_FIELD, "float" );
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_PRIMITIVE, "double" );
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_FIELD, "double" );
+		expectedDBTypeForEntityType.put( DataType.BYTE_PRIMITIVE, "tinyint" );
+		expectedDBTypeForEntityType.put( DataType.BYTE_FIELD, "tinyint" );
+		expectedDBTypeForEntityType.put( DataType.BYTES_PRIMITIVE, "tinyblob" );
+		expectedDBTypeForEntityType.put( DataType.URL, "varchar" );
+		expectedDBTypeForEntityType.put( DataType.TIMEZONE, "varchar" );
+		expectedDBTypeForEntityType.put( DataType.DATE_TEMPORAL_TYPE, "date" );
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIMESTAMP_TEMPORAL_TYPE, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIME_TEMPORAL_TYPE, "time without time zone" );
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_DATE_TEMPORAL_TYPE, "date" );
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_TIMESTAMP_TEMPORAL_TYPE, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.LOCALDATE, "date" );
+		expectedDBTypeForEntityType.put( DataType.LOCALTIME, "time without time zone" );
+		expectedDBTypeForEntityType.put( DataType.LOCALDATETIME, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.BIGINTEGER, "decimal" );
+		expectedDBTypeForEntityType.put( DataType.BIGDECIMAL, "decimal" );
+		expectedDBTypeForEntityType.put( DataType.SERIALIZABLE, "tinyblob" );
+		expectedDBTypeForEntityType.put( DataType.UUID, "uuid" );
+		expectedDBTypeForEntityType.put( DataType.INSTANT, "timestamp without time zone" );
+		expectedDBTypeForEntityType.put( DataType.DURATION, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.CHARACTER, "char" );
+		expectedDBTypeForEntityType.put( DataType.TEXT, "text" );
+		expectedDBTypeForEntityType.put( DataType.STRING, "varchar" );
+	}};
 
 	/**
 	 * Holds configuration for the MariaDB database container. If the build is run with <code>-Pdocker</code> then
@@ -37,6 +85,21 @@ class MariaDatabase implements TestableDatabase {
 	@Override
 	public String getUri() {
 		return buildUriWithCredentials( address() );
+	}
+
+	@Override
+	public String getNativeDatatypeQuery(String tableName, String columnName) {
+		if( columnName == null ) {
+			return selectColumnsOnlyQuery.replace(TABLE_PARAM, tableName );
+		}
+		return findTypeForColumnBaseQuery.replace(
+				TABLE_PARAM, tableName).replace(
+				COLUMN_PARAM, columnName);
+	}
+
+	@Override
+	public String getExpectedNativeDatatype(DataType dataType) {
+		return expectedDBTypeForEntityType.get(dataType);
 	}
 
 	private String address() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -5,11 +5,59 @@
  */
 package org.hibernate.reactive.containers;
 
+import java.util.EnumMap;
+import java.util.Map;
+
 class MySQLDatabase implements TestableDatabase {
 
 	static MySQLDatabase INSTANCE = new MySQLDatabase();
 
 	public final static String IMAGE_NAME = "mysql:8.0.27";
+
+	String findTypeForColumnBaseQuery =
+					"select DATA_TYPE from information_schema.columns where TABLE_NAME = '" + TABLE_PARAM + "'  and COLUMN_NAME = '" + COLUMN_PARAM + "'";
+
+	String selectColumnsOnlyQuery
+			= "select COLUMN_NAME from information_schema.columns where TABLE_NAME = '" + TABLE_PARAM + "'";
+
+	public static Map<DataType, String> expectedDBTypeForEntityType = new EnumMap<DataType, String>( DataType.class);
+	static {{
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_PRIMITIVE, "bit" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_FIELD, "bit" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_NUMERIC, "int" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_TRUE_FALSE, "char" );
+		expectedDBTypeForEntityType.put( DataType.BOOLEAN_YES_NO, "char" );
+		expectedDBTypeForEntityType.put( DataType.INT_PRIMITIVE, "int" );
+		expectedDBTypeForEntityType.put( DataType.INTEGER_FIELD, "int" );
+		expectedDBTypeForEntityType.put( DataType.LONG_PRIMITIVE, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.LONG_FIELD, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.FLOAT_PRIMITIVE, "float" );
+		expectedDBTypeForEntityType.put( DataType.FLOAT_FIELD, "float" );
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_PRIMITIVE, "double" );
+		expectedDBTypeForEntityType.put( DataType.DOUBLE_FIELD, "double" );
+		expectedDBTypeForEntityType.put( DataType.BYTE_PRIMITIVE, "tinyint" );
+		expectedDBTypeForEntityType.put( DataType.BYTE_FIELD, "tinyint" );
+		expectedDBTypeForEntityType.put( DataType.BYTES_PRIMITIVE, "tinyblob" );
+		expectedDBTypeForEntityType.put( DataType.URL, "varchar" );
+		expectedDBTypeForEntityType.put( DataType.TIMEZONE, "varchar" );
+		expectedDBTypeForEntityType.put( DataType.DATE_TEMPORAL_TYPE, "date" );
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIMESTAMP_TEMPORAL_TYPE, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.DATE_AS_TIME_TEMPORAL_TYPE, "time" );
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_DATE_TEMPORAL_TYPE, "date" );
+		expectedDBTypeForEntityType.put( DataType.CALENDAR_AS_TIMESTAMP_TEMPORAL_TYPE, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.LOCALDATE, "date" );
+		expectedDBTypeForEntityType.put( DataType.LOCALTIME, "time" );
+		expectedDBTypeForEntityType.put( DataType.LOCALDATETIME, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.BIGINTEGER, "decimal" );
+		expectedDBTypeForEntityType.put( DataType.BIGDECIMAL, "decimal" );
+		expectedDBTypeForEntityType.put( DataType.SERIALIZABLE, "tinyblob" );
+		expectedDBTypeForEntityType.put( DataType.UUID, "binary" );
+		expectedDBTypeForEntityType.put( DataType.INSTANT, "datetime" );
+		expectedDBTypeForEntityType.put( DataType.DURATION, "bigint" );
+		expectedDBTypeForEntityType.put( DataType.CHARACTER, "char" );
+		expectedDBTypeForEntityType.put( DataType.TEXT, "text" );
+		expectedDBTypeForEntityType.put( DataType.STRING, "varchar" );
+	}};
 
 	/**
 	 * Holds configuration for the MySQL database container. If the build is run with <code>-Pdocker</code> then
@@ -38,6 +86,21 @@ class MySQLDatabase implements TestableDatabase {
 		return buildUriWithCredentials( address() );
 	}
 
+	@Override
+	public String getNativeDatatypeQuery(String tableName, String columnName) {
+		if( columnName == null ) {
+			return selectColumnsOnlyQuery.replace(TABLE_PARAM, tableName );
+		}
+		return findTypeForColumnBaseQuery.replace(
+				TABLE_PARAM, tableName).replace(
+				COLUMN_PARAM, columnName);
+	}
+
+	@Override
+	public String getExpectedNativeDatatype(DataType dataType) {
+		return expectedDBTypeForEntityType.get(dataType);
+	}
+
 	private String address() {
 		String address;
 		if ( DatabaseConfiguration.USE_DOCKER ) {
@@ -60,7 +123,7 @@ class MySQLDatabase implements TestableDatabase {
 		return "mysql://" + mysql.getUsername() + ":" + mysql.getPassword() + "@" + jdbcUrl.substring(13);
 	}
 
-	private MySQLDatabase() {
+	protected MySQLDatabase() {
 	}
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
@@ -9,9 +9,36 @@ package org.hibernate.reactive.containers;
  * A database that we use for testing.
  */
 public interface TestableDatabase {
+	enum DataType {
+		BOOLEAN_PRIMITIVE, BOOLEAN_FIELD, BOOLEAN_TRUE_FALSE, BOOLEAN_YES_NO, BOOLEAN_NUMERIC,
+		INT_PRIMITIVE, INTEGER_FIELD,
+		LONG_PRIMITIVE, LONG_FIELD,
+		FLOAT_PRIMITIVE, FLOAT_FIELD,
+		DOUBLE_PRIMITIVE, DOUBLE_FIELD,
+		BYTE_PRIMITIVE, BYTE_FIELD,
+		BYTES_PRIMITIVE,
+		URL,
+		TIMEZONE,
+		DATE_TEMPORAL_TYPE, DATE_AS_TIME_TEMPORAL_TYPE, DATE_AS_TIMESTAMP_TEMPORAL_TYPE,
+		CALENDAR_AS_DATE_TEMPORAL_TYPE, CALENDAR_AS_TIMESTAMP_TEMPORAL_TYPE,
+		LOCALDATE, LOCALTIME, LOCALDATETIME,
+		BIGINTEGER, BIGDECIMAL,
+		SERIALIZABLE,
+		UUID,
+		INSTANT,
+		DURATION,
+		CHARACTER, TEXT, STRING
+	}
+
+	String TABLE_PARAM = "$table";
+	String COLUMN_PARAM = "$column";
 
 	String getJdbcUrl();
 
 	String getUri();
+
+	String getNativeDatatypeQuery(String tableName, String columnName);
+
+	String getExpectedNativeDatatype(DataType dataType);
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/BasicTypesTestEntity.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/BasicTypesTestEntity.java
@@ -1,0 +1,112 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.schema;
+
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.URL;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.TimeZone;
+import java.util.UUID;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Version;
+
+import org.hibernate.annotations.Type;
+
+@Entity(name = "BasicTypesTestEntity")
+@Table(name = BasicTypesTestEntity.TABLE_NAME)
+public class BasicTypesTestEntity {
+
+	public static final String TABLE_NAME = "BASIC_TYPES_TABLE";
+
+	String name;
+
+	@Id
+	@GeneratedValue
+	Integer id;
+	@Version
+	Integer version;
+	String aString;
+
+	boolean primitiveBoolean;
+	int primitiveInt;
+	long primitiveLong;
+	float primitiveFloat;
+	double primitiveDouble;
+	byte primitiveByte;
+	byte[] primitiveBytes;
+
+	Boolean fieldBoolean;
+	Integer fieldInteger;
+	Long fieldLong;
+	Float fieldFloat;
+	Double fieldDouble;
+	Byte fieldByte;
+
+	@Type(type = "true_false")
+	Boolean booleanTrueFalse;
+
+	@Type(type = "yes_no")
+	Boolean booleanYesNo;
+
+	@Type(type = "numeric_boolean")
+	Boolean booleanNumeric;
+
+	URL url;
+
+	TimeZone timeZone;
+
+	@Temporal(TemporalType.DATE)
+	Date date;
+	@Temporal(TemporalType.TIMESTAMP)
+	Date dateAsTimestamp;
+
+	@Temporal(TemporalType.DATE)
+	Calendar calendarAsDate;
+	@Temporal(TemporalType.TIMESTAMP)
+	Calendar calendarAsTimestamp;
+
+	@Column(name = "localdayte")
+	LocalDate localDate;
+	@Column(name = "alocalDT")
+	LocalDateTime localDateTime;
+	LocalTime theLocalTime;
+	@Temporal(TemporalType.TIME)
+	Date dateAsTime;
+
+	@javax.persistence.Basic
+	Serializable thing;
+
+	UUID uuid;
+
+	BigDecimal bigDecimal;
+	BigInteger bigInteger;
+
+	Instant instant;
+
+	Duration duration;
+
+	Serializable serializable;
+
+	public BasicTypesTestEntity() {
+	}
+	public BasicTypesTestEntity(String name) {
+		this.name = name;
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/ColumnTypesMappingTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/ColumnTypesMappingTest.java
@@ -1,0 +1,226 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.schema;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.containers.TestableDatabase;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.getDatatypeQuery;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.getExpectedDatatype;
+
+import java.sql.Blob;
+import java.sql.SQLException;
+
+/**
+ * Check that each property is mapped as the expected type in the database.
+ */
+public class ColumnTypesMappingTest extends BaseReactiveTest {
+
+	@Rule
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
+
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( BasicTypesTestEntity.class );
+		return configuration;
+	}
+
+	private void testDatatype(TestContext context, String columnName, TestableDatabase.DataType datatype) {
+		BasicTypesTestEntity testEntity = new BasicTypesTestEntity( "Testing: " + columnName );
+		test( context, getSessionFactory()
+				.withTransaction( (session, t) -> session.persist( testEntity ) )
+				.thenCompose( v1 -> openSession()
+						.thenCompose( s -> s
+								.find( BasicTypesTestEntity.class, testEntity.id )
+								.thenAccept( result -> context.assertEquals( testEntity.name, result.name ) )
+								.thenCompose( v -> {
+											String query = getDatatypeQuery( BasicTypesTestEntity.TABLE_NAME, columnName );
+											return s.createNativeQuery( query )
+													.getSingleResult()
+													.thenAccept(
+															result -> context.assertEquals( getExpectedDatatype( datatype ),
+																	convertToString( result )
+															) );
+										}
+								)
+						)
+				)
+		);
+	}
+
+	private String convertToString(Object result) {
+		if (result == null) {
+			return null;
+		}
+
+		if ( result instanceof String) {
+			return (String) result;
+		}
+
+		try {
+			// This is needed because of a bug in the Vert.x client
+			if ( result instanceof Blob ) {
+				final Blob blob = (Blob) result;
+				return new String( blob.getBytes( 1l, (int) blob.length() ) );
+			}
+		}
+		catch (SQLException e) {
+			throw new IllegalArgumentException( e );
+		}
+
+		throw new IllegalArgumentException( "Unexpected type: " + result.getClass() );
+	}
+
+	@Test
+	public void testBigDecimal(TestContext context) {
+		testDatatype( context, "bigDecimal", TestableDatabase.DataType.BIGDECIMAL);
+	}
+
+	@Test
+	public void testStringType(TestContext context) {
+		testDatatype( context, "aString", TestableDatabase.DataType.STRING );
+	}
+
+	@Test
+	public void testIntegerFieldType(TestContext context) {
+		testDatatype( context, "fieldInteger", TestableDatabase.DataType.INTEGER_FIELD );
+	}
+
+	@Test
+	public void testIntegerPrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveInt", TestableDatabase.DataType.INT_PRIMITIVE );
+	}
+
+	@Test
+	public void testBigIntegerType(TestContext context) {
+		testDatatype( context, "bigInteger", TestableDatabase.DataType.BIGINTEGER );
+	}
+
+	@Test
+	public void testLongFieldType(TestContext context) {
+		testDatatype( context, "fieldLong", TestableDatabase.DataType.LONG_FIELD );
+	}
+
+	@Test
+	public void testLongPrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveLong", TestableDatabase.DataType.LONG_PRIMITIVE );
+	}
+
+	@Test
+	public void testFloatFieldType(TestContext context) {
+		testDatatype( context, "fieldFloat", TestableDatabase.DataType.FLOAT_FIELD );
+	}
+
+	@Test
+	public void testFloatPrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveFloat", TestableDatabase.DataType.FLOAT_PRIMITIVE );
+	}
+
+
+	@Test
+	public void testDoubleFieldType(TestContext context) {
+		testDatatype( context, "fieldDouble", TestableDatabase.DataType.DOUBLE_FIELD );
+	}
+
+	@Test
+	public void testDoublePrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveDouble", TestableDatabase.DataType.DOUBLE_PRIMITIVE );
+	}
+
+	@Test
+	public void testBooleanPrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveBoolean", TestableDatabase.DataType.BOOLEAN_PRIMITIVE );
+	}
+
+	@Test
+	public void testBooleanFieldType(TestContext context) {
+		testDatatype( context, "fieldBoolean", TestableDatabase.DataType.BOOLEAN_FIELD );
+	}
+
+	@Test
+	public void testBooleanTrueFalseType(TestContext context) {
+		testDatatype( context, "booleanTrueFalse", TestableDatabase.DataType.CHARACTER );
+	}
+
+	@Test
+	public void testBooleanYesNoType(TestContext context) {
+		testDatatype( context, "booleanYesNo", TestableDatabase.DataType.BOOLEAN_YES_NO );
+	}
+
+	@Test
+	public void testBooleanNumericType(TestContext context) {
+		testDatatype( context, "booleanNumeric", TestableDatabase.DataType.BOOLEAN_NUMERIC );
+	}
+
+	@Test
+	public void testBytePrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveByte", TestableDatabase.DataType.BYTE_PRIMITIVE );
+	}
+
+	@Test
+	public void testBytesPrimitiveType(TestContext context) {
+		testDatatype( context, "primitiveBytes", TestableDatabase.DataType.BYTES_PRIMITIVE );
+	}
+
+	@Test
+	public void testByteFieldType(TestContext context) {
+		testDatatype( context, "fieldByte", TestableDatabase.DataType.BYTE_FIELD );
+	}
+
+	@Test
+	public void testUrlType(TestContext context) {
+		testDatatype( context, "url", TestableDatabase.DataType.URL );
+	}
+
+	@Test
+	public void testDateType(TestContext context) {
+		testDatatype( context, "date", TestableDatabase.DataType.DATE_TEMPORAL_TYPE );
+	}
+
+	@Test
+	public void testDateAsTimestampType(TestContext context) {
+		testDatatype( context, "dateAsTimestamp", TestableDatabase.DataType.DATE_AS_TIMESTAMP_TEMPORAL_TYPE );
+	}
+
+	@Test
+	public void testTimeZoneType(TestContext context) {
+		testDatatype( context, "timeZone", TestableDatabase.DataType.TIMEZONE );
+	}
+
+	@Test
+	public void testCalendarAsDateType(TestContext context) {
+		testDatatype( context, "calendarAsDate", TestableDatabase.DataType.DATE_TEMPORAL_TYPE );
+	}
+
+	@Test
+	public void testCalendarAsTimestampType(TestContext context) {
+		testDatatype( context, "calendarAsTimestamp", TestableDatabase.DataType.CALENDAR_AS_TIMESTAMP_TEMPORAL_TYPE );
+	}
+
+	@Test
+	public void testLocalDateType(TestContext context) {
+		testDatatype( context, "localdayte", TestableDatabase.DataType.LOCALDATE );
+	}
+
+	@Test
+	public void testLocalDateTimeType(TestContext context) {
+		testDatatype( context, "alocalDT", TestableDatabase.DataType.LOCALDATETIME );
+	}
+
+	@Test
+	public void testSerializableType(TestContext context) {
+		testDatatype( context, "serializable", TestableDatabase.DataType.SERIALIZABLE );
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateMySqlTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateMySqlTestBase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.reactive;
+package org.hibernate.reactive.schema;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -21,9 +21,9 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.hibernate.tool.schema.spi.SchemaManagementException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,14 +32,13 @@ import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
 
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MYSQL;
 import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.GROUPED;
 import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.INDIVIDUALLY;
 
-public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
+public abstract class SchemaUpdateMySqlTestBase extends BaseReactiveTest {
 
-	public static class IndividuallySchemaUpdateMariaDBTestBase
-			extends SchemaUpdateMariaDBTestBase {
+	public static class IndividuallySchemaUpdateMySqlTestBase extends SchemaUpdateMySqlTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {
@@ -49,7 +48,7 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 		}
 	}
 
-	public static class GroupedSchemaUpdateMariaDBTestBase extends SchemaUpdateMariaDBTestBase {
+	public static class GroupedSchemaUpdateMySqlTestBase extends SchemaUpdateMySqlTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {
@@ -67,7 +66,7 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 	}
 
 	@Rule
-	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.runOnlyFor( MARIA );
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.runOnlyFor( MYSQL );
 
 	@Before
 	@Override
@@ -93,7 +92,6 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 				.thenCompose( v -> factoryManager.stop() ) );
 	}
 
-
 	@Test
 	public void testValidationSucceed(TestContext context) {
 		Configuration createHbm2ddlConf = constructConfiguration( "validate" );
@@ -103,37 +101,8 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 		test( context, setupSessionFactory( createHbm2ddlConf ) );
 	}
 
-	//TODO: I'm just checking that the validation fails because the table is missing, but we need more tests to check that
-	//      it fails for other scenarios: missing column, wrong type (?) and so on. (I don't know exactly what cases `validate`
-	//      actually checks).
-	@Test
-	public void testValidationFails(TestContext context) {
-		Configuration createHbm2ddlConf = constructConfiguration( "validate" );
-		createHbm2ddlConf.addAnnotatedClass( AAnother.class );
-
-		test( context, setupSessionFactory( createHbm2ddlConf )
-				.handle( (unused, throwable) -> {
-					context.assertNotNull( throwable );
-					context.assertEquals( throwable.getClass(), SchemaManagementException.class );
-					context.assertEquals( throwable.getMessage(), "Schema-validation: missing table [hreact.AAnother]" );
-					return null;
-				} ) );
-	}
-
 	@Test
 	public void testUpdate(TestContext context) {
-
-		// NOTE: MariaDB returns 'A' for ascending columns sorted in ascending order
-		//       for the collation column using this query:
-		//           select * from information_schema.statistics.
-		//       For some reason, it returns null for collation when explicitly
-		//       listed, as in:
-		//           select column_name, collation from information_schema.statistics
-		//       In addition, MariaDB does not support descending indexes currently
-		//       (https://jira.mariadb.org/browse/MDEV-13756)
-
-		// For now, collation will remain in the query, but checks on results
-		// returned for that column will be commented out.
 		final String indexDefinitionQuery =
 				"select column_name, collation from information_schema.statistics " +
 						"where table_schema = 'hreact' " +
@@ -197,7 +166,7 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( result -> {
 													final Object[] resultArray = (Object[]) result;
 													context.assertEquals( "id", resultArray[0] );
-													//context.assertEquals( "A", resultArray[1] );
+													context.assertEquals( "A", resultArray[1] );
 												} )
 										).thenCompose( v -> s.createNativeQuery( indexDefinitionQuery )
 												.setParameter( 1, "ASimple" )
@@ -207,9 +176,9 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( list -> {
 													context.assertEquals( 2, list.size() );
 													context.assertEquals( "aValue", ( (Object[]) list.get( 0 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
 													context.assertEquals( "aStringValue", ( (Object[]) list.get( 1 ) )[0] );
-													//context.assertEquals( "D", ( (Object[]) list.get( 1 ) )[1] );
+													context.assertEquals( "D", ( (Object[]) list.get( 1 ) )[1] );
 												} )
 										).thenCompose( v -> s.createNativeQuery( indexDefinitionQuery )
 												.setParameter( 1, "ASimple" )
@@ -219,9 +188,9 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( list -> {
 													context.assertEquals( 2, list.size() );
 													context.assertEquals( "aValue", ( (Object[]) list.get( 0 ) )[0] );
-													//context.assertEquals( "D", ( (Object[]) list.get( 0 ) )[1] );
+													context.assertEquals( "D", ( (Object[]) list.get( 0 ) )[1] );
 													context.assertEquals( "data", ( (Object[]) list.get( 1 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 1 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 1 ) )[1] );
 												} )
 										).thenCompose( v -> s.createNativeQuery( indexDefinitionQuery )
 												.setParameter( 1, "ASimple" )
@@ -231,7 +200,7 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( list -> {
 													context.assertEquals( 1, list.size() );
 													context.assertEquals( "aStringValue", ( (Object[]) list.get( 0 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
 												} )
 										).thenCompose( v -> s.createNativeQuery( indexDefinitionQuery )
 												.setParameter( 1, "AOther" )
@@ -241,9 +210,9 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( list -> {
 													context.assertEquals( 2, list.size() );
 													context.assertEquals( "id1", ( (Object[]) list.get( 0 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
 													context.assertEquals( "id2", ( (Object[]) list.get( 1 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 1 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 1 ) )[1] );
 												} )
 										).thenCompose( v -> s.createNativeQuery( indexDefinitionQuery )
 												.setParameter( 1, "AAnother" )
@@ -253,7 +222,7 @@ public abstract class SchemaUpdateMariaDBTestBase extends BaseReactiveTest {
 												.thenAccept( list -> {
 													context.assertEquals( 1, list.size() );
 													context.assertEquals( "id", ( (Object[]) list.get( 0 ) )[0] );
-													//context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
+													context.assertEquals( "A", ( (Object[]) list.get( 0 ) )[1] );
 												} )
 										// check foreign keys
 										).thenCompose( v -> s.createNativeQuery( foreignKeyDefinitionQuery )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdatePostgreSqlTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdatePostgreSqlTestBase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.reactive;
+package org.hibernate.reactive.schema;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -21,9 +21,9 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.hibernate.tool.schema.spi.SchemaManagementException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -32,13 +32,13 @@ import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
 
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.GROUPED;
 import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.INDIVIDUALLY;
 
-public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
+public abstract class SchemaUpdatePostgreSqlTestBase extends BaseReactiveTest {
 
-	public static class IndividuallySchemaUpdateCockroachTestBase extends SchemaUpdateCockroachDBTestBase {
+	public static class IndividuallySchemaUpdatePostgreSqlTestBase extends SchemaUpdatePostgreSqlTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {
@@ -48,7 +48,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 		}
 	}
 
-	public static class GroupedSchemaUpdateCockroachTestBase extends SchemaUpdateCockroachDBTestBase {
+	public static class GroupedSchemaUpdatePostgreSqlTestBase extends SchemaUpdatePostgreSqlTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {
@@ -66,7 +66,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 	}
 
 	@Rule
-	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.runOnlyFor( COCKROACHDB );
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
 
 	@Before
 	@Override
@@ -92,7 +92,6 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 				.thenCompose( v -> factoryManager.stop() ) );
 	}
 
-
 	@Test
 	public void testValidationSucceed(TestContext context) {
 		Configuration createHbm2ddlConf = constructConfiguration( "validate" );
@@ -100,23 +99,6 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 		createHbm2ddlConf.addAnnotatedClass( AOther.class );
 
 		test( context, setupSessionFactory( createHbm2ddlConf ) );
-	}
-
-	//TODO: I'm just checking that the validation fails because the table is missing, but we need more tests to check that
-	//      it fails for other scenarios: missing column, wrong type (?) and so on. (I don't know exactly what cases `validate`
-	//      actually checks).
-	@Test
-	public void testValidationFails(TestContext context) {
-		Configuration createHbm2ddlConf = constructConfiguration( "validate" );
-		createHbm2ddlConf.addAnnotatedClass( AAnother.class );
-
-		test( context, setupSessionFactory( createHbm2ddlConf )
-				.handle( (unused, throwable) -> {
-					context.assertNotNull( throwable );
-					context.assertEquals( throwable.getClass(), SchemaManagementException.class );
-					context.assertEquals( throwable.getMessage(), "Schema-validation: missing table [public.AAnother]" );
-					return null;
-				} ) );
 	}
 
 	@Test
@@ -174,19 +156,19 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.getResultList()
 												.thenAccept( list -> {
 													context.assertEquals(
-															"CREATE INDEX i_asimple_avalue_astringvalue ON postgres.public.asimple USING btree (avalue ASC, astringvalue DESC)",
+															"CREATE UNIQUE INDEX asimple_pkey ON public.asimple USING btree (id)",
 															list.get( 0 )
 													);
 													context.assertEquals(
-															"CREATE INDEX i_asimple_avalue_data ON postgres.public.asimple USING btree (avalue DESC, data ASC)",
+															"CREATE INDEX i_asimple_avalue_astringvalue ON public.asimple USING btree (avalue, astringvalue DESC)",
 															list.get( 1 )
 													);
 													context.assertEquals(
-															"CREATE UNIQUE INDEX \"primary\" ON postgres.public.asimple USING btree (id ASC)",
+															"CREATE INDEX i_asimple_avalue_data ON public.asimple USING btree (avalue DESC, data)",
 															list.get( 2 )
 													);
 													context.assertEquals(
-															"CREATE UNIQUE INDEX u_asimple_astringvalue ON postgres.public.asimple USING btree (astringvalue ASC)",
+															"CREATE UNIQUE INDEX u_asimple_astringvalue ON public.asimple USING btree (astringvalue)",
 															list.get( 3 )
 													);
 												} )
@@ -196,7 +178,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.getSingleResult()
 												.thenAccept( result ->
 																	 context.assertEquals(
-																			 "CREATE UNIQUE INDEX \"primary\" ON postgres.public.aother USING btree (id1 ASC, id2 ASC)",
+																			 "CREATE UNIQUE INDEX aother_pkey ON public.aother USING btree (id1, id2)",
 																			 result
 																	 )
 												)
@@ -206,7 +188,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.getSingleResult()
 												.thenAccept( result ->
 																	 context.assertEquals(
-																			 "CREATE UNIQUE INDEX \"primary\" ON postgres.public.aanother USING btree (id ASC)",
+																			 "CREATE UNIQUE INDEX aanother_pkey ON public.aanother USING btree (id)",
 																			 result
 																	 )
 												)
@@ -266,7 +248,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 
 	@Entity(name = "ASimple")
 	@Table(name = "ASimple", indexes = {
-			@Index(name = "i_asimple_avalue_astringValue", columnList = "aValue ASC, aStringValue DESC"),
+			@Index(name = "i_asimple_avalue_astringvalue", columnList = "aValue ASC, aStringValue DESC"),
 			@Index(name = "i_asimple_avalue_data", columnList = "aValue DESC, data ASC")
 	},
 			uniqueConstraints = { @UniqueConstraint(name = "u_asimple_astringvalue", columnNames = "aStringValue") }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
-package org.hibernate.reactive;
+package org.hibernate.reactive.schema;
 
 import java.io.Serializable;
 import java.util.Objects;
@@ -22,9 +22,9 @@ import javax.persistence.Table;
 import javax.persistence.UniqueConstraint;
 
 import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.hibernate.tool.schema.spi.SchemaManagementException;
 
 import org.junit.After;
 import org.junit.Before;
@@ -167,23 +167,6 @@ public abstract class SchemaUpdateSqlServerTestBase extends BaseReactiveTest {
 		configuration.addAnnotatedClass( AOther.class );
 
 		test( context, setupSessionFactory( configuration ) );
-	}
-
-	//TODO: We need more tests to check that it fails for other scenarios:
-	//      missing column, wrong type (?) and so on. (I don't know exactly what cases `validate` actually checks).
-	@Test
-	public void testValidationFails(TestContext context) {
-		Configuration configuration = constructConfiguration( "validate" );
-		configuration.addAnnotatedClass( AAnother.class );
-
-		final String errorMessage = "Schema-validation: missing table [" + addCatalog( "dbo.AAnother" ) + "]";
-		test( context, setupSessionFactory( configuration )
-				.handle( (unused, throwable) -> {
-					context.assertNotNull( throwable );
-					context.assertEquals( throwable.getClass(), SchemaManagementException.class );
-					context.assertEquals( throwable.getMessage(), errorMessage );
-					return null;
-				} ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTestBase.java
@@ -1,0 +1,125 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.schema;
+
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.provider.Settings;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
+import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.GROUPED;
+import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.INDIVIDUALLY;
+
+/**
+ * Schema update will run different queries when the table already exists or
+ * whn columns are missing.
+ */
+public abstract class SchemaUpdateTestBase extends BaseReactiveTest {
+
+	public static class IndividuallyStrategyTest extends SchemaUpdateTestBase {
+
+		@Override
+		protected Configuration constructConfiguration(String hbm2DdlOption) {
+			final Configuration configuration = super.constructConfiguration( hbm2DdlOption );
+			configuration.setProperty( Settings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY, INDIVIDUALLY.toString() );
+			return configuration;
+		}
+	}
+
+	public static class GroupedStrategyTest extends SchemaUpdateTestBase {
+
+		@Override
+		protected Configuration constructConfiguration(String hbm2DdlOption) {
+			final Configuration configuration = super.constructConfiguration( hbm2DdlOption );
+			configuration.setProperty( Settings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY, GROUPED.toString() );
+			return configuration;
+		}
+	}
+
+	@Rule
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
+
+	protected Configuration constructConfiguration(String action) {
+		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty( Settings.HBM2DDL_AUTO, action );
+		configuration.addAnnotatedClass( BasicTypesTestEntity.class );
+		return configuration;
+	}
+
+	@Before
+	@Override
+	public void before(TestContext context) {
+		// For these tests we create the factory when we need it
+	}
+
+	@After
+	@Override
+	public void after(TestContext context) {
+		super.after( context );
+		closeFactory( context );
+	}
+
+	/**
+	 * Test missing columns creation during schema update
+	 */
+	@Test
+	public void testMissingColumnsCreation(TestContext context) {
+		test( context,
+			  setupSessionFactory( constructConfiguration( "drop" ) )
+					  .thenCompose( v -> getSessionFactory().withTransaction( SchemaUpdateTestBase::createTable ) )
+					  .whenComplete( (u, throwable) -> factoryManager.stop() )
+					  .thenCompose( vv -> setupSessionFactory( constructConfiguration( "update" ) )
+							  .thenCompose( u -> getSessionFactory().withSession( SchemaUpdateTestBase::checkAllColumnsExist ) ) )
+		);
+	}
+
+	/**
+	 * Test table creation during schema update
+	 */
+	@Test
+	public void testWholeTableCreation(TestContext context) {
+		test( context,
+			setupSessionFactory( constructConfiguration( "drop" ) )
+				.whenComplete( (u, throwable) -> factoryManager.stop() )
+				.thenCompose( v -> setupSessionFactory( constructConfiguration( "update" ) )
+					.thenCompose( vv -> getSessionFactory().withSession( SchemaUpdateTestBase::checkAllColumnsExist ) ) )
+		);
+	}
+
+	// I don't think it's possible to create a table without columns, so we add
+	// a column that's not mapped by the entity.
+	// We expect the other columns to be created during the update schema phase.
+	private static CompletionStage<Integer> createTable(Stage.Session session, Stage.Transaction transaction) {
+		return session
+				.createNativeQuery( "create table " + BasicTypesTestEntity.TABLE_NAME + " (unmapped_column " + columnType() + ")" )
+				.executeUpdate();
+	}
+
+	private static String columnType() {
+		return dbType() == SQLSERVER ? "int" : "integer";
+	}
+
+	/**
+	 * 	The table is empty, we just want to check that a query runs without errors.
+	 * 	The query throws an exception if one of the columns is missing
+ 	 */
+	private static CompletionStage<BasicTypesTestEntity> checkAllColumnsExist(Stage.Session session) {
+		return session.find( BasicTypesTestEntity.class, 10 );
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaValidationTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaValidationTestBase.java
@@ -1,0 +1,137 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.schema;
+
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.GROUPED;
+import static org.hibernate.tool.schema.JdbcMetadaAccessStrategy.INDIVIDUALLY;
+
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.provider.Settings;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+import org.hibernate.tool.schema.spi.SchemaManagementException;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+/**
+ * Test schema validation at startup for all the supported types:
+ * - Missing table validation error
+ * - No validation error when everything is fine
+ * - TODO: Missing column
+ * - TODO: Wrong column type
+ */
+public abstract class SchemaValidationTestBase extends BaseReactiveTest {
+
+	public static class IndividuallyStrategyTest extends SchemaValidationTestBase {
+
+		@Override
+		protected Configuration constructConfiguration(String hbm2DdlOption) {
+			final Configuration configuration = super.constructConfiguration( hbm2DdlOption );
+			configuration.setProperty( Settings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY, INDIVIDUALLY.toString() );
+			return configuration;
+		}
+	}
+
+	public static class GroupedStrategyTest extends SchemaValidationTestBase {
+
+		@Override
+		protected Configuration constructConfiguration(String hbm2DdlOption) {
+			final Configuration configuration = super.constructConfiguration( hbm2DdlOption );
+			configuration.setProperty( Settings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY, GROUPED.toString() );
+			return configuration;
+		}
+	}
+
+	@Rule
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
+
+	protected Configuration constructConfiguration(String action) {
+		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty( Settings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY, INDIVIDUALLY.toString() );
+		configuration.setProperty( Settings.HBM2DDL_AUTO, action );
+		return configuration;
+	}
+
+	@Before
+	@Override
+	public void before(TestContext context) {
+		Configuration createConf = constructConfiguration( "create" );
+		createConf.addAnnotatedClass( BasicTypesTestEntity.class );
+
+		// Make sure that the extra table is not in the db
+		Configuration dropConf = constructConfiguration( "drop" );
+		dropConf.addAnnotatedClass( Extra.class );
+
+		test( context, setupSessionFactory( dropConf )
+				.thenCompose( v -> factoryManager.stop() )
+				.thenCompose( v -> setupSessionFactory( createConf ) )
+				.thenCompose( v -> factoryManager.stop() )
+		);
+	}
+
+	@After
+	@Override
+	public void after(TestContext context) {
+		super.after( context );
+		closeFactory( context );
+	}
+
+	@Test
+	public void testValidationSucceeds(TestContext context) {
+		Configuration validateConf = constructConfiguration( "validate" );
+		validateConf.addAnnotatedClass( BasicTypesTestEntity.class );
+
+		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder()
+				.applySettings( validateConf.getProperties() );
+		test( context, setupSessionFactory( validateConf ) );
+	}
+
+	@Test
+	public void testValidationFails(TestContext context) {
+		Configuration validateConf = constructConfiguration( "validate" );
+		validateConf.addAnnotatedClass( BasicTypesTestEntity.class );
+		// The table mapping this entity shouldn't be in the db
+		validateConf.addAnnotatedClass( Extra.class );
+
+		final String errorMessage = "Schema-validation: missing table [" + Extra.TABLE_NAME + "]";
+		test( context, setupSessionFactory( validateConf )
+				.handle( (unused, throwable) -> {
+					context.assertNotNull( throwable );
+					context.assertEquals( throwable.getClass(), SchemaManagementException.class );
+					context.assertEquals( throwable.getMessage(), errorMessage );
+					return null;
+				} )
+		);
+	}
+
+	/**
+	 * An extra entity used for validation,
+	 * it should not be created at start up
+	 */
+	@Entity(name = "Extra")
+	@Table(name = Extra.TABLE_NAME)
+	public static class Extra {
+		public static final String TABLE_NAME = "EXTRA_TABLE";
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String description;
+	}
+}


### PR DESCRIPTION
Fixes #1005

- Adds test to verify column entity datatypes match types returned from DB-specific schema extractors
- Refactored schema update/validation tests to schema package

replaces [PR 1017](https://github.com/hibernate/hibernate-reactive/pull/1017)