### PR TITLE
Upgrade to JBoss Logging 3.4.3.Final

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -17,10 +17,10 @@ dependencies {
     api 'io.smallrye.reactive:mutiny:1.3.0'
 
     //Logging
-    implementation 'org.jboss.logging:jboss-logging:3.4.2.Final'
+    implementation 'org.jboss.logging:jboss-logging:3.4.3.Final'
     compileOnly 'org.jboss.logging:jboss-logging-annotations:2.2.1.Final'
 
-    annotationProcessor 'org.jboss.logging:jboss-logging:3.4.2.Final'
+    annotationProcessor 'org.jboss.logging:jboss-logging:3.4.3.Final'
     annotationProcessor 'org.jboss.logging:jboss-logging-annotations:2.2.1.Final'
     annotationProcessor 'org.jboss.logging:jboss-logging-processor:2.2.1.Final'
 

--- a/integration-tests/verticle-postgres-it/build.gradle
+++ b/integration-tests/verticle-postgres-it/build.gradle
@@ -17,7 +17,7 @@ dependencies {
     runtimeOnly "io.smallrye.reactive:smallrye-mutiny-vertx-mysql-client:${smallryeMutinyVertxVersion}"
 
     // logging
-    implementation 'org.jboss.logging:jboss-logging:3.4.2.Final'
+    implementation 'org.jboss.logging:jboss-logging:3.4.3.Final'
     runtimeOnly "org.apache.logging.log4j:log4j-core:2.17.1"
 
     // Testing


### PR DESCRIPTION
Aligning with latest in Quarkus and ORM core.

We should probably declare a centralized "libraries" section, but won't do that today.