### PR TITLE
SQL keywords should always be lowercase

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveIdentityGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveIdentityGenerator.java
@@ -83,7 +83,7 @@ public class ReactiveIdentityGenerator extends IdentityGenerator {
 		 */
 		@Override
 		public String toStatementString() {
-			return "select " + identityColumnName + " from NEW TABLE (" + super.toStatementString() + ")";
+			return "select " + identityColumnName + " from new table (" + super.toStatementString() + ")";
 		}
 	}
 


### PR DESCRIPTION
I know, the 80s were fun, but it's time to move on...