### PR TITLE
Print thread ids when internal assertion fails

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/InternalStateAssertions.java
@@ -43,7 +43,12 @@ public final class InternalStateAssertions {
 
 	public static void assertCurrentThreadMatches(Thread expectedThread) {
 		if ( ENFORCE && ( Thread.currentThread() != expectedThread ) ) {
-			throw LOG.detectedUsedOfTheSessionOnTheWrongThread( expectedThread.getName(), Thread.currentThread().getName() );
+			throw LOG.detectedUsedOfTheSessionOnTheWrongThread(
+					expectedThread.getId(),
+					expectedThread.getName(),
+					Thread.currentThread().getId(),
+					Thread.currentThread().getName()
+			);
 		}
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -207,8 +207,8 @@ public interface Log extends BasicLogger {
 	IllegalStateException shouldBeInvokedInVertxEventLoopThread(String name);
 
 	@Message(id = 69, value = "Detected use of the reactive Session from a different Thread than the one which was used to open the reactive Session - this suggests an invalid integration; "
-			+ "original thread: '%1$s' current Thread: '%2$s'")
-	IllegalStateException detectedUsedOfTheSessionOnTheWrongThread(String expectedThreadName, String currentThreadName);
+			+ "original thread [%1$s]: '%2$s' current Thread [%3$s]: '%4$s'")
+	IllegalStateException detectedUsedOfTheSessionOnTheWrongThread(long expectedThreadId, String expectedThreadName, long currentThreadId, String currentThreadName);
 
 	@Message(id = 70, value = "Unable to locate persistence units")
 	PersistenceException unableToLocatePersistenceUnits(@Cause Throwable e);


### PR DESCRIPTION
Sometime two different threads can have the same name