### PR TITLE
Fix Db2 build failure on CI 

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveAbstractCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveAbstractCollectionPersister.java
@@ -184,7 +184,7 @@ public interface ReactiveAbstractCollectionPersister extends ReactiveCollectionP
 
             if ( LOG.isDebugEnabled() ) {
                 LOG.debugf(
-                        "Updating rows of collection: %s#%s",
+                        "Updating rows of collection: %s",
                         collectionInfoString( this, collection, id, session )
                 );
             }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -32,7 +32,6 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.runner.RunWith;
 
 import io.smallrye.mutiny.Uni;
@@ -67,8 +66,8 @@ public abstract class BaseReactiveTest {
 
 	public static SessionFactoryManager factoryManager = new SessionFactoryManager();
 
-	@Rule
-	public Timeout rule = Timeout.seconds( 5 * 60 );
+	@ClassRule
+	public static Timeout rule = Timeout.seconds( 10 * 60 );
 
 	@ClassRule
 	public static RunTestOnContext vertxContextRule = new RunTestOnContext( () -> {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -34,7 +34,7 @@ class DB2Database implements TestableDatabase {
 
 	public static DB2Database INSTANCE = new DB2Database();
 
-	public static final String IMAGE_NAME = "ibmcom/db2:11.5.5.1";
+	public static final String IMAGE_NAME = "ibmcom/db2:11.5.7.0";
 
 	public static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -83,11 +83,12 @@ class DB2Database implements TestableDatabase {
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
 	static final Db2Container db2 = new Db2Container( IMAGE_NAME )
-		      .withUsername(DatabaseConfiguration.USERNAME)
-		      .withPassword(DatabaseConfiguration.PASSWORD)
-		      .withDatabaseName(DatabaseConfiguration.DB_NAME)
-		      .acceptLicense()
-		      .withReuse(true);
+			.withUsername( DatabaseConfiguration.USERNAME )
+			.withPassword( DatabaseConfiguration.PASSWORD )
+			.withDatabaseName( DatabaseConfiguration.DB_NAME )
+			.withLogConsumer( of -> System.out.println( of.getUtf8String() ) )
+			.acceptLicense()
+			.withReuse( true );
 
 	private String getRegularJdbcUrl() {
 		return "jdbc:db2://localhost:50000/" + db2.getDatabaseName();


### PR DESCRIPTION
It seems the problem on CI was that the test time out was too short when using Db2. This was causing the first test to fail and some other tests after it even if the database was started (not sure why).

This PR contains:
* Increase timeout for the tests and switch to a class rule (this is what fixed the build on CI)
* Upgrade Db2 to 11.5.7.0
* Print the start up console of Db2 when using docker
* Fix a debug message (it was expecting two parameters but there was only one)