### PR TITLE
Enable WrongCredentialsTest for MySQL

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -84,6 +84,7 @@ class MySQLDatabase implements TestableDatabase {
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
+			.withCommand( "--default-authentication-plugin=mysql_native_password" )
 			.withReuse( true );
 
 	private String getRegularJdbcUrl() {


### PR DESCRIPTION
The previous pr had the wrong configuration (I didn't notice).
This is the right one:
```
.withCommand( "--default-authentication-plugin=mysql_native_password" )
```