### PR TITLE
add SessionFactory.getStatistics()

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -37,6 +37,7 @@ import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.session.ReactiveSession;
 
 import io.smallrye.mutiny.Uni;
+import org.hibernate.stat.Statistics;
 
 /**
  * An API for Hibernate Reactive where non-blocking operations are
@@ -1851,6 +1852,12 @@ public interface Mutiny {
 		 * cache.
 		 */
 		Cache getCache();
+
+		/**
+		 * Obtain the {@link Statistics} object exposing factory-level
+		 * metrics.
+		 */
+		Statistics getStatistics();
 
 		/**
 		 * Destroy the session factory and clean up its connection pool.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -30,6 +30,7 @@ import org.hibernate.reactive.session.impl.ReactiveStatelessSessionImpl;
 import org.hibernate.service.ServiceRegistry;
 
 import io.smallrye.mutiny.Uni;
+import org.hibernate.stat.Statistics;
 
 import static org.hibernate.reactive.common.InternalStateAssertions.assertUseOnEventLoop;
 
@@ -270,6 +271,11 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory, Implemen
 	@Override
 	public Cache getCache() {
 		return delegate.getCache();
+	}
+
+	@Override
+	public Statistics getStatistics() {
+		return delegate.getStatistics();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -37,6 +37,7 @@ import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.stat.Statistics;
 
 /**
  * An API for Hibernate Reactive where non-blocking operations are
@@ -1847,6 +1848,12 @@ public interface Stage {
 		 * cache.
 		 */
 		Cache getCache();
