### PR TITLE
#1059 Test SqlConnectOptions creation from URL

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -216,6 +216,12 @@ public interface Log extends BasicLogger {
 	@Message(id = 72, value= "Cannot update an uninitialized proxy. Make sure to fetch the value before trying to update it: %1$s")
 	HibernateException uninitializedProxyUpdate(Object entity);
 
+	@Message(id = 73, value= "Database username not specified (set the property 'javax.persistence.jdbc.user', or include it as a parameter in the connection URL)")
+	HibernateException databaseUsernameNotSpecifiedOnUrl();
+
+	@Message(id = 74, value = "URI parsing found duplicate property '%s=%s' found. URI = [%s]" )
+	HibernateException  duplicateUriProperty(String key, String value, String uri);
+
 	// Same method that exists in CoreMessageLogger
 	@LogMessage(level = WARN)
 	@Message(id = 104, value = "firstResult/maxResults specified with collection fetch; applying in memory!" )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -200,7 +200,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 	protected URI jdbcUrl(Map<?,?> configurationValues) {
 		String url = ConfigurationHelper.getString( Settings.URL, configurationValues );
 		LOG.sqlClientUrl( url);
-		return parse( url );
+		return parse( url, true );
 	}
 
 	/**
@@ -239,6 +239,10 @@ public class DefaultSqlClientPool extends SqlClientPool
 	}
 
 	public static URI parse(String url) {
+		return parse( url, true );
+	}
+
+	public static URI parse(String url, boolean checkDbType) {
 
 		if ( url == null || url.trim().isEmpty() ) {
 			throw new HibernateError( "The configuration property '" + Settings.URL + "' was not provided, or is in invalid format. This is required when using the default DefaultSqlClientPool: " +
@@ -246,10 +250,17 @@ public class DefaultSqlClientPool extends SqlClientPool
 		}
 
 		if ( url.startsWith( "jdbc:" ) ) {
-			return URI.create( updateUrl( url.substring( 5 ) ) );
+			if( checkDbType ) {
+				return URI.create( updateUrl( url.substring( 5 ) ) );
+			}
+			return URI.create( url.substring( 5 ) );
 		}
 
-		return URI.create( updateUrl( url ) );
+		if( checkDbType ) {
+			return URI.create( updateUrl( url ) );
+		}
+
+		return URI.create( url );
 	}
 
 	private static String updateUrl(String url) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
@@ -119,7 +119,8 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
         }
 
         // port may be empty. Check and set default port if necessary based on scheme
-        if ( connectOptions.getPort() == -1 ) {
+        if ( connectOptions.getPort() == -1 ||
+                ( originalScheme.equalsIgnoreCase( "cockroachdb" ) && connectOptions.getPort() == 5432 ) ) {
             connectOptions.setPort( defaultPort( originalScheme ) );
         }
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
@@ -90,7 +90,6 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
     @Override
     public SqlConnectOptions connectOptions(URI uri) {
         SqlConnectOptions connectOptions;
-        String originalScheme = uri.getScheme();
         URI convertedURI = ReactiveToVertxUriConverter.convertUriToVertx( uri );
 
         // if scheme is unsupported then vertx will throw an error
@@ -118,13 +117,7 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
 
         // password property can be overridden. Check and override if necessary
         if ( pass != null ) {
-            connectOptions.setPassword( user );
-        }
-
-        // port may be empty. Check and set default port if necessary based on scheme
-        if ( connectOptions.getPort() == -1 ||
-                ( originalScheme.equalsIgnoreCase( "cockroachdb" ) && connectOptions.getPort() == 5432 ) ) {
-            connectOptions.setPort( defaultPort( originalScheme ) );
+            connectOptions.setPassword( pass );
         }
 
         //enable the prepared statement cache by default
@@ -149,24 +142,4 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
 
         return connectOptions;
     }
-
-    private int defaultPort(String scheme) {
-        switch ( scheme ) {
-            case "postgresql":
-            case "postgres":
-                return 5432;
-            case "mariadb":
-            case "mysql":
-                return 3306;
-            case "db2":
-                return 50000;
-            case "cockroachdb":
-                return 26257;
-            case "sqlserver":
-                return 1433;
-            default:
-                throw new IllegalArgumentException( "Unknown default port for scheme: " + scheme );
-        }
-    }
-
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ReactiveToVertxUriConverter.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ReactiveToVertxUriConverter.java
@@ -1,0 +1,248 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.pool.impl;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Vertx JDBC URI parsers expect a PostgreSQL-like structure which is not neccessarily
+ * supported by all DB's. This utility class provides logic that will
+ * check a URI and convert it, if necessary, to adhere to the parser REGEX.
+ * <p>
+ * DB2 and SQL Server URI's may require replacement of separator characters in order to
+ * correctly use the SqlConnectOptions.fromUri() and a specific DB driver and parser.
+ */
+public class ReactiveToVertxUriConverter {
+
+	static public URI convertUriToVertx(URI uri) {
+		String scheme = uri.getScheme();
+		String path = uri.getPath();
+
+		String database = path.length() > 0
+				? path.substring( 1 )
+				: "";
+
+		if ( scheme.equals( "db2" ) && database.indexOf( ':' ) > 0 ) {
+			return convertUriToVertxIfDb2( uri );
+		}
+		else if ( scheme.equals( "sqlserver" ) ) {
+			return convertUriToVertxIfSqlServer( uri );
+		}
+		else if ( uri.toString().contains( "cockroachdb" ) ) {
+			return URI.create( uri.toString().replaceAll( "^cockroachdb:", "postgres:" ) );
+		}
+
+		return uri;
+	}
+
+	/**
+	 * This utility method provides URI conversion to replace  the URI : and ; separators for DB2 with vertx's ? and &.
+	 * Vertx manages a common URL syntax rather than multiple DB syntax's for their SqlConnectOptions.fromUri()
+	 * implementations.
+	 *
+	 * @param uri
+	 *
+	 * @return uri
+	 */
+	static public URI convertUriToVertxIfDb2(URI uri) {
+		String scheme = uri.getScheme();
+		String path = uri.getPath();
+
+		String database = path.length() > 0
+				? path.substring( 1 )
+				: "";
+
+		if ( scheme.equals( "db2" ) && database.indexOf( ':' ) > 0 ) {
+			// DB2 URLs are a bit odd and have the format:
+			// jdbc:db2://<HOST>:<PORT>/<DB>:key1=value1;key2=value2;
+			database = database.substring( 0, database.indexOf( ':' ) );
+		}
+		else {
+			return uri;
+		}
+
+		String host = uri.getHost();
+		int port = uri.getPort();
+
+		if ( port == -1 ) {
+			port = 50000;
+		}
+
+		//see if the credentials were specified via properties
+		String username = null;
+		String password = null;
+		Map<String, String> extraProperties = new HashMap<>();
+
+		//if not, look for URI-style user info first
+		String userInfo = uri.getUserInfo();
+		if ( userInfo != null ) {
+			String[] bits = userInfo.split( ":" );
+			username = bits[0];
+			if ( bits.length > 1 ) {
+				password = bits[1];
+			}
+		}
+		else {
+			//check the query for named parameters
+			//in case it's a JDBC-style URL
+			String[] params = {};
+			// DB2 URLs are a bit odd and have the format:
+			// jdbc:db2://<HOST>:<PORT>/<DB>:key1=value1;key2=value2;
+			if ( scheme.equals( "db2" ) ) {
+				int queryIndex = uri.getPath().indexOf( ':' ) + 1;
+				if ( queryIndex > 0 ) {
+					params = uri.getPath().substring( queryIndex ).split( ";" );
+				}
+			}
+
+			for ( String param : params ) {
+				if ( param.startsWith( "user=" ) ) {
+					username = param.substring( 5 );
+				}
+				else if ( param.startsWith( "pass=" ) ) {
+					password = param.substring( 5 );
+				}
+				else if ( param.startsWith( "password=" ) ) {
+					password = param.substring( 9 );
+				}
+				else if ( param.startsWith( "database=" ) ) {
+					database = param.substring( 9 );
+				}
+				else {
+					String[] keyValuePair = param.split( "=" );
+					extraProperties.put( keyValuePair[0].trim(), keyValuePair[1].trim() );
+				}
+			}
+		}
+
+		// build new URI string like:
+		// db2://localhost:44444/hreact?user=hreact&password=hreact
+		return rebuildURI( "db2", host, port, database, username, password, extraProperties );
+	}
+
+	/**
+	 * This method provides URI conversion to replace  the URI : and ; separators for MSSQL with vertx's ? and &.
+	 * Vertx manages a common URL syntax rather than multiple DB syntax's for their SqlConnectOptions.fromUri()
+	 * implementations.
+	 *
+	 * @param uri
+	 *
+	 * @return uri
+	 */
+	static public URI convertUriToVertxIfSqlServer(URI uri) {
+		// EXAMPLE URL
+		//  sqlserver://localhost:52618;user=SA;password=~!HReact!~
+		String scheme = uri.getScheme();
+		String path = uri.getPath();
+
+		String database = path.length() > 0
+				? path.substring( 1 )
+				: "";
+
+		if ( !scheme.equals( "sqlserver" ) ) {
+			return uri;
+		}
+
+		String host = uri.getHost();
+		int port = uri.getPort();
+		int index = uri.toString().indexOf( ';' );
+
+		if ( index > 0 ) {
+			// SQL Server separates parameters in the url with a semicolon (';')
+			// and the URI class doesn't get the right value for host and port when the url
+			// contains parameters
+			URI uriWithoutParams = URI.create( uri.toString().substring( 0, index ) );
+			host = uriWithoutParams.getHost();
+			port = uriWithoutParams.getPort();
+		}
+
+		if ( port == -1 ) {
+			port = 1433;
+		}
+
+		//see if the credentials were specified via properties
+		String username = null;
+		String password = null;
+		Map<String, String> extraProperties = new HashMap<>();
+
+		//if not, look for URI-style user info first
+		String userInfo = uri.getUserInfo();
+		if ( userInfo != null ) {
+			String[] bits = userInfo.split( ":" );
+			username = bits[0];
+			if ( bits.length > 1 ) {
+				password = bits[1];
+			}
+		}
+		else {
+			//check the query for named parameters
+			//in case it's a JDBC-style URL
+			String[] params = {};
+			// SQL Server separates parameters in the url with a semicolon (';')
+			// Ex: jdbc:sqlserver://<server>:<port>;<database>=AdventureWorks;user=<user>;password=<password>
+			String query = uri.getQuery();
+			String rawQuery = uri.getRawQuery();
+			String s = uri.toString();
+			int queryIndex = s.indexOf( ';' ) + 1;
+			if ( queryIndex > 0 ) {
+				params = s.substring( queryIndex ).split( ";" );
+			}
+
+			for ( String param : params ) {
+				if ( param.startsWith( "user=" ) ) {
+					username = param.substring( 5 );
+				}
+				else if ( param.startsWith( "pass=" ) ) {
+					password = param.substring( 5 );
+				}
+				else if ( param.startsWith( "password=" ) ) {
+					password = param.substring( 9 );
+				}
+				else if ( param.startsWith( "database=" ) ) {
+					database = param.substring( 9 );
+				}
+				else {
+					String[] keyValuePair = param.split( "=" );
+					extraProperties.put( keyValuePair[0].trim(), keyValuePair[1].trim() );
+				}
+			}
+		}
+
+		// build new URI string like:
+		// sqlserver://localhost:44444/hreact?user=hreact&password=hreact
+		return rebuildURI( "sqlserver", host, port, database, username, password, extraProperties );
+	}
+
+	private static URI rebuildURI(String dbName, String host, int port, String database, String username,
+			String password, Map<String, String> extraProperties) {
+		StringBuilder sb = new StringBuilder( dbName + "://" );
+		sb.append( host ).append( ":" ).append( port );
+		if ( database != null && !database.isEmpty() ) {
+			sb.append( "/" ).append( database );
+		}
+		if ( username != null || password != null || !extraProperties.isEmpty() ) {
+			sb.append( "?" );
+		}
+		if ( username != null ) {
+			sb.append( "user=" ).append( username );
+			if ( password != null ) {
+				sb.append( "&" );
+			}
+		}
+
+		if ( password != null ) {
+			sb.append( "password=" ).append( password );
+		}
+		for ( Object key : extraProperties.keySet() ) {
+			String value = extraProperties.get( key );
+			sb.append( "&" ).append( (String) key ).append( "=" ).append( value );
+		}
+
+		return URI.create( sb.toString() );
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateError;
 import org.hibernate.HibernateException;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
+import org.hibernate.reactive.pool.impl.ReactiveToVertxUriConverter;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -25,39 +26,19 @@ import io.vertx.sqlclient.SqlConnectOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class JdbcUrlParserTest {
+public class JdbcUrlParserTest extends ReactiveToVertxUriConverter {
 
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
 	private SqlConnectOptions getUriPoolConnectOptions(String url) {
-		URI uri = DefaultSqlClientPool.parse( url);
+		URI uri = DefaultSqlClientPool.parse( url, false);
 		DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
 		final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
 		return connectOptions;
 	}
 
 	private SqlConnectOptions verifyURLWithPort(int expectedPort, String url, Map<String, String> expectedProperties) {
-		assertThat( url.startsWith( "jdbc" ) ).isTrue();
-
-		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
-
-		assertThat( connectOptions ).isNotNull();
-		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
-		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
-		assertThat( connectOptions.getPort() ).isEqualTo( expectedPort );
-		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
-		assertThat( connectOptions.getPassword() ).isEqualTo( "testpassword" );
-
-		for( Object key : expectedProperties.keySet() ) {
-			assertThat(connectOptions.getProperties().keySet().contains( key )).isTrue();
-			assertThat(connectOptions.getProperties().get(key)).isEqualTo( expectedProperties.get(key) );
-		}
-
-		return connectOptions;
-	}
-
-	private SqlConnectOptions verifyURLWithoutPort(int expectedPort, String url, Map<String, String> expectedProperties) {
 		assertThat( url.startsWith( "jdbc" ) ).isTrue();
 
 		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
@@ -144,16 +125,22 @@ public class JdbcUrlParserTest {
 	}
 
 	@Test
+	public void testPGWithHostNoPort() {
+		String url = "jdbc:postgresql://localhost/hreact?loggerLevel=OFF&user=testuser&password=testpassword";
+		verifyURLWithPort( DEFAULT_PORT_PG, url, PgConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
 	public void testPGWithUserInfoNoPort() {
 		// DefaultSqlClientPoolConfiguration should check for port and apply a default if none found on URL
 		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact";
-		verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+		verifyURLWithPort( DEFAULT_PORT_PG, url, PgConnectOptions.DEFAULT_PROPERTIES );
 	}
 
 	@Test(expected = IllegalArgumentException.class)
 	public void testPGWithUserInfoInvalidUrl() {
 		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact%%%%xxxx=yyyyy";
-		verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+		verifyURLWithPort( DEFAULT_PORT_PG, url, PgConnectOptions.DEFAULT_PROPERTIES );
 	}
 
 	@Test(expected = HibernateException.class)
@@ -166,7 +153,7 @@ public class JdbcUrlParserTest {
 	@Test
 	public void testPGWithUserInfoUnsupportedProperties() {
 		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact?loggerLevel=OFF";
-		SqlConnectOptions connectOptions = verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+		SqlConnectOptions connectOptions = verifyURLWithPort( DEFAULT_PORT_PG, url, PgConnectOptions.DEFAULT_PROPERTIES );
 		assertThat(connectOptions.getProperties().keySet().contains( "loggerLevel" )).isFalse();
 	}
 
@@ -176,7 +163,7 @@ public class JdbcUrlParserTest {
 		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
 
 		assertThat( connectOptions ).isNotNull();
-		assertThat( connectOptions.getPort() ).isEqualTo( 5432 );
+		assertThat( connectOptions.getPort() ).isEqualTo( DEFAULT_PORT_PG );
 		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
 	}
 
@@ -186,8 +173,15 @@ public class JdbcUrlParserTest {
 		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
 
 		assertThat( connectOptions ).isNotNull();
-		assertThat( connectOptions.getPort() ).isEqualTo( 5432 );
+		assertThat( connectOptions.getPort() ).isEqualTo( DEFAULT_PORT_COCKROACHDB );
 		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
+	}
+
+	@Test
+	public void testCockroachDBWithUserInfoNoPort() {
+		// DefaultSqlClientPoolConfiguration should check for port and apply a default if none found on URL
+		String url = "jdbc:cockroachdb://testuser:testpassword@localhost/hreact";
+		verifyURLWithPort( DEFAULT_PORT_COCKROACHDB, url, PgConnectOptions.DEFAULT_PROPERTIES );
 	}
 
 	// Example format at https://vertx.io/docs/vertx-mysql-client/java/#_configuration
@@ -212,6 +206,12 @@ public class JdbcUrlParserTest {
 	}
 
 	@Test
+	public void testMYSQLWithHostNoPort() {
+		String url = "jdbc:mysql://localhost/hreact?user=testuser&password=testpassword";
+		verifyURLWithPort( DEFAULT_PORT_MYSQL, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
 	public void testMYSQLWithHostPortUnsupportedProperties() {
 		String url = "jdbc:mysql://localhost:22222/hreact?user=testuser&password=testpassword&prop_1=value_1";
 		SqlConnectOptions connectOptions = verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
@@ -228,7 +228,7 @@ public class JdbcUrlParserTest {
 	@Test
 	public void testMARIADBWithUserInfo() {
 		String url = "jdbc:mariadb://localhost:3306/hreact?user=testuser&password=testpassword";
-		verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		verifyURLWithPort( DEFAULT_PORT_MARIADB, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
 	}
 
 	@Test
@@ -240,14 +240,20 @@ public class JdbcUrlParserTest {
 	@Test
 	public void testMARIADBWithUserInfoUnsupportedProperties() {
 		String url = "jdbc:mariadb://localhost:3306/hreact?user=testuser&password=testpassword&prop_1=value_1";
-		SqlConnectOptions connectOptions = verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		SqlConnectOptions connectOptions = verifyURLWithPort( DEFAULT_PORT_MARIADB, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
 		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
 	}
 
 	@Test
 	public void testMARIADBWithHostPort() {
 		String url = "jdbc:mariadb://testuser:testpassword@localhost:3306/hreact";
-		verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		verifyURLWithPort( DEFAULT_PORT_MARIADB, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testMARIADBWithHostNoPort() {
+		String url = "jdbc:mariadb://testuser:testpassword@localhost/hreact";
+		verifyURLWithPort( DEFAULT_PORT_MARIADB, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
 	}
 
 	@Test
@@ -259,7 +265,7 @@ public class JdbcUrlParserTest {
 	@Test
 	public void testMARIADBWithHostPortUnsupportedProperties() {
 		String url = "jdbc:mariadb://localhost:3306/hreact?user=testuser&password=testpassword&prop_1=value_1";
-		SqlConnectOptions connectOptions = verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		SqlConnectOptions connectOptions = verifyURLWithPort( DEFAULT_PORT_MARIADB, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
 		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
 	}
 
@@ -276,7 +282,7 @@ public class JdbcUrlParserTest {
 		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
 
 		assertThat( connectOptions ).isNotNull();
-		assertThat( connectOptions.getPort() ).isEqualTo( 3306 );
+		assertThat( connectOptions.getPort() ).isEqualTo( DEFAULT_PORT_MARIADB );
 		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
 	}
 
@@ -311,6 +317,12 @@ public class JdbcUrlParserTest {
 	}
 
 	@Test
+	public void testMSSQLWithHostNoPort() {
+		String url = "jdbc:sqlserver://localhost;database=hreact;user=testuser;password=testpassword";
+		verifyURLWithPort( DEFAULT_PORT_MSSQL, url, MSSQLConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
 	public void testMSSQLWithHostPortUnsupportedProperties() {
 		String url = "jdbc:sqlserver://localhost:33333;database=hreact;user=testuser;password=testpassword;prop_1=value_1";
 		SqlConnectOptions connectOptions = verifyURLWithPort( 33333, url, MSSQLConnectOptions.DEFAULT_PROPERTIES );
@@ -332,7 +344,7 @@ public class JdbcUrlParserTest {
 		assertThat( connectOptions ).isNotNull();
 		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
 		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
-		assertThat( connectOptions.getPort() ).isEqualTo( 1433 );
+		assertThat( connectOptions.getPort() ).isEqualTo( DEFAULT_PORT_MSSQL );
 		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
 		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
 	}
@@ -351,6 +363,12 @@ public class JdbcUrlParserTest {
 	}
 
 	@Test
+	public void testDB2WithUserInfoNoPort() {
+		String url = "jdbc:db2://testuser:testpassword@localhost/hreact";
+		verifyURLWithPort( DEFAULT_PORT_DB2, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
 	public void testDB2WithUserInfoUnsupportedProperties() {
 		String url = "jdbc:db2://testuser:testpassword@localhost:44444/hreact?prop_1=value_1";
 		SqlConnectOptions connectOptions = verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
@@ -359,9 +377,14 @@ public class JdbcUrlParserTest {
 
 	@Test
 	public void testDB2WithHostPort() {
-		//jdbc:postgresql://localhost:49219/hreact?loggerLevel=OFF&user=hreact&password=hreact
 		String url = "jdbc:db2://localhost:44444/hreact:user=testuser;password=testpassword;";
 		verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testDB2WithHostNoPort() {
+		String url = "jdbc:db2://localhost/hreact:user=testuser;password=testpassword;";
+		verifyURLWithPort( DEFAULT_PORT_DB2, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
 	}
 
 	@Test
@@ -386,7 +409,7 @@ public class JdbcUrlParserTest {
 		assertThat( connectOptions ).isNotNull();
 		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
 		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
-		assertThat( connectOptions.getPort() ).isEqualTo( 50000 );
+		assertThat( connectOptions.getPort() ).isEqualTo( DEFAULT_PORT_DB2 );
 		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
 		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
@@ -14,7 +14,12 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 
 import java.net.URI;
+import java.util.Map;
 
+import io.vertx.db2client.DB2ConnectOptions;
+import io.vertx.mssqlclient.MSSQLConnectOptions;
+import io.vertx.mysqlclient.MySQLConnectOptions;
+import io.vertx.pgclient.PgConnectOptions;
 import io.vertx.sqlclient.SqlConnectOptions;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,6 +29,53 @@ public class JdbcUrlParserTest {
 	@Rule
 	public ExpectedException thrown = ExpectedException.none();
 
+	private SqlConnectOptions getUriPoolConnectOptions(String url) {
+		URI uri = DefaultSqlClientPool.parse( url);
+		DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
+		final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
+		return connectOptions;
+	}
+
+	private SqlConnectOptions verifyURLWithPort(int expectedPort, String url, Map<String, String> expectedProperties) {
+		assertThat( url.startsWith( "jdbc" ) ).isTrue();
+
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
+		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
+		assertThat( connectOptions.getPort() ).isEqualTo( expectedPort );
+		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "testpassword" );
+
+		for( Object key : expectedProperties.keySet() ) {
+			assertThat(connectOptions.getProperties().keySet().contains( key )).isTrue();
+			assertThat(connectOptions.getProperties().get(key)).isEqualTo( expectedProperties.get(key) );
+		}
+
+		return connectOptions;
+	}
+
+	private SqlConnectOptions verifyURLWithoutPort(int expectedPort, String url, Map<String, String> expectedProperties) {
+		assertThat( url.startsWith( "jdbc" ) ).isTrue();
+
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
+		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
+		assertThat( connectOptions.getPort() ).isEqualTo( expectedPort );
+		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "testpassword" );
+
+		for( Object key : expectedProperties.keySet() ) {
+			assertThat(connectOptions.getProperties().keySet().contains( key )).isTrue();
+			assertThat(connectOptions.getProperties().get(key)).isEqualTo( expectedProperties.get(key) );
+		}
+
+		return connectOptions;
+	}
+
 	@Test
 	public void returnsNullForNull() {
 		thrown.expect( HibernateError.class );
@@ -31,10 +83,9 @@ public class JdbcUrlParserTest {
 		assertThat( uri ).isNull();
 	}
 
-	@Test
+	@Test(expected = IllegalArgumentException.class)
 	public void invalidParameter() {
-		thrown.expect( HibernateError.class );
-		URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact");
+		URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact?badvalue");
 		DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
 		final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
 	}
@@ -69,5 +120,190 @@ public class JdbcUrlParserTest {
 	public void parseScheme() {
 		URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact");
 		assertThat(uri).hasScheme("postgresql");
+	}
+
+	// Example format from https://vertx.io/docs/vertx-pg-client/java/#_configuration
+	@Test
+	public void testPG() {
+		String url = "jdbc:postgresql://testuser:testpassword@localhost:11111/hreact";
+		verifyURLWithPort( 11111, url, PgConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
+	public void testPG_2() {
+		String url = "jdbc:postgresql://localhost:11111/hreact?loggerLevel=OFF&user=testuser&password=testpassword";
+		verifyURLWithPort( 11111, url, PgConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
+	public void testPGNoPort() {
+		// DefaultSqlClientPoolConfiguration should check for port and apply a default if none found on URL
+		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact";
+		verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testPGInvalidUrl() {
+		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact%%%%xxxx=yyyyy";
+		verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
+	public void testPGUnsupportedProperties() {
+		String url = "jdbc:postgresql://testuser:testpassword@localhost/hreact?loggerLevel=OFF";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 5432, url, PgConnectOptions.DEFAULT_PROPERTIES );
+		assertThat(connectOptions.getProperties().keySet().contains( "loggerLevel" )).isFalse();
+	}
+
+	@Test
+	public void testPGPassword() {
+		String url = "jdbc:postgresql://testuser:~!HReact!~@localhost/hreact";
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getPort() ).isEqualTo( 5432 );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
+	}
+
+	@Test
+	public void testCockroachDBPassword() {
+		String url = "jdbc:cockroachdb://testuser:~!HReact!~@localhost/hreact";
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getPort() ).isEqualTo( 5432 );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
+	}
+
+	// Example format https://vertx.io/docs/vertx-mysql-client/java/#_configuration
+	@Test
+	public void testMYSQL() {
+		String url = "jdbc:mysql://localhost:22222/hreact?user=testuser&password=testpassword";
+		verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testMYSQLUnsupportedProperties() {
+		String url = "jdbc:mysql://localhost:22222/hreact?user=testuser&password=testpassword&prop_1=value_1";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMYSQLInvalidUrl() {
+		String url = "jdbc:mysql://localhost:22222/hreact?user=testuser&password=testpassword%%%%xxxx=yyyyy";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "xxxx" )).isFalse();
+	}
+
+	@Test
+	public void testMARIADB() {
+		String url = "jdbc:mariadb://localhost:3306/hreact?user=testuser&password=testpassword";
+		verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testMARIADBNonDefaultPort() {
+		String url = "jdbc:mariadb://localhost:22222/hreact?user=testuser&password=testpassword";
+		verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testMARIADBUnsupportedProperties() {
+		String url = "jdbc:mariadb://localhost:3306/hreact?user=testuser&password=testpassword&prop_1=value_1";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 3306, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMARIADBInvalidUrl() {
+		String url = "jdbc:mariadb://localhost:22222/hreact?user=testuser&password=testpassword%%%%xxxx=yyyyy";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 22222, url, MySQLConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "xxxx" )).isFalse();
+	}
+
+	@Test
+	public void testMARIADBPassword() {
+		String url = "jdbc:mariadb://testuser:~!HReact!~@localhost:3306/hreact";
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getPort() ).isEqualTo( 3306 );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
+	}
+
+	// Example format https://vertx.io/docs/vertx-mssql-client/java/#_configuration
+	@Test
+	public void testMSSQL() {
+		String url = "jdbc:sqlserver://testuser:testpassword@localhost:33333/hreact";
+		verifyURLWithPort( 33333, url, MSSQLConnectOptions.DEFAULT_PROPERTIES );
+	}
+
+	@Test
+	public void testMSSQLUnsupportedProperties() {
+		String url = "jdbc:sqlserver://testuser:testpassword@localhost:33333/hreact?prop_1=value_1";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 33333, url, MSSQLConnectOptions.DEFAULT_PROPERTIES );
+		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMSSQLInvalidUrl() {
+		String url = "jdbc:sqlserver://testuser:testpassword@localhost:33333/hreact%%%%xxxx=yyyyy";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 33333, url, MSSQLConnectOptions.DEFAULT_PROPERTIES );
+		assertThat(connectOptions.getProperties().keySet().contains( "xxxx" )).isFalse();
+	}
+
+	@Test
+	public void testMSSQLPassword() {
+		String url = "jdbc:sqlserver://testuser:~!HReact!~@localhost/hreact";
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
+		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
+		assertThat( connectOptions.getPort() ).isEqualTo( 1433 );
+		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
+	}
+
+	// Example format https://vertx.io/docs/vertx-db2-client/java/#_configuration
+	@Test
+	public void testDB2WithUserInfo() {
+		String url = "jdbc:db2://testuser:testpassword@localhost:44444/hreact:prop1=value1;";
+		verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testDB2WithHostPort() {
+		//jdbc:postgresql://localhost:49219/hreact?loggerLevel=OFF&user=hreact&password=hreact
+		String url = "jdbc:db2://localhost:44444/hreact:user=testuser;password=testpassword;prop1=value1;";
+		verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+	}
+
+	@Test
+	public void testDB2UnsupportedProperties() {
+		String url = "jdbc:db2://testuser:testpassword@localhost:44444/hreact?prop_1=value_1";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "prop_1" )).isFalse();
+	}
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testDB2InvalidUrl() {
+		String url = "jdbc:db2://testuser:testpassword@localhost:44444/hreact%%%%xxxx=yyyyy";
+		SqlConnectOptions connectOptions = verifyURLWithPort( 44444, url, DB2ConnectOptions.DEFAULT_CONNECTION_ATTRIBUTES );
+		assertThat(connectOptions.getProperties().keySet().contains( "loggerLevel" )).isFalse();
+	}
+
+	@Test
+	public void testDB2Password() {
+		String url = "jdbc:db2://testuser:~!HReact!~@localhost/hreact";
+		SqlConnectOptions connectOptions = getUriPoolConnectOptions( url );
+
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getDatabase() ).isEqualTo( "hreact" );
+		assertThat( connectOptions.getHost() ).isEqualTo( "localhost" );
+		assertThat( connectOptions.getPort() ).isEqualTo( 50000 );
+		assertThat( connectOptions.getUser() ).isEqualTo( "testuser" );
+		assertThat( connectOptions.getPassword() ).isEqualTo( "~!HReact!~" );
 	}
 }


### PR DESCRIPTION
See #1059

Changed `DefaultSqlClientPoolConfiguration.connectOptions()` to parse URI using vertx sql client `SqlConnectOptions.fromUri()`

Note that vertx parsing logic currently recognizes a limited set of URI parameters which was logged with this issue: [#1115 ](https://github.com/eclipse-vertx/vertx-sql-client/issues/1115).  The conversation currently stands with adding a logged warning message for each non-supported parameter.
