### PR TITLE
Enable WrongCredentialsTest for MySQL

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -84,6 +84,7 @@ class MySQLDatabase implements TestableDatabase {
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
+			.withCommand( "--authentication-policy=caching_sha2_password" )
 			.withReuse( true );
 
 	private String getRegularJdbcUrl() {


### PR DESCRIPTION
Fixes #511 
I had to set the authentication policy at start up. 
I don't know why it solved the issue because it should be the default setting.