### PR TITLE
Issue #1058 - Replaced deprecated methods

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DefaultPortTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DefaultPortTest.java
@@ -15,9 +15,8 @@ import org.hibernate.reactive.containers.DatabaseConfiguration;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
 import org.hibernate.reactive.provider.Settings;
 
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import io.vertx.sqlclient.SqlConnectOptions;
 import org.assertj.core.api.Assertions;
@@ -28,9 +27,6 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
  * Test the default port is set correctly when using {@link DefaultSqlClientPoolConfiguration}
  */
 public class DefaultPortTest {
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Test
 	public void testDefaultPortIsSet() throws URISyntaxException {
@@ -44,10 +40,10 @@ public class DefaultPortTest {
 
 	@Test
 	public void testUnrecognizedSchemeException() throws URISyntaxException {
-		thrown.expect( IllegalArgumentException.class );
-
-		URI uri = new URI( "bogusScheme://localhost/database" );
-		new DefaultSqlClientPoolConfiguration().connectOptions( uri );
+		Assert.assertThrows(IllegalArgumentException.class, () -> {
+			URI uri = new URI( "bogusScheme://localhost/database" );
+			new DefaultSqlClientPoolConfiguration().connectOptions( uri );
+		});
 	}
 
 	private static String scheme() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
@@ -15,9 +15,9 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import io.vertx.ext.unit.TestContext;
 
@@ -34,9 +34,6 @@ public class IdentityGeneratorTypeForCockroachDBTest extends BaseReactiveTest {
 
 	@Rule
 	public DatabaseSelectionRule runOnly = runOnlyFor( COCKROACHDB );
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	/**
 	 * When {@link AvailableSettings#USE_GET_GENERATED_KEYS} is enabled, different
@@ -78,22 +75,24 @@ public class IdentityGeneratorTypeForCockroachDBTest extends BaseReactiveTest {
 
 	@Test
 	public void integerIdentityType(TestContext context) {
-		thrown.expectMessage( "too big" );
-		thrown.expectMessage( "Integer" );
+		Exception thrown = Assert.assertThrows(Exception.class, () ->
+				test( context, getMutinySessionFactory()
+					.withTransaction( (s, tx) -> s.persist( new IntegerTypeEntity() ) )
+		) );
 
-		test( context, getMutinySessionFactory()
-				.withTransaction( (s, tx) -> s.persist( new IntegerTypeEntity() ) )
-		);
+		Assert.assertTrue( thrown.getMessage().contains( "too big" ) );
+		Assert.assertTrue( thrown.getMessage().contains( "Integer" ) );
 	}
 
 	@Test
 	public void shortIdentityType(TestContext context) {
-		thrown.expectMessage( "too big" );
-		thrown.expectMessage( "Short" );
+		Exception thrown = Assert.assertThrows(Exception.class, () ->
+				test( context, getMutinySessionFactory()
+					.withTransaction( (s, tx) -> s.persist( new ShortTypeEntity() ) )
+		) );
 
-		test( context, getMutinySessionFactory()
-				.withTransaction( (s, tx) -> s.persist( new ShortTypeEntity() ) )
-		);
+		Assert.assertTrue( thrown.getMessage().contains( "too big" ) );
+		Assert.assertTrue( thrown.getMessage().contains( "Short" ) );
 	}
 
 	interface TypeIdentity<T extends Number> {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveMultitenantNoResolverTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveMultitenantNoResolverTest.java
@@ -24,9 +24,9 @@ import org.hibernate.reactive.testing.DatabaseSelectionRule;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.ext.unit.TestContext;
@@ -52,9 +52,6 @@ public class ReactiveMultitenantNoResolverTest extends BaseReactiveTest {
 	// To check if we are using the right database we run native queries for PostgreSQL
 	@Rule
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );
-
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
 
 	@Override
 	protected Configuration constructConfiguration() {
@@ -270,74 +267,82 @@ public class ReactiveMultitenantNoResolverTest extends BaseReactiveTest {
 
 	@Test
 	public void testOpenSessionThrowsExceptionWithoutTenant(TestContext context) {
-		thrown.expectCause( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () -> test( context, openSession().thenCompose( this::selectCurrentDB ) ) );
 
-		test( context, openSession().thenCompose( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithSessionThrowsExceptionWithoutTenant(TestContext context) {
-		thrown.expectCause( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getSessionFactory().withSession( this::selectCurrentDB ) ) );
 
-		test( context, getSessionFactory().withSession( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithTransactionThrowsExceptionWithoutTenant(TestContext context) {
-		thrown.expectCause( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getSessionFactory().withTransaction( (s, t) -> selectCurrentDB( s ) ) ) );
 
-		test( context, getSessionFactory().withTransaction( (s, t) -> selectCurrentDB( s ) ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithStatelessTransactionThrowsExceptionWithoutTenant(TestContext context) {
-		thrown.expectCause( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getSessionFactory().withStatelessTransaction( (s, t) -> selectCurrentDB( s ) ) ) );
 
-		test( context, getSessionFactory().withStatelessTransaction( (s, t) -> selectCurrentDB( s ) ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testOpenSessionThrowsExceptionWithoutTenantWithMutiny(TestContext context) {
-		thrown.expect( HibernateException.class );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, openMutinySession().call( this::selectCurrentDB ) ) );
 
-		test( context, openMutinySession().call( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithSessionThrowsExceptionWithoutTenantWithMutiny(TestContext context) {
-		thrown.expect( HibernateException.class );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getMutinySessionFactory().withSession( this::selectCurrentDB ) ) );
 
-		test( context, getMutinySessionFactory().withSession( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithTransactionThrowsExceptionWithoutTenantWithMutiny(TestContext context) {
-		thrown.expect( HibernateException.class );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getMutinySessionFactory().withTransaction( (s, t) -> selectCurrentDB( s ) ) ) );
 
-		test( context, getMutinySessionFactory().withTransaction( (s, t) -> selectCurrentDB( s ) ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithStatelessSessionThrowsExceptionWithoutTenant(TestContext context) {
-		thrown.expectCause( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getSessionFactory().withStatelessSession( this::selectCurrentDB ) ) );
 
-		test( context, getSessionFactory().withStatelessSession( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@Test
 	public void testWithStatelessSessionThrowsExceptionWithoutTenantWithMutiny(TestContext context) {
-		thrown.expect( isA( HibernateException.class ) );
-		thrown.expectMessage( "no tenant identifier" );
+		Exception thrown = Assert.assertThrows( Exception.class, () ->
+				test( context, getMutinySessionFactory().withStatelessSession( this::selectCurrentDB ) ) );
 
-		test( context, getMutinySessionFactory().withStatelessSession( this::selectCurrentDB ) );
+		Assert.assertEquals( HibernateException.class, thrown.getCause().getClass() );
+		Assert.assertTrue( thrown.getMessage().contains( "no tenant identifier" ) );
 	}
 
 	@AfterClass

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
@@ -5,15 +5,14 @@
  */
 package org.hibernate.reactive.configuration;
 
+import java.net.URI;
+
 import org.hibernate.HibernateError;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
 
-import org.junit.Rule;
+import org.junit.Assert;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
-
-import java.net.URI;
 
 import io.vertx.sqlclient.SqlConnectOptions;
 
@@ -21,22 +20,21 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class JdbcUrlParserTest {
 
-	@Rule
-	public ExpectedException thrown = ExpectedException.none();
-
 	@Test
 	public void returnsNullForNull() {
-		thrown.expect( HibernateError.class );
-		URI uri = DefaultSqlClientPool.parse( null );
-		assertThat( uri ).isNull();
+		Assert.assertThrows(HibernateError.class, () -> {
+			URI uri = DefaultSqlClientPool.parse(null);
+			assertThat(uri).isNull();
+		});
 	}
 
 	@Test
 	public void invalidParameter() {
-		thrown.expect( HibernateError.class );
-		URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact");
-		DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
-		final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
+		Assert.assertThrows(HibernateError.class, () -> {
+			URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact" );
+			DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
+			final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
+		});
 	}
 
 	@Test


### PR DESCRIPTION
#1058. 
Replaced deprecated ExpectedException.none() with Assert.assertThrows(). 
Other assertions such as exception message and cause also used the Assert library for consistency.