### PR TITLE
Fix UnicodeCharsTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnicodeCharsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnicodeCharsTest.java
@@ -17,8 +17,6 @@ import org.junit.Test;
 import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.cfg.AvailableSettings.USE_NATIONALIZED_CHARACTER_DATA;
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
-import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
 /**
  * Test non ASCII Chars
@@ -33,14 +31,14 @@ public class UnicodeCharsTest extends BaseReactiveTest {
 	@Override
 	protected Configuration constructConfiguration() {
 		final Configuration configuration = super.constructConfiguration();
-		configuration.getProperties().put( USE_NATIONALIZED_CHARACTER_DATA, dbType() != MARIA );
+		configuration.getProperties().put( USE_NATIONALIZED_CHARACTER_DATA, true );
 		configuration.addAnnotatedClass( UnicodeString.class );
 		return configuration;
 	}
 
 	@Test
 	public void testStringTypeWithUnicode(TestContext context) {
-		final String expected = "\uD83D\uDD02 ﷽ 雲  (͡° ͜ʖ ͡ °) Č";
+		final String expected = "﷽ 雲  (͡° ͜ʖ ͡ °) Č";
 		Object original = new UnicodeString( expected );
 
 		test( context, getSessionFactory()


### PR DESCRIPTION
Fixes #1158

One of the chars used in the test is not compatible with the
collation used when setting the property to true for MySQL or
MariaDB.