+
+		/**
+		 * Obtain the {@link Statistics} object exposing factory-level
+		 * metrics.
+		 */
+		Statistics getStatistics();
 
 		/**
 		 * Destroy the session factory and clean up its connection pool.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
@@ -27,6 +27,7 @@ import org.hibernate.reactive.session.impl.ReactiveSessionImpl;
 import org.hibernate.reactive.session.impl.ReactiveStatelessSessionImpl;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.service.ServiceRegistry;
+import org.hibernate.stat.Statistics;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 import static org.hibernate.reactive.util.impl.CompletionStages.rethrow;
@@ -240,6 +241,11 @@ public class StageSessionFactoryImpl implements Stage.SessionFactory, Implemento
 	@Override
 	public Cache getCache() {
 		return delegate.getCache();
+	}
+
+	@Override
+	public Statistics getStatistics() {
+		return delegate.getStatistics();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StatisticsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StatisticsTest.java
@@ -1,0 +1,169 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import io.vertx.ext.unit.TestContext;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.EntityStatistics;
+import org.hibernate.stat.QueryStatistics;
+import org.hibernate.stat.Statistics;
+import org.junit.After;
+import org.junit.Test;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
+
+
+public class StatisticsTest extends BaseReactiveTest {
+
+    @Override
+    protected Configuration constructConfiguration() {
+        Configuration configuration = super.constructConfiguration();
+        configuration.addAnnotatedClass( Named.class );
+        configuration.setProperty( GENERATE_STATISTICS, "true" );
+        return configuration;
+    }
+
+    @After
+    public void cleanDB(TestContext context) {
+        getSessionFactory().close();
+    }
+
+    @Test
+    public void testMutinyStatistics(TestContext context) {
+        Statistics statistics = getMutinySessionFactory().getStatistics();
+        test( context,
+                getMutinySessionFactory()
+                        .withTransaction(
+                                (s, t) -> s.persistAll( new Named("foo"), new Named("bar"), new Named("baz") )
+                        )
+                        .chain( ()->
+                                getMutinySessionFactory().withTransaction(
+                                        (s, t) -> s.find(Named.class, 1).chain(s::remove)
+                                ) )
+                        .invoke( v-> {
+                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
+                            context.assertEquals( 1L, statistics.getEntityLoadCount() );
+                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+
+                            context.assertEquals( 2L, statistics.getFlushCount() );
+                            context.assertEquals( 2L, statistics.getSessionOpenCount() );
+                            context.assertEquals( 2L, statistics.getSessionCloseCount() );
+//                            context.assertEquals( 2L, statistics.getTransactionCount() );
+//                            context.assertEquals( 2L, statistics.getConnectCount() );
+//                            context.assertEquals( 5L, statistics.getPrepareStatementCount() );
+
+                            EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
+                            context.assertEquals( 3L, entityStatistics.getInsertCount() );
+                            context.assertEquals( 1L, entityStatistics.getLoadCount() );
+                            context.assertEquals( 1L, entityStatistics.getDeleteCount() );
+
+                            context.assertEquals( 0, statistics.getQueries().length );
+                        } )
+                        .chain( ()->
+                                getMutinySessionFactory().withTransaction(
+                                        (s, t) -> s.createQuery("from Named").getResultList()
+                                ) )
+                        .invoke( v-> {
+                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
+                            context.assertEquals( 3L, statistics.getEntityLoadCount() );
+                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+                            context.assertEquals( 1L, statistics.getQueryExecutionCount() );
+
+                            context.assertEquals( 1, statistics.getQueries().length );
+
+                            QueryStatistics queryStatistics = statistics.getQueryStatistics("from Named");
+                            context.assertEquals( 1L, queryStatistics.getExecutionCount() );
+                            context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
+                            context.assertNotEquals( 0L, queryStatistics.getExecutionMaxTime() );
+
+                            context.assertEquals( 3L, statistics.getFlushCount() );
+                            context.assertEquals( 3L, statistics.getSessionOpenCount() );
+                            context.assertEquals( 3L, statistics.getSessionCloseCount() );
+//                            context.assertEquals( 3L, statistics.getTransactionCount() );
+//                            context.assertEquals( 3L, statistics.getConnectCount() );
+//                            context.assertEquals( 6L, statistics.getPrepareStatementCount() );
+                        } )
+        );
+    }
+
+    @Test
+    public void testStageStatistics(TestContext context) {
+        Statistics statistics = getSessionFactory().getStatistics();
+        test( context,
+                getSessionFactory()
+                        .withTransaction(
+                                (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
+                        )
+                        .thenCompose( v ->
+                                getSessionFactory().withTransaction(
+                                        (s, t) -> s.find(Named.class, 1).thenCompose(s::remove)
+                                ) )
+                        .thenAccept( v-> {
+                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
+                            context.assertEquals( 1L, statistics.getEntityLoadCount() );
+                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+
+                            context.assertEquals( 2L, statistics.getFlushCount() );
+                            context.assertEquals( 2L, statistics.getSessionOpenCount() );
+                            context.assertEquals( 2L, statistics.getSessionCloseCount() );
+//                            context.assertEquals( 2L, statistics.getTransactionCount() );
+//                            context.assertEquals( 2L, statistics.getConnectCount() );
+//                            context.assertEquals( 5L, statistics.getPrepareStatementCount() );
+
+                            EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
+                            context.assertEquals( 3L, entityStatistics.getInsertCount() );
+                            context.assertEquals( 1L, entityStatistics.getLoadCount() );
+                            context.assertEquals( 1L, entityStatistics.getDeleteCount() );
+
+                            context.assertEquals( 0, statistics.getQueries().length );
+                        } )
+                        .thenCompose( v ->
+                                getSessionFactory().withTransaction(
+                                        (s, t) -> s.createQuery("from Named").getResultList()
+                                ) )
+                        .thenAccept( v-> {
+                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
+                            context.assertEquals( 3L, statistics.getEntityLoadCount() );
+                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+                            context.assertEquals( 1L, statistics.getQueryExecutionCount() );
+
+                            context.assertEquals( 1, statistics.getQueries().length );
+
+                            QueryStatistics queryStatistics = statistics.getQueryStatistics("from Named");
+                            context.assertEquals( 1L, queryStatistics.getExecutionCount() );
+                            context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
+                            context.assertNotEquals( 0L, queryStatistics.getExecutionMaxTime() );
+
+                            context.assertEquals( 3L, statistics.getFlushCount() );
+                            context.assertEquals( 3L, statistics.getSessionOpenCount() );
+                            context.assertEquals( 3L, statistics.getSessionCloseCount() );
+//                            context.assertEquals( 3L, statistics.getTransactionCount() );
+//                            context.assertEquals( 3L, statistics.getConnectCount() );
+//                            context.assertEquals( 6L, statistics.getPrepareStatementCount() );
+                        } )
+        );
+    }
+
+    @Entity(name="Named")
+    @Table(name = "named_thing")
+    static class Named {
+        @Id @GeneratedValue
+        Integer id;
+        String name;
+
+        public Named(String name) {
+            this.name = name;
+        }
+
+        public Named() {}
+    }
+
+}


### PR DESCRIPTION
Initial support for statistics.

Of course, all the JDBC-level statistics are missing, so I guess we need to mess up some of our nice clean code with trash like:

```java
final StatisticsImplementor statistics = sessionFactory.getStatistics();
if ( statistics.isStatisticsEnabled() ) {
	statistics.connect();
}
```