### PR TITLE
Revise startup message

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -29,7 +29,7 @@ import static org.jboss.logging.Logger.Level.WARN;
 public interface Log extends BasicLogger {
 
 	@LogMessage(level = INFO)
-	@Message(id = 1, value = "Hibernate Reactive Preview")
+	@Message(id = 1, value = "Hibernate Reactive")
 	void startHibernateReactive();
 
 	@LogMessage(level = INFO)


### PR DESCRIPTION
Revise the Hibernate Reactive startup message. Currently it shows

```
INFO  [or.hi.re.pr.im.ReactiveIntegrator] (JPA Startup Thread: default-reactive) HR000001: Hibernate Reactive Preview
```

As HR is now past 1.0, it isn't really preview anymore.