### PR TITLE
Add limitations for Oracle and Db2 to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,4 +247,8 @@ At present several minor limitations remain.
   database-generated `@Version` properties is not yet supported.
 - The annotation `@org.hibernate.annotations.CollectionId` is not yet 
   supported.
-
+- With Db2:
+  * [Automatic schema](http://hibernate.org/reactive/documentation/1.1/reference/html_single/#_automatic_schema_export) update and validation is not supported.
+- [With Oracle](https://github.com/hibernate/hibernate-reactive/issues/1168):
+  * Querying a column mapped as `raw` throws an exception;
+  * Insert-select queries will cause on exception (see https://github.com/eclipse-vertx/vertx-sql-client/issues/1108). 


### PR DESCRIPTION
I've noticed that we have this section in the README but didn't update it with the limitation for each database.
I wonder if adding these limitations for Oracle is helpful or we should jsut list them as bugs.