### PR TITLE
Cleaned up SqlConnectOptions to pass to vertx sql client connection

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPoolConfiguration.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.pool.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
@@ -130,6 +131,7 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
 		//see if the credentials were specified via properties
 		String username = user;
 		String password = pass;
+		Map<String, String> extraProps = new HashMap<>();
 		if ( username == null || password == null ) {
 			//if not, look for URI-style user info first
 			String userInfo = uri.getUserInfo();
@@ -184,6 +186,10 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
 					else if ( param.startsWith( "database=" ) ) {
 						database = param.substring( 9 );
 					}
+					else {
+						String[] propertySet = param.split( "=" );
+						extraProps.put( propertySet[0], propertySet[1] );
+					}
 				}
 			}
 		}
@@ -201,6 +207,10 @@ public class DefaultSqlClientPoolConfiguration implements SqlClientPoolConfigura
 
 		if ( password != null ) {
 			connectOptions.setPassword( password );
+		}
+
+		for ( String key : extraProps.keySet() ) {
+			connectOptions.addProperty( key, extraProps.get( key ) );
 		}
 
 		//enable the prepared statement cache by default

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/JdbcUrlParserTest.java
@@ -6,12 +6,15 @@
 package org.hibernate.reactive.configuration;
 
 import org.hibernate.HibernateError;
+import org.hibernate.reactive.containers.DatabaseConfiguration;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
 
 import org.junit.Test;
 
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 
 import io.vertx.sqlclient.SqlConnectOptions;
 
@@ -19,6 +22,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.Assert.assertThrows;
 
 public class JdbcUrlParserTest {
+	private static final Map<String, String> EXTRA_PARAMS = new HashMap<>();
+	static {
+		EXTRA_PARAMS.put("param1","value1");
+		EXTRA_PARAMS.put("param2","value2");
+		EXTRA_PARAMS.put("param3","value3");
+	}
 
 	@Test
 	public void returnsNullForNull() {
@@ -29,7 +38,7 @@ public class JdbcUrlParserTest {
 	}
 
 	@Test
-	public void invalidParameter() {
+	public void missingUser() {
 		assertThrows( HibernateError.class, () -> {
 			URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact" );
 			DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
@@ -67,5 +76,58 @@ public class JdbcUrlParserTest {
 	public void parseScheme() {
 		URI uri = DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact");
 		assertThat(uri).hasScheme("postgresql");
+	}
+
+	@Test
+	public void invalidProperty() {
+		assertThrows( IllegalArgumentException.class, () -> {
+			DefaultSqlClientPool.parse( "jdbc:postgresql://localhost:5432/hreact?user=hello;$%_*(_(R=234" );
+		} );
+	}
+
+	@Test
+	public void loggerLevelParamRemovedFromUrl() { //TestContext context) {
+		// There's currently a mismatch between
+		String url = DatabaseConfiguration.getJdbcUrl();
+		assertThat(url.contains( "loggerLevel" )).isFalse();
+	}
+
+	@Test
+	public void extraParametersPostgreSQL() {
+		testExtraParameters( "jdbc:postgresql://localhost:5432/hreact?user=hello", "&" );
+	}
+
+	@Test
+	public void extraParametersDB2() {
+		testExtraParameters( "jdbc:db2://localhost:50000/hreact:user=hello", ";" );
+	}
+
+	@Test
+	public void extraParametersSqlServer() {
+		testExtraParameters( "jdbc:sqlserver://localhost:1433;database=hreact;user=hello", ";" );
+	}
+
+	@Test
+	public void extraParametersMySql() {
+		testExtraParameters( "jdbc:mysql://localhost:3306/hreact?user=hello", "&" );
+	}
+
+	@Test
+	public void extraParametersOracle() {
+		testExtraParameters( "jdbc:oracle://localhost:1521/hreact?user=hello", "&" );
+	}
+
+	private void testExtraParameters(String baseUrl, String paramSeparator) {
+		StringBuilder sb = new StringBuilder();
+		for( String key : EXTRA_PARAMS.keySet() )  {
+			sb.append( paramSeparator ).append( key ).append( "=" ).append( EXTRA_PARAMS.get( key ));
+		}
+		URI uri = DefaultSqlClientPool.parse( baseUrl + sb.toString() );
+		DefaultSqlClientPoolConfiguration cfg = new DefaultSqlClientPoolConfiguration();
+		final SqlConnectOptions connectOptions = cfg.connectOptions( uri );
+		assertThat( connectOptions ).isNotNull();
+		assertThat( connectOptions.getProperties().get( "param1" ) ).isNotNull();
+		assertThat( connectOptions.getProperties().get( "param2" ) ).isNotNull();
+		assertThat( connectOptions.getProperties().get( "param3" ) ).isNotNull();
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -89,7 +89,7 @@ class PostgreSQLDatabase implements TestableDatabase {
 			.withReuse( true );
 
 	private String getRegularJdbcUrl() {
-		return "jdbc:postgresql://localhost:5432/" + postgresql.getDatabaseName() + "?loggerLevel=OFF";
+		return "jdbc:postgresql://localhost:5432/" + postgresql.getDatabaseName();
 	}
 
 	@Override
@@ -117,14 +117,20 @@ class PostgreSQLDatabase implements TestableDatabase {
 			// Calling start() will start the container (if not already started)
 			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port
 			postgresql.start();
-			return postgresql.getJdbcUrl();
+			// New Postgres Driver has dropped support for loggerLevel
+			// removing it from current Docker PG container URL to prevent exceptions in tests
+			String jdbcUrl = postgresql.getJdbcUrl();
+			if ( jdbcUrl.contains( "&loggerLevel=OFF" ) ) {
+				return jdbcUrl.replace( "&loggerLevel=OFF", "" );
+			}
+			return jdbcUrl.replace("?loggerLevel=OFF", "?");
 		}
 
 		return getRegularJdbcUrl();
 	}
 
 	private static String buildJdbcUrlWithCredentials(String jdbcUrl) {
-		return jdbcUrl + "&user=" + postgresql.getUsername() + "&password=" + postgresql.getPassword();
+		return jdbcUrl + "user=" + postgresql.getUsername() + "&password=" + postgresql.getPassword();
 	}
 
 	private static String buildUriWithCredentials(String jdbcUrl) {


### PR DESCRIPTION
Fixes #864

PG's **loggerLevel** property is not supported in latest release and it was throwing `PgException` through vertx.  Removed that property from our testing and added logic to prevent it from being allowed through `DefaultSqlClientPoolConfiguration`

Lastly, added capturing general URL properties and applying them to the  `DefaultSqlClientPoolConfiguration.connectOptions()` call.

This allows users to add properties at their own risk and Vertx sql client will process them.