### PR TITLE
In tests, delete entities after all the sessions have been closed

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -276,19 +276,25 @@ public class SqlClientConnection implements ReactiveConnection {
 
 	@Override
 	public CompletionStage<Void> beginTransaction() {
-		return connection.begin().toCompletionStage()
+		return connection.begin()
+				.onSuccess( tx -> LOG.tracef( "Transaction started: %s", tx ) )
+				.toCompletionStage()
 				.thenAccept( tx -> transaction = tx );
 	}
 
 	@Override
 	public CompletionStage<Void> commitTransaction() {
-		return transaction.commit().toCompletionStage()
+		return transaction.commit()
+				.onSuccess( v -> LOG.tracef( "Transaction committed: %s", transaction ) )
+				.toCompletionStage()
 				.whenComplete( (v, x) -> transaction = null );
 	}
 
 	@Override
 	public CompletionStage<Void> rollbackTransaction() {
-		return transaction.rollback().toCompletionStage()
+		return transaction.rollback()
+				.onSuccess( v -> LOG.tracef( "Transaction rollbacked: %s", transaction ) )
+				.toCompletionStage()
 				.whenComplete( (v, x) -> transaction = null );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -61,11 +61,11 @@ public class SqlClientConnection implements ReactiveConnection {
 	private final SqlConnection connection;
 	private Transaction transaction;
 
-	SqlClientConnection(SqlConnection connection, Pool pool,
-						SqlStatementLogger sqlStatementLogger) {
+	SqlClientConnection(SqlConnection connection, Pool pool, SqlStatementLogger sqlStatementLogger) {
 		this.pool = pool;
 		this.sqlStatementLogger = sqlStatementLogger;
 		this.connection = connection;
+		LOG.tracef( "Connection created: %s", connection );
 	}
 
 	@Override
@@ -294,7 +294,9 @@ public class SqlClientConnection implements ReactiveConnection {
 
 	@Override
 	public CompletionStage<Void> close() {
-		return connection.close().toCompletionStage();
+		return connection.close()
+				.onSuccess( event -> LOG.tracef( "Connection closed: %s", connection ) )
+				.toCompletionStage();
 	}
 
 	@SuppressWarnings("unchecked")

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -5,9 +5,12 @@
  */
 package org.hibernate.reactive.pool.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
+import org.hibernate.reactive.logging.impl.Log;
+import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.ReactiveConnectionPool;
 
@@ -33,6 +36,8 @@ import io.vertx.sqlclient.SqlConnection;
  * @see ExternalSqlClientPool the implementation used in Quarkus
  */
 public abstract class SqlClientPool implements ReactiveConnectionPool {
+
+	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	/**
 	 * @return the underlying Vert.x {@link Pool} for the current context.
@@ -72,7 +77,8 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 	}
 
 	private CompletionStage<ReactiveConnection> getConnectionFromPool(Pool pool) {
-		return pool.getConnection().toCompletionStage().thenApply( this::newConnection );
+		return pool.getConnection()
+				.toCompletionStage().thenApply( this::newConnection );
 	}
 
 	private SqlClientConnection newConnection(SqlConnection connection) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -237,6 +237,8 @@ public abstract class BaseReactiveTest {
 	public void after(TestContext context) {
 		test( context, closeSession( session )
 				.thenAccept( v -> session = null )
+				.thenCompose( v -> closeSession( statelessSession ) )
+				.thenAccept( v -> statelessSession = null )
 				.thenCompose( v -> closeSession( connection ) )
 				.thenAccept( v -> connection = null )
 				.thenCompose( v -> cleanDb() )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchFetchTest.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.CascadeType;
@@ -29,7 +30,6 @@ import javax.persistence.Version;
 import org.hibernate.Hibernate;
 import org.hibernate.LockMode;
 import org.hibernate.annotations.BatchSize;
-import org.hibernate.cfg.Configuration;
 
 import org.junit.After;
 import org.junit.Test;
@@ -40,17 +40,14 @@ import io.vertx.ext.unit.TestContext;
 public class BatchFetchTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Node.class );
-		configuration.addAnnotatedClass( Element.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Node.class, Element.class );
 	}
 
 	@After
 	public void cleanDb(TestContext context) {
 		test( context, getSessionFactory()
-				.withTransaction( (s, t) -> s.createQuery( "delete from Element" ).executeUpdate()
+				.withTransaction( s -> s.createQuery( "delete from Element" ).executeUpdate()
 						.thenCompose( v -> s.createQuery( "delete from Node" ).executeUpdate() ) ) );
 	}
 
@@ -64,43 +61,45 @@ public class BatchFetchTest extends BaseReactiveTest {
 		basik.parent.elements.add( new Element( basik.parent ) );
 		basik.parent.elements.add( new Element( basik.parent ) );
 
-		test(
-				context,
-				openSession()
-						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
-						.thenCompose( v -> openSession() )
-						.thenCompose( s -> s.createQuery( "from Node n order by id", Node.class )
-								.getResultList()
-								.thenCompose( list -> {
-									context.assertEquals( list.size(), 2 );
-									Node n1 = list.get( 0 );
-									Node n2 = list.get( 1 );
-									context.assertFalse( Hibernate.isInitialized( n1.elements ) );
-									context.assertFalse( Hibernate.isInitialized( n2.elements ) );
-									return s.fetch( n1.elements ).thenAccept( elements -> {
+		test( context, getSessionFactory()
+				.withTransaction( s -> s.persist( basik ) )
+				.thenCompose( v -> openSession() )
+				.thenCompose( s -> s.createQuery( "from Node n order by id", Node.class )
+						.getResultList()
+						.thenCompose( list -> {
+							context.assertEquals( list.size(), 2 );
+							Node n1 = list.get( 0 );
+							Node n2 = list.get( 1 );
+							context.assertFalse( Hibernate.isInitialized( n1.elements ) );
+							context.assertFalse( Hibernate.isInitialized( n2.elements ) );
+							return s.fetch( n1.elements )
+									.thenAccept( elements -> {
 										context.assertTrue( Hibernate.isInitialized( elements ) );
 										context.assertTrue( Hibernate.isInitialized( n1.elements ) );
 										context.assertTrue( Hibernate.isInitialized( n2.elements ) );
 									} );
-								} )
-						)
-						.thenCompose( v -> openSession() )
-						.thenCompose( s -> s.createQuery( "from Element e order by id", Element.class )
-								.getResultList()
-								.thenCompose( list -> {
-									context.assertEquals( list.size(), 5 );
-									list.forEach( element -> context.assertFalse( Hibernate.isInitialized( element.node ) ) );
-									list.forEach( element -> context.assertEquals( s.getLockMode( element.node ), LockMode.NONE ) );
-									return s.fetch( list.get( 0 ).node )
-											.thenAccept( node -> {
-												context.assertTrue( Hibernate.isInitialized( node ) );
-												//TODO: I would like to assert that they're all initialized
-												//      but apparently it doesn't set the proxies to init'd
-												//      so check the LockMode as a workaround
-												list.forEach( element -> context.assertEquals( s.getLockMode( element.node ), LockMode.READ ) );
-											} );
-								} )
-						)
+						} )
+				)
+				.thenCompose( v -> openSession() )
+				.thenCompose( s -> s.createQuery( "from Element e order by id", Element.class )
+						.getResultList()
+						.thenCompose( list -> {
+							context.assertEquals( list.size(), 5 );
+							list.forEach( element -> context.assertFalse( Hibernate.isInitialized( element.node ) ) );
+							list.forEach( element -> context.assertEquals( s.getLockMode( element.node ), LockMode.NONE ) );
+							return s.fetch( list.get( 0 ).node )
+									.thenAccept( node -> {
+										context.assertTrue( Hibernate.isInitialized( node ) );
+										//TODO: I would like to assert that they're all initialized
+										//      but apparently it doesn't set the proxies to init'd
+										//      so check the LockMode as a workaround
+										list.forEach( element -> context.assertEquals(
+												s.getLockMode( element.node ),
+												LockMode.READ
+										) );
+									} );
+						} )
+				)
 		);
 	}
 
@@ -114,19 +113,17 @@ public class BatchFetchTest extends BaseReactiveTest {
 		basik.parent.elements.add( new Element( basik.parent ) );
 		basik.parent.elements.add( new Element( basik.parent ) );
 
-		test(
-				context,
-				openSession()
-						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
-						.thenCompose( v -> openSession() )
-						.thenCompose( s -> s.find( Element.class, basik.elements.get( 1 ).id, basik.elements.get( 2 ).id, basik.elements.get( 0 ).id ) )
-						.thenAccept( elements -> {
-							context.assertFalse( elements.isEmpty() );
-							context.assertEquals( 3, elements.size() );
-							context.assertEquals( basik.elements.get( 1 ).id, elements.get( 0 ).id );
-							context.assertEquals( basik.elements.get( 2 ).id, elements.get( 1 ).id );
-							context.assertEquals( basik.elements.get( 0 ).id, elements.get( 2 ).id );
-						} )
+		test( context, getSessionFactory()
+				.withTransaction( s -> s.persist( basik ) )
+				.thenCompose( v -> openSession() )
+				.thenCompose( s -> s.find( Element.class, basik.elements.get( 1 ).id, basik.elements.get( 2 ).id, basik.elements.get( 0 ).id ) )
+				.thenAccept( elements -> {
+					context.assertFalse( elements.isEmpty() );
+					context.assertEquals( 3, elements.size() );
+					context.assertEquals( basik.elements.get( 1 ).id, elements.get( 0 ).id );
+					context.assertEquals( basik.elements.get( 2 ).id, elements.get( 1 ).id );
+					context.assertEquals( basik.elements.get( 0 ).id, elements.get( 2 ).id );
+				} )
 		);
 	}
 
@@ -139,20 +136,22 @@ public class BatchFetchTest extends BaseReactiveTest {
 		node.elements.add( new Element( node ) );
 		node.elements.add( new Element( node ) );
 
-		test( context, openSession()
-				.thenCompose( s -> s.persist( node ).thenCompose( v -> s.flush() ) )
-				.thenCompose( v -> openSession() )
-				.thenCompose( s -> s.createQuery( "from Node n order by id", Node.class )
-						.getResultList()
-						.thenCompose( list -> {
-							context.assertEquals( list.size(), 1 );
-							Node n1 = list.get( 0 );
-							context.assertFalse( Hibernate.isInitialized( n1.elements ) );
-							return s.fetch( n1.elements ).thenAccept( elements -> {
-								context.assertTrue( Hibernate.isInitialized( elements ) );
-								context.assertTrue( Hibernate.isInitialized( n1.elements ) );
-							} );
-						} )
+		test( context, getSessionFactory()
+				.withTransaction( s -> s.persist( node ) )
+				.thenCompose( v -> getSessionFactory()
+						.withTransaction( s -> s
+								.createQuery( "from Node n order by id", Node.class )
+								.getResultList()
+								.thenCompose( list -> {
+									context.assertEquals( list.size(), 1 );
+									Node n1 = list.get( 0 );
+									context.assertFalse( Hibernate.isInitialized( n1.elements ) );
+									return s.fetch( n1.elements ).thenAccept( elements -> {
+										context.assertTrue( Hibernate.isInitialized( elements ) );
+										context.assertTrue( Hibernate.isInitialized( n1.elements ) );
+									} );
+								} )
+						)
 				)
 		);
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
@@ -9,17 +9,16 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.impl.OracleParameters;
 import org.hibernate.reactive.pool.impl.PostgresParameters;
 import org.hibernate.reactive.pool.impl.SQLServerParameters;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -30,9 +29,9 @@ public class BatchQueryOnConnectionTest extends BaseReactiveTest {
 
 	private static final int BATCH_SIZE = 20;
 
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "DataPoint" ) );
+	@Override
+	protected Set<Class<?>> annotatedEntities() {
+		return Set.of( DataPoint.class );
 	}
 
 	@Test
@@ -130,12 +129,6 @@ public class BatchQueryOnConnectionTest extends BaseReactiveTest {
 			default:
 				return sql;
 		}
-	}
-
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( DataPoint.class );
-		return configuration;
 	}
 
 	@Entity(name = "DataPoint")

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BlockSequenceGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BlockSequenceGeneratorTest.java
@@ -6,10 +6,11 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 import org.junit.Test;
 
 import javax.persistence.*;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -17,10 +18,8 @@ import java.util.Objects;
 public class BlockSequenceGeneratorTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( TableId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( TableId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BlockTableGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BlockTableGeneratorTest.java
@@ -5,22 +5,28 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import javax.persistence.TableGenerator;
+import javax.persistence.Version;
+
+
 import org.junit.Test;
 
-import javax.persistence.*;
-import java.util.Objects;
+import io.vertx.ext.unit.TestContext;
 
 
 
 public class BlockTableGeneratorTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( TableId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( TableId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CacheTest.java
@@ -5,7 +5,12 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
+import javax.persistence.Cacheable;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
 import org.hibernate.annotations.Cache;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
@@ -13,216 +18,217 @@ import org.hibernate.cfg.Environment;
 import org.junit.After;
 import org.junit.Test;
 
-import javax.persistence.Cacheable;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.Id;
-import javax.persistence.Table;
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.annotations.CacheConcurrencyStrategy.NONSTRICT_READ_WRITE;
 
 public class CacheTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Named.class );
-        configuration.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "true" );
-        configuration.setProperty( Environment.CACHE_REGION_FACTORY, "org.hibernate.cache.jcache.JCacheRegionFactory" );
-        configuration.setProperty( "hibernate.javax.cache.provider", "org.ehcache.jsr107.EhcacheCachingProvider" );
-        configuration.setProperty( "hibernate.javax.cache.uri", "/ehcache.xml" );
-        return configuration;
-    }
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Named.class );
+		configuration.setProperty( Environment.USE_SECOND_LEVEL_CACHE, "true" );
+		configuration.setProperty( Environment.CACHE_REGION_FACTORY, "org.hibernate.cache.jcache.JCacheRegionFactory" );
+		configuration.setProperty( "hibernate.javax.cache.provider", "org.ehcache.jsr107.EhcacheCachingProvider" );
+		configuration.setProperty( "hibernate.javax.cache.uri", "/ehcache.xml" );
+		return configuration;
+	}
 
-    @After
-    public void cleanDB(TestContext context) {
-        getSessionFactory().close();
-    }
+	@After
+	public void cleanDB(TestContext context) {
+		getSessionFactory().close();
+	}
 
-    @Test
-    public void testCacheWithHQL(TestContext context) {
-        org.hibernate.Cache cache = getSessionFactory().getCache();
-        test( context,
-                getSessionFactory().withTransaction(
-                        (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
-                )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //populate the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createQuery("from Named" ).getResultList()
-                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertTrue( cache.contains(Named.class, 3) );
-                        } )
-                        //read stuff from the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("foo", n.name) )
-                        ) )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 2)
-                                        .thenAccept( n-> context.assertEquals("bar", n.name) )
-                        ) )
-                        //change the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createQuery("update Named set name='x'||name" ).executeUpdate()
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //read stuff from the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
-                        ) )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 2)
-                                        .thenAccept( n-> context.assertEquals("xbar", n.name) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                            //evict the region
-                            cache.evict(Named.class);
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //repopulate the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createQuery("from Named" ).getResultList()
-                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertTrue( cache.contains(Named.class, 3) );
-                        } )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
-                        ) )
-                        //change the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createQuery("delete Named" ).executeUpdate()
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-        );
-    }
+	@Test
+	public void testCacheWithHQL(TestContext context) {
+		org.hibernate.Cache cache = getSessionFactory().getCache();
+		test(
+				context,
+				getSessionFactory().withTransaction(
+								(s, t) -> s.persist( new Named( "foo" ), new Named( "bar" ), new Named( "baz" ) )
+						)
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//populate the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createQuery( "from Named" ).getResultList()
+										.thenAccept( list -> context.assertEquals( 3, list.size() ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertTrue( cache.contains( Named.class, 3 ) );
+						} )
+						//read stuff from the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "foo", n.name ) )
+						) )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 2 )
+										.thenAccept( n -> context.assertEquals( "bar", n.name ) )
+						) )
+						//change the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createQuery( "update Named set name='x'||name" ).executeUpdate()
+						) )
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//read stuff from the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "xfoo", n.name ) )
+						) )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 2 )
+										.thenAccept( n -> context.assertEquals( "xbar", n.name ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+							//evict the region
+							cache.evict( Named.class );
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//repopulate the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createQuery( "from Named" ).getResultList()
+										.thenAccept( list -> context.assertEquals( 3, list.size() ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertTrue( cache.contains( Named.class, 3 ) );
+						} )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "xfoo", n.name ) )
+						) )
+						//change the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createQuery( "delete Named" ).executeUpdate()
+						) )
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+		);
+	}
 
-    @Test
-    public void testCacheWithNativeSQL(TestContext context) {
-        org.hibernate.Cache cache = getSessionFactory().getCache();
-        test( context,
-                getSessionFactory().withTransaction(
-                        (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
-                )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //populate the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createNativeQuery("select * from named_thing", Named.class ).getResultList()
-                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertTrue( cache.contains(Named.class, 3) );
-                        } )
-                        //read stuff from the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("foo", n.name) )
-                        ) )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 2)
-                                        .thenAccept( n-> context.assertEquals("bar", n.name) )
-                        ) )
-                        //change the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createNativeQuery("update named_thing set name=concat('x',name)" ).executeUpdate()
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //read stuff from the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
-                        ) )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 2)
-                                        .thenAccept( n-> context.assertEquals("xbar", n.name) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                            //evict the region
-                            cache.evict(Named.class);
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-                        //repopulate the cache
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createNativeQuery("select * from named_thing", Named.class ).getResultList()
-                                        .thenAccept( list -> context.assertEquals(3, list.size()) )
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertTrue( cache.contains(Named.class, 1) );
-                            context.assertTrue( cache.contains(Named.class, 2) );
-                            context.assertTrue( cache.contains(Named.class, 3) );
-                        } )
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.find(Named.class, 1)
-                                        .thenAccept( n-> context.assertEquals("xfoo", n.name) )
-                        ) )
-                        //change the database
-                        .thenCompose( v-> getSessionFactory().withSession(
-                                s -> s.createNativeQuery("delete from named_thing" ).executeUpdate()
-                        ) )
-                        .thenAccept( v-> {
-                            context.assertFalse( cache.contains(Named.class, 1) );
-                            context.assertFalse( cache.contains(Named.class, 2) );
-                            context.assertFalse( cache.contains(Named.class, 3) );
-                        } )
-        );
-    }
+	@Test
+	public void testCacheWithNativeSQL(TestContext context) {
+		org.hibernate.Cache cache = getSessionFactory().getCache();
+		test(
+				context,
+				getSessionFactory().withTransaction(
+								(s, t) -> s.persist( new Named( "foo" ), new Named( "bar" ), new Named( "baz" ) )
+						)
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//populate the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createNativeQuery( "select * from named_thing", Named.class ).getResultList()
+										.thenAccept( list -> context.assertEquals( 3, list.size() ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertTrue( cache.contains( Named.class, 3 ) );
+						} )
+						//read stuff from the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "foo", n.name ) )
+						) )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 2 )
+										.thenAccept( n -> context.assertEquals( "bar", n.name ) )
+						) )
+						//change the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createNativeQuery( "update named_thing set name=concat('x',name)" )
+										.executeUpdate()
+						) )
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//read stuff from the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "xfoo", n.name ) )
+						) )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 2 )
+										.thenAccept( n -> context.assertEquals( "xbar", n.name ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+							//evict the region
+							cache.evict( Named.class );
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+						//repopulate the cache
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createNativeQuery( "select * from named_thing", Named.class ).getResultList()
+										.thenAccept( list -> context.assertEquals( 3, list.size() ) )
+						) )
+						.thenAccept( v -> {
+							context.assertTrue( cache.contains( Named.class, 1 ) );
+							context.assertTrue( cache.contains( Named.class, 2 ) );
+							context.assertTrue( cache.contains( Named.class, 3 ) );
+						} )
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.find( Named.class, 1 )
+										.thenAccept( n -> context.assertEquals( "xfoo", n.name ) )
+						) )
+						//change the database
+						.thenCompose( v -> getSessionFactory().withSession(
+								s -> s.createNativeQuery( "delete from named_thing" ).executeUpdate()
+						) )
+						.thenAccept( v -> {
+							context.assertFalse( cache.contains( Named.class, 1 ) );
+							context.assertFalse( cache.contains( Named.class, 2 ) );
+							context.assertFalse( cache.contains( Named.class, 3 ) );
+						} )
+		);
+	}
 
-    @Entity(name="Named")
-    @Table(name = "named_thing")
-    @Cacheable
-    @Cache(region="reg.named", usage=NONSTRICT_READ_WRITE)
-    static class Named {
-        @Id @GeneratedValue
-        Integer id;
-        String name;
+	@Entity(name = "Named")
+	@Table(name = "named_thing")
+	@Cacheable
+	@Cache(region = "reg.named", usage = NONSTRICT_READ_WRITE)
+	static class Named {
+		@Id
+		@GeneratedValue
+		Integer id;
+		String name;
 
-        public Named(String name) {
-            this.name = name;
-        }
+		public Named(String name) {
+			this.name = name;
+		}
 
-        public Named() {}
-    }
+		public Named() {
+		}
+	}
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedTest.java
@@ -5,12 +5,9 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.CompletionStage;
 import javax.persistence.Basic;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -22,9 +19,14 @@ import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.MappedSuperclass;
 import javax.persistence.OneToMany;
-import java.util.Set;
-import java.util.UUID;
-import java.util.concurrent.CompletionStage;
+
+import org.hibernate.Hibernate;
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 /**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedToOnesEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedToOnesEagerTest.java
@@ -5,17 +5,28 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.Hibernate;
-import org.hibernate.reactive.stage.Stage;
-import org.junit.Before;
-import org.junit.Test;
-
-import javax.persistence.*;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletionStage;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.MappedSuperclass;
+import javax.persistence.OneToMany;
+
+import org.hibernate.Hibernate;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.stage.Stage;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeTest.java
@@ -5,11 +5,9 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -27,9 +25,13 @@ import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 public class CascadeTest extends BaseReactiveTest {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 
 import org.junit.Test;
@@ -17,6 +16,7 @@ import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.Table;
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -25,10 +25,8 @@ import java.util.concurrent.CompletionStage;
 public class CompositeIdTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( GuineaPig.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( GuineaPig.class );
 	}
 
 	private CompletionStage<Void> populateDB() {
@@ -37,22 +35,6 @@ public class CompositeIdTest extends BaseReactiveTest {
 						session -> session.persist( new GuineaPig(5, "Aloi", 100) )
 							.thenCompose( v -> session.flush() )
 				 );
-	}
-
-	private CompletionStage<Integer> cleanDB() {
-		return getSessionFactory()
-				.withSession( session -> session.createQuery( "delete GuineaPig" ).executeUpdate() );
-	}
-
-	public void after(TestContext context) {
-		test( context,
-			  cleanDB()
-					  .whenComplete( (res, err) -> {
-						  // in case cleanDB() fails we
-						  // still have to close the factory
-						  super.after( context );
-					  } )
-		);
 	}
 
 	private CompletionStage<String> selectNameFromId(Integer id) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomGeneratorTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.id.Configurable;
 import org.hibernate.reactive.id.ReactiveIdentifierGenerator;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
@@ -20,6 +19,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Version;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.concurrent.CompletionStage;
@@ -29,10 +30,8 @@ import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 public class CustomGeneratorTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( CustomId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( CustomId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomSqlTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomSqlTest.java
@@ -6,11 +6,12 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.SQLUpdate;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -21,65 +22,71 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 
 public class CustomSqlTest extends BaseReactiveTest {
 
-    @Rule
-    public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL, COCKROACHDB );
+	@Rule
+	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL, COCKROACHDB );
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass(Record.class);
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Record.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Record record = new Record();
-        record.text = "initial text";
-        test(context,
-                getMutinySessionFactory()
-                        .withSession( session -> session.persist(record)
-                                .chain(session::flush)
-                                .invoke( () -> record.text = "edited text" )
-                                .chain(session::flush)
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withSession( session -> session.find(Record.class, record.id)
-                                        .invoke( (result) -> {
-                                            context.assertNotNull(result);
-                                            context.assertEquals("edited text", result.text );
-                                            context.assertNotNull(result.updated);
-                                            context.assertNull(result.deleted);
-                                        } )
-                                        .chain(session::remove)
-                                        .chain(session::flush)
-                                ) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withSession( session -> session.find(Record.class, record.id)
-                                        .invoke( (result) -> {
-                                            context.assertNotNull(result);
-                                            context.assertEquals("edited text", result.text );
-                                            context.assertNotNull(result.updated);
-                                            context.assertNotNull(result.deleted);
-                                        } )
-                                ) )
-        );
-    }
+	@Test
+	public void test(TestContext context) {
+		Record record = new Record();
+		record.text = "initial text";
+		test(
+				context,
+				getMutinySessionFactory()
+						.withSession( session -> session.persist( record )
+								.chain( session::flush )
+								.invoke( () -> record.text = "edited text" )
+								.chain( session::flush )
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withSession( session -> session.find( Record.class, record.id )
+										.invoke( (result) -> {
+											context.assertNotNull( result );
+											context.assertEquals( "edited text", result.text );
+											context.assertNotNull( result.updated );
+											context.assertNull( result.deleted );
+										} )
+										.chain( session::remove )
+										.chain( session::flush )
+								) )
+						.chain( () -> getMutinySessionFactory()
+								.withSession( session -> session.find( Record.class, record.id )
+										.invoke( (result) -> {
+											context.assertNotNull( result );
+											context.assertEquals( "edited text", result.text );
+											context.assertNotNull( result.updated );
+											context.assertNotNull( result.deleted );
+										} )
+								) )
+		);
+	}
 
-    @Entity
-    @Table(name="SqlRecord")
-    @SQLInsert(sql = "insert into sqlrecord (text, updated, id) values ($1, localtimestamp, $2)")
-    @SQLUpdate(sql = "update sqlrecord set text=$1, updated=localtimestamp where id=$2")
-    @SQLDelete(sql = "update sqlrecord set deleted=localtimestamp where id=$1")
-    static class Record {
-        @GeneratedValue @Id long id;
-        @Basic(optional = false) String text;
-        @Column(insertable = false, updatable = false, nullable = false) LocalDateTime updated;
-        @Column(insertable = false, updatable = false) LocalDateTime deleted;
-    }
+	@Entity
+	@Table(name = "SqlRecord")
+	@SQLInsert(sql = "insert into sqlrecord (text, updated, id) values ($1, localtimestamp, $2)")
+	@SQLUpdate(sql = "update sqlrecord set text=$1, updated=localtimestamp where id=$2")
+	@SQLDelete(sql = "update sqlrecord set deleted=localtimestamp where id=$1")
+	static class Record {
+		@GeneratedValue
+		@Id
+		long id;
+		@Basic(optional = false)
+		String text;
+		@Column(insertable = false, updatable = false, nullable = false)
+		LocalDateTime updated;
+		@Column(insertable = false, updatable = false)
+		LocalDateTime deleted;
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomStoredProcedureSqlTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomStoredProcedureSqlTest.java
@@ -6,6 +6,8 @@
 package org.hibernate.reactive;
 
 import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -16,7 +18,6 @@ import javax.persistence.Table;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.SQLUpdate;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
 import org.junit.Before;
@@ -70,11 +71,10 @@ public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 			"$BODY$ " +
 			"LANGUAGE plpgsql;";
 
+
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SimpleRecord.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SimpleRecord.class );
 	}
 
 	@Before

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DynamicUpdateTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/DynamicUpdateTest.java
@@ -5,15 +5,8 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-
-import org.hibernate.annotations.DynamicInsert;
-import org.hibernate.annotations.DynamicUpdate;
-import org.hibernate.annotations.OptimisticLocking;
-import org.hibernate.cfg.Configuration;
-
-import org.junit.Test;
-
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -21,15 +14,21 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+import org.hibernate.annotations.OptimisticLocking;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
 import static org.hibernate.annotations.OptimisticLockType.DIRTY;
 
 public class DynamicUpdateTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Record.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Record.class );
 	}
 
 	@Test
@@ -54,7 +53,8 @@ public class DynamicUpdateTest extends BaseReactiveTest {
 										.chain( session::flush )
 								) )
 						.chain( () -> getMutinySessionFactory()
-								.withSession( session -> session.find( Record.class, record.id )
+								.withSession( session -> session
+										.find( Record.class, record.id )
 										.invoke( context::assertNull )
 								) )
 		);

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive;
 
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -15,9 +16,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -45,10 +44,9 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -57,11 +55,6 @@ public class EagerElementCollectionForBasicTypeListTest extends BaseReactiveTest
 		thePerson = new Person( 7242000, "Claude", phones );
 
 		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( thePerson ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,9 +17,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -41,10 +40,9 @@ public class EagerElementCollectionForBasicTypeMapTest extends BaseReactiveTest 
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -56,11 +54,6 @@ public class EagerElementCollectionForBasicTypeMapTest extends BaseReactiveTest 
 
 		test( context, openMutinySession().chain( session -> session
 				.persist( thePerson ).call( session::flush ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -19,9 +19,6 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -48,10 +45,9 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -60,11 +56,6 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 		thePerson = new Person( 7242000, "Claude", phones );
 
 		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( thePerson ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -18,9 +19,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,10 +29,9 @@ public class EagerElementCollectionForEmbeddableEntityTypeMapTest extends BaseRe
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -44,11 +42,6 @@ public class EagerElementCollectionForEmbeddableEntityTypeMapTest extends BaseRe
 		thePerson.getPhones().put( "cccc", new Phone("123-456-7890" ) );
 
 		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( thePerson ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,9 +18,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -29,10 +28,9 @@ public class EagerElementCollectionForEmbeddedEmbeddableMapTest extends BaseReac
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -43,11 +41,6 @@ public class EagerElementCollectionForEmbeddedEmbeddableMapTest extends BaseReac
 		thePerson.addAlternatePhone( "cccc", HOME, "333" );
 
 		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( thePerson ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -17,9 +18,7 @@ import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -49,10 +48,9 @@ public class EagerElementCollectionForEmbeddedEmbeddableTest extends BaseReactiv
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -67,11 +65,6 @@ public class EagerElementCollectionForEmbeddedEmbeddableTest extends BaseReactiv
 				.thenCompose( session -> session.persist( thePerson )
 						.thenCompose( v -> session.flush() ) )
 		);
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerManyToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerManyToOneAssociationTest.java
@@ -5,30 +5,27 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
 
-import org.junit.After;
 import org.junit.Test;
 
-import javax.persistence.*;
-import java.util.Objects;
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 public class EagerManyToOneAssociationTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( Book.class, Author.class ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToManyAssociationTest.java
@@ -5,15 +5,14 @@
  */
 package org.hibernate.reactive;
 
-import org.hibernate.cfg.Configuration;
 import org.junit.Test;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
-import org.junit.After;
 
 import io.vertx.ext.unit.TestContext;
 
@@ -21,42 +20,10 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 public class EagerOneToManyAssociationTest extends BaseReactiveTest {
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Author.class, Book.class );
 	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( Author.class, Book.class ) );
-	}
-//
-//	private CompletionStage<Integer> populateDB(Book... books) {
-//		StringBuilder authorQueryBuilder = new StringBuilder();
-//		StringBuilder bookQueryBuilder = new StringBuilder();
-//		for ( Book book : books ) {
-//			bookQueryBuilder.append( ", ( " );
-//			bookQueryBuilder.append( book.getId() );
-//			bookQueryBuilder.append( ", '" );
-//			bookQueryBuilder.append( book.getTitle() );
-//			bookQueryBuilder.append( "')" );
-//			for ( Author author: book.getAuthors() ) {
-//				authorQueryBuilder.append( ", (" );
-//				authorQueryBuilder.append( author.getId() );
-//				authorQueryBuilder.append( ", '" );
-//				authorQueryBuilder.append( author.getName() );
-//				authorQueryBuilder.append( "', " );
-//				authorQueryBuilder.append( book.getId() );
-//				authorQueryBuilder.append( ") " );
-//			}
-//		}
-//
-//		String authorQuery = "INSERT INTO " + Author.TABLE + " (id, name, book_id) VALUES " + authorQueryBuilder.substring( 1 ) + ";";
-//		String bookQuery = "INSERT INTO " + Book.TABLE + " (id, title) VALUES " + bookQueryBuilder.substring( 1 ) + ";";
-//		return connection().update( bookQuery).thenCompose( ignore -> connection().update( authorQuery ) );
-//	}
 
 	@Test
 	public void findBookWithAuthors(TestContext context) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOneToOneAssociationTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -13,9 +15,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -23,16 +23,8 @@ import io.vertx.ext.unit.TestContext;
 public class EagerOneToOneAssociationTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( Book.class, Author.class ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
@@ -18,9 +19,7 @@ import javax.persistence.FetchType;
 import javax.persistence.Id;
 import javax.persistence.OrderBy;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -52,10 +51,9 @@ public class EagerOrderedElementCollectionForEmbeddableTypeListTest extends Base
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before
@@ -66,11 +64,6 @@ public class EagerOrderedElementCollectionForEmbeddableTypeListTest extends Base
 		thePerson = new Person( 777777, "Claude", phones );
 		test( context, getSessionFactory()
 				.withTransaction( (s, t) -> s.persist( thePerson ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
@@ -6,10 +6,11 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.CascadeType;
@@ -21,79 +22,88 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 
 public class EagerUniqueKeyTest extends BaseReactiveTest {
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass(Foo.class);
-        configuration.addAnnotatedClass(Bar.class);
-        return configuration;
-    }
 
-    @Test
-    public void testFindJoin(TestContext context) {
-        Foo foo = new Foo(new Bar("unique"));
-        test(context, getSessionFactory()
-                .withTransaction( (session, transaction)
-                        -> session.persist(foo)
-                        .thenCompose( v -> session.flush() )
-                        .thenAccept( v -> session.clear() )
-                        .thenCompose( v -> session.find(Foo.class, foo.id) )
-                        .thenAccept( result -> {
-                            context.assertTrue( Hibernate.isInitialized(result.bar) );
-                            context.assertEquals("unique", result.bar.key );
-                        } )
-                ) );
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Foo.class, Bar.class );
+	}
+
+	@Test
+	public void testFindJoin(TestContext context) {
+		Foo foo = new Foo( new Bar( "unique" ) );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( foo )
+						.thenCompose( v -> session.flush() )
+						.thenAccept( v -> session.clear() )
+						.thenCompose( v -> session.find( Foo.class, foo.id ) )
+						.thenAccept( result -> {
+							context.assertTrue( Hibernate.isInitialized( result.bar ) );
+							context.assertEquals( "unique", result.bar.key );
+						} )
+				) );
+	}
 
 
-    @Test
-    public void testMergeDetached(TestContext context) {
-        Bar bar = new Bar("unique2");
-        test(context, getSessionFactory()
-                .withTransaction( (session, tx) -> session.persist(bar) )
-                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.merge( new Foo(bar) ) ) )
-                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique2", b.key ) )
-                ) ) );
-    }
+	@Test
+	public void testMergeDetached(TestContext context) {
+		Bar bar = new Bar( "unique2" );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session -> session.merge( new Foo( bar ) ) ) )
+				.thenCompose( result -> getSessionFactory()
+						.withTransaction( session -> session.fetch( result.bar )
+						.thenAccept( b -> context.assertEquals( "unique2", b.key ) )
+				) ) );
+	}
 
-    @Test
-    public void testMergeReference(TestContext context) {
-        Bar bar = new Bar("unique3");
-        test(context, getSessionFactory()
-                .withTransaction( (session, tx) -> session.persist(bar) )
-                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.merge( new Foo( session.getReference(Bar.class, bar.id) ) ) ) )
-                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique3", b.key ) )
-                ) ) );
-    }
+	@Test
+	public void testMergeReference(TestContext context) {
+		Bar bar = new Bar( "unique3" );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session -> session.merge( new Foo( session.getReference( Bar.class, bar.id ) )) ) )
+				.thenCompose( result -> getSessionFactory().withTransaction( session -> session.fetch( result.bar )
+						.thenAccept( b -> context.assertEquals( "unique3", b.key ) )
+				) ) );
+	}
 
-    @Entity(name="Foo")
-    static class Foo {
-        Foo(Bar bar) {
-            this.bar = bar;
-        }
-        Foo(){}
-        @GeneratedValue @Id
-        long id;
-        @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
-        @Fetch(FetchMode.JOIN)
-        @JoinColumn(name="bar_key", referencedColumnName = "nat_key")
-        Bar bar;
-    }
+	@Entity(name = "Foo")
+	static class Foo {
+		Foo(Bar bar) {
+			this.bar = bar;
+		}
 
-    @Entity(name="Bar")
-    static class Bar implements Serializable {
-        Bar(String key) {
-            this.key = key;
-        }
-        Bar(){}
-        @GeneratedValue @Id
-        long id;
-        @Column(name="nat_key", unique = true)
-        String key;
-    }
+		Foo() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+		@ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
+		@Fetch(FetchMode.JOIN)
+		@JoinColumn(name = "bar_key", referencedColumnName = "nat_key")
+		Bar bar;
+	}
+
+	@Entity(name = "Bar")
+	static class Bar implements Serializable {
+		Bar(String key) {
+			this.key = key;
+		}
+
+		Bar() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+		@Column(name = "nat_key", unique = true)
+		String key;
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EmptyCompositeCollectionKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EmptyCompositeCollectionKeyTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -18,7 +19,6 @@ import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.cfg.Environment;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -27,16 +27,15 @@ import io.vertx.ext.unit.TestContext;
 public class EmptyCompositeCollectionKeyTest extends BaseReactiveTest {
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Family.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		configuration.getProperties().put( Environment.CREATE_EMPTY_COMPOSITES_ENABLED, "true" );
-		configuration.addAnnotatedClass( Family.class );
 		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Family" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
@@ -6,8 +6,10 @@
 package org.hibernate.reactive;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.CompletionStage;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -28,8 +30,8 @@ import javax.persistence.Version;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.util.impl.CompletionStages;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -38,111 +40,119 @@ import io.vertx.ext.unit.TestContext;
 public class FilterTest extends BaseReactiveTest {
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Element.class, Node.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.addPackage(this.getClass().getPackage().getName());
-		configuration.addAnnotatedClass(Node.class);
-		configuration.addAnnotatedClass(Element.class);
+		configuration.addPackage( this.getClass().getPackage().getName() );
 		return configuration;
 	}
 
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Element" )
-				.thenCompose( v -> getSessionFactory()
-						.withTransaction( (s, t) -> s
-								.createQuery( "delete from Node" ).executeUpdate() ) ) );
+	@Override
+	protected CompletionStage<Void> cleanDb() {
+		return getSessionFactory()
+				.withTransaction( s -> s.createQuery( "delete from Element" ).executeUpdate()
+						.thenCompose( v -> s.createQuery( "delete from Node" ).executeUpdate() )
+						.thenCompose( CompletionStages::voidFuture ) );
 	}
 
 	@Test
 	public void testFilter(TestContext context) {
+		Node basik = new Node( "Child" );
+		basik.parent = new Node( "Parent" );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.get( 0 ).deleted = true;
 
-		Node basik = new Node("Child");
-		basik.parent = new Node("Parent");
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.get(0).deleted = true;
-
-		test(context,
+		test(
+				context,
 				openSession()
-						.thenCompose(s -> s.persist(basik).thenCompose(v -> s.flush()))
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("current");
-									return s.createQuery("select distinct n from Node n left join fetch n.elements order by n.id")
-											.setComment("Hello World!")
+						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "current" );
+									return s.createQuery( "select distinct n from Node n left join fetch n.elements order by n.id" )
+											.setComment( "Hello World!" )
 											.getResultList();
-								}))
-						.thenAccept(list -> {
-							context.assertEquals(list.size(), 2);
-							context.assertEquals(((Node) list.get(0)).elements.size(), 2);
-						})
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("current");
-									return s.createQuery("select distinct n, e from Node n join n.elements e").getResultList();
-								}))
-						.thenAccept(list -> context.assertEquals(list.size(), 2))
+								} ) )
+						.thenAccept( list -> {
+							context.assertEquals( list.size(), 2 );
+							context.assertEquals( ( (Node) list.get( 0 ) ).elements.size(), 2 );
+						} )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "current" );
+									return s.createQuery( "select distinct n, e from Node n join n.elements e" )
+											.getResultList();
+								} ) )
+						.thenAccept( list -> context.assertEquals( list.size(), 2 ) )
 		);
 	}
 
 	@Test
 	public void testFilterWithParameter(TestContext context) {
 
-		Node basik = new Node("Child");
+		Node basik = new Node( "Child" );
 		basik.region = "oceania";
-		basik.parent = new Node("Parent");
+		basik.parent = new Node( "Parent" );
 		basik.parent.region = "oceania";
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.get(0).region = "asia";
-		basik.elements.get(1).region = "oceania";
-		basik.elements.get(2).region = "oceania";
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.get( 0 ).region = "asia";
+		basik.elements.get( 1 ).region = "oceania";
+		basik.elements.get( 2 ).region = "oceania";
 
-		test(context,
+		test(
+				context,
 				openSession()
-						.thenCompose(s -> s.persist(basik).thenCompose(v -> s.flush()))
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("region").setParameter("region", "oceania");
-									return s.createQuery("select distinct n from Node n left join fetch n.elements order by n.id")
-											.setComment("Hello World!")
+						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "region" ).setParameter( "region", "oceania" );
+									return s.createQuery(
+													"select distinct n from Node n left join fetch n.elements order by n.id" )
+											.setComment( "Hello World!" )
 											.getResultList();
-								}))
-						.thenAccept(list -> {
-							context.assertEquals(list.size(), 2);
-							context.assertEquals(((Node) list.get(0)).elements.size(), 2);
-						})
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("region").setParameter("region", "oceania");
-									return s.createQuery("select distinct n, e from Node n join n.elements e").getResultList();
-								}))
-						.thenAccept(list -> context.assertEquals(list.size(), 2))
+								} ) )
+						.thenAccept( list -> {
+							context.assertEquals( list.size(), 2 );
+							context.assertEquals( ( (Node) list.get( 0 ) ).elements.size(), 2 );
+						} )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "region" ).setParameter( "region", "oceania" );
+									return s.createQuery( "select distinct n, e from Node n join n.elements e" )
+											.getResultList();
+								} ) )
+						.thenAccept( list -> context.assertEquals( list.size(), 2 ) )
 		);
 	}
 
 	@Test
 	public void testFilterCollectionFetch(TestContext context) {
 
-		Node basik = new Node("Child");
-		basik.parent = new Node("Parent");
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.get(0).deleted = true;
+		Node basik = new Node( "Child" );
+		basik.parent = new Node( "Parent" );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.get( 0 ).deleted = true;
 
-		test(context,
+		test(
+				context,
 				openSession()
-						.thenCompose(s -> s.persist(basik).thenCompose(v -> s.flush()))
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("current");
+						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "current" );
 									return s.find( Node.class, basik.getId() )
 											.thenCompose( node -> s.fetch( node.elements ) );
-								}))
+								} ) )
 						.thenAccept( list -> context.assertEquals( 2, list.size() ) )
 		);
 	}
@@ -150,26 +160,27 @@ public class FilterTest extends BaseReactiveTest {
 	@Test
 	public void testFilterCollectionFetchWithParameter(TestContext context) {
 
-		Node basik = new Node("Child");
+		Node basik = new Node( "Child" );
 		basik.region = "oceania";
-		basik.parent = new Node("Parent");
+		basik.parent = new Node( "Parent" );
 		basik.parent.region = "oceania";
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.get(0).region = "asia";
-		basik.elements.get(1).region = "oceania";
-		basik.elements.get(2).region = "oceania";
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.get( 0 ).region = "asia";
+		basik.elements.get( 1 ).region = "oceania";
+		basik.elements.get( 2 ).region = "oceania";
 
-		test(context,
+		test(
+				context,
 				openSession()
-						.thenCompose(s -> s.persist(basik).thenCompose(v -> s.flush()))
-						.thenCompose(v -> openSession()
-								.thenCompose(s -> {
-									s.enableFilter("region").setParameter("region", "oceania");
+						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
+						.thenCompose( v -> openSession()
+								.thenCompose( s -> {
+									s.enableFilter( "region" ).setParameter( "region", "oceania" );
 									return s.find( Node.class, basik.getId() )
 											.thenCompose( node -> s.fetch( node.elements ) );
-								}))
+								} ) )
 						.thenAccept( list -> context.assertEquals( 2, list.size() ) )
 		);
 	}
@@ -216,15 +227,19 @@ public class FilterTest extends BaseReactiveTest {
 		String region;
 
 		@ManyToOne(fetch = FetchType.LAZY,
-				cascade = {CascadeType.PERSIST,
+				cascade = {
+						CascadeType.PERSIST,
 						CascadeType.REFRESH,
 						CascadeType.MERGE,
-						CascadeType.REMOVE})
+						CascadeType.REMOVE
+				})
 		Node parent;
 
 		@OneToMany(fetch = FetchType.LAZY,
-				cascade = {CascadeType.PERSIST,
-						CascadeType.REMOVE},
+				cascade = {
+						CascadeType.PERSIST,
+						CascadeType.REMOVE
+				},
 				mappedBy = "node")
 		@Filter(name = "current")
 		@Filter(name = "region")
@@ -310,19 +325,19 @@ public class FilterTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) {
+			if ( this == o ) {
 				return true;
 			}
-			if (o == null || getClass() != o.getClass()) {
+			if ( o == null || getClass() != o.getClass() ) {
 				return false;
 			}
 			Node node = (Node) o;
-			return Objects.equals(string, node.string);
+			return Objects.equals( string, node.string );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(string);
+			return Objects.hash( string );
 		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Entity;
@@ -16,11 +18,9 @@ import javax.persistence.NamedQuery;
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -43,10 +43,8 @@ public class FilterWithPaginationTest extends BaseReactiveTest {
 	FamousPerson rebeccaSinger = new FamousPerson( 5L, "Rebecca Ferguson", Status.LIVING, "Shot to fame on The X Factor and is currently a solo artist." );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( FamousPerson.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( FamousPerson.class );
 	}
 
 	@Before
@@ -54,12 +52,6 @@ public class FilterWithPaginationTest extends BaseReactiveTest {
 		test( context, getMutinySessionFactory().withSession( s -> s
 					  .persistAll( margaret, nellie, hedy, rebeccaActress, rebeccaSinger )
 					  .chain( s::flush ) ) );
-	}
-
-	@After
-	public void clearDb(TestContext context) {
-		test( context, getMutinySessionFactory().withTransaction( (s, tx) -> s
-				.createQuery( "delete from FamousPerson" ).executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FindAfterFlushTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FindAfterFlushTest.java
@@ -5,15 +5,15 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -24,18 +24,8 @@ import io.vertx.ext.unit.TestContext;
 public class FindAfterFlushTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Webcomic.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, getSessionFactory()
-				.withTransaction( (session, tx) -> session
-						.createQuery( "delete from Webcomic" )
-						.executeUpdate() ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Webcomic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FormulaTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FormulaTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 
 import org.hibernate.annotations.Formula;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
 import org.junit.Rule;
@@ -20,6 +19,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import java.time.Instant;
+import java.util.Collection;
+import java.util.List;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MYSQL;
@@ -30,10 +31,8 @@ public class FormulaTest extends BaseReactiveTest {
 	public DatabaseSelectionRule rule = DatabaseSelectionRule.skipTestsFor( MARIA, MYSQL );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Record.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Record.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyJoinedTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertyJoinedTableTest.java
@@ -5,7 +5,9 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -24,7 +26,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -45,18 +46,16 @@ public class GeneratedPropertyJoinedTableTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL, COCKROACHDB, MYSQL );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.setProperty(AvailableSettings.HBM2DDL_CREATE_SOURCE, "script-then-metadata");
-		configuration.setProperty(AvailableSettings.HBM2DDL_CREATE_SCRIPT_SOURCE, "/mysql-pipe.sql");
-		configuration.addAnnotatedClass( GeneratedWithIdentity.class );
-		configuration.addAnnotatedClass( GeneratedRegular.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( GeneratedWithIdentity.class, GeneratedRegular.class );
 	}
 
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "GeneratedWithIdentity", "GeneratedRegular" ) );
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.setProperty( AvailableSettings.HBM2DDL_CREATE_SOURCE, "script-then-metadata" );
+		configuration.setProperty( AvailableSettings.HBM2DDL_CREATE_SCRIPT_SOURCE, "/mysql-pipe.sql" );
+		return configuration;
 	}
 
 	@Test
@@ -64,38 +63,39 @@ public class GeneratedPropertyJoinedTableTest extends BaseReactiveTest {
 		final GeneratedWithIdentity davide = new GeneratedWithIdentity( "Davide", "D'Alto" );
 
 		CurrentUser.INSTANCE.logIn( "dd-insert" );
-		test( context,
-			  getMutinySessionFactory()
-					  // Generated during insert
-					  .withSession( session -> session.persist( davide ).call( session::flush )
-							  .invoke( v -> {
-								  context.assertNotNull( davide.id );
-								  context.assertEquals( "Davide", davide.firstname );
-								  context.assertEquals( "D'Alto", davide.lastname );
-								  context.assertEquals( "Davide D'Alto", davide.fullName );
-								  context.assertNotNull( davide.createdAt );
-								  context.assertEquals( "dd-insert", davide.createdBy );
-								  context.assertEquals( "dd-insert", davide.updatedBy );
-								  context.assertNull( davide.never );
-								  CurrentUser.INSTANCE.logOut();
-							  } ) )
-					  // Generated during update
-					  .chain( () -> getMutinySessionFactory()
-							  .withSession( session -> session.find( GeneratedWithIdentity.class, davide.id )
-									  .chain( result -> {
-										  CurrentUser.INSTANCE.logIn( "dd-update" );
-										  result.lastname = "O'Tall";
-										  return session.flush().invoke( afterUpdate -> {
-											  context.assertEquals( "Davide", result.firstname );
-											  context.assertEquals( "O'Tall", result.lastname );
-											  context.assertEquals( "Davide O'Tall", result.fullName );
-											  context.assertEquals( davide.createdAt, result.createdAt );
-											  context.assertEquals( "dd-insert", result.createdBy );
-											  context.assertEquals( "dd-update", result.updatedBy );
-											  context.assertNull( result.never );
-											  CurrentUser.INSTANCE.logOut();
-										  } );
-									  } ) ) )
+		test( context, getMutinySessionFactory()
+				// Generated during insert
+				.withTransaction( session -> session.persist( davide ) )
+				.invoke( v -> {
+					context.assertNotNull( davide.id );
+					context.assertEquals( "Davide", davide.firstname );
+					context.assertEquals( "D'Alto", davide.lastname );
+					context.assertEquals( "Davide D'Alto", davide.fullName );
+					context.assertNotNull( davide.createdAt );
+					context.assertEquals( "dd-insert", davide.createdBy );
+					context.assertEquals( "dd-insert", davide.updatedBy );
+					context.assertNull( davide.never );
+					CurrentUser.INSTANCE.logOut();
+				} )
+				// Generated during update
+				.chain( () -> getMutinySessionFactory()
+						.withTransaction( session -> session
+								.find( GeneratedWithIdentity.class, davide.id )
+								.chain( result -> {
+									CurrentUser.INSTANCE.logIn( "dd-update" );
+									result.lastname = "O'Tall";
+									return session.flush().invoke( afterUpdate -> {
+										context.assertEquals( "Davide", result.firstname );
+										context.assertEquals( "O'Tall", result.lastname );
+										context.assertEquals( "Davide O'Tall", result.fullName );
+										context.assertEquals( davide.createdAt, result.createdAt );
+										context.assertEquals( "dd-insert", result.createdBy );
+										context.assertEquals( "dd-update", result.updatedBy );
+										context.assertNull( result.never );
+										CurrentUser.INSTANCE.logOut();
+									} );
+								} ) )
+				)
 		);
 	}
 
@@ -104,38 +104,40 @@ public class GeneratedPropertyJoinedTableTest extends BaseReactiveTest {
 		final GeneratedRegular davide = new GeneratedRegular( "Davide", "D'Alto" );
 
 		CurrentUser.INSTANCE.logIn( "dd-insert" );
-		test( context,
-			  getMutinySessionFactory()
-					  // Generated during insert
-					  .withSession( session -> session.persist( davide ).call( session::flush )
-							  .invoke( v -> {
-								  context.assertNotNull( davide.id );
-								  context.assertEquals( "Davide", davide.firstname );
-								  context.assertEquals( "D'Alto", davide.lastname );
-								  context.assertEquals( "Davide D'Alto", davide.fullName );
-								  context.assertNotNull( davide.createdAt );
-								  context.assertEquals( "dd-insert", davide.createdBy );
-								  context.assertEquals( "dd-insert", davide.updatedBy );
-								  context.assertNull( davide.never );
-								  CurrentUser.INSTANCE.logOut();
-							  } ) )
-					  // Generated during update
-					  .chain( () -> getMutinySessionFactory()
-							  .withSession( session -> session.find( GeneratedRegular.class, davide.id )
-									  .chain( result -> {
-										  CurrentUser.INSTANCE.logIn( "dd-update" );
-										  result.lastname = "O'Tall";
-										  return session.flush().invoke( afterUpdate -> {
-											  context.assertEquals( "Davide", result.firstname );
-											  context.assertEquals( "O'Tall", result.lastname );
-											  context.assertEquals( "Davide O'Tall", result.fullName );
-											  context.assertEquals( davide.createdAt, result.createdAt );
-											  context.assertEquals( "dd-insert", result.createdBy );
-											  context.assertEquals( "dd-update", result.updatedBy );
-											  context.assertNull( result.never );
-											  CurrentUser.INSTANCE.logOut();
-										  } );
-									  } ) ) )
+		test(
+				context,
+				getMutinySessionFactory()
+						// Generated during insert
+						.withTransaction( session -> session.persist( davide ) )
+						.invoke( v -> {
+							context.assertNotNull( davide.id );
+							context.assertEquals( "Davide", davide.firstname );
+							context.assertEquals( "D'Alto", davide.lastname );
+							context.assertEquals( "Davide D'Alto", davide.fullName );
+							context.assertNotNull( davide.createdAt );
+							context.assertEquals( "dd-insert", davide.createdBy );
+							context.assertEquals( "dd-insert", davide.updatedBy );
+							context.assertNull( davide.never );
+							CurrentUser.INSTANCE.logOut();
+						} )
+						// Generated during update
+						.chain( () -> getMutinySessionFactory()
+								.withSession( session -> session
+										.find( GeneratedRegular.class, davide.id )
+										.chain( result -> {
+											CurrentUser.INSTANCE.logIn( "dd-update" );
+											result.lastname = "O'Tall";
+											return session.flush().invoke( afterUpdate -> {
+												context.assertEquals( "Davide", result.firstname );
+												context.assertEquals( "O'Tall", result.lastname );
+												context.assertEquals( "Davide O'Tall", result.fullName );
+												context.assertEquals( davide.createdAt, result.createdAt );
+												context.assertEquals( "dd-insert", result.createdBy );
+												context.assertEquals( "dd-update", result.updatedBy );
+												context.assertNull( result.never );
+												CurrentUser.INSTANCE.logOut();
+											} );
+										} ) ) )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/GeneratedPropertySingleTableTest.java
@@ -5,7 +5,9 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -23,7 +25,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -39,24 +40,21 @@ import static org.hibernate.reactive.testing.DatabaseSelectionRule.runOnlyFor;
  */
 public class GeneratedPropertySingleTableTest extends BaseReactiveTest {
 
-
 	// It requires native queries, so it won't work for every db
 	@Rule
 	public DatabaseSelectionRule selectionRule = runOnlyFor( POSTGRESQL, COCKROACHDB, MYSQL );
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( GeneratedWithIdentity.class, GeneratedRegular.class );
+	}
 
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		configuration.setProperty(AvailableSettings.HBM2DDL_CREATE_SOURCE, "script-then-metadata");
 		configuration.setProperty(AvailableSettings.HBM2DDL_CREATE_SCRIPT_SOURCE, "/mysql-pipe.sql");
-		configuration.addAnnotatedClass( GeneratedWithIdentity.class );
-		configuration.addAnnotatedClass( GeneratedRegular.class );
 		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( GeneratedWithIdentity.class, GeneratedRegular.class ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedLimitTest.java
@@ -5,16 +5,17 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 /**
@@ -28,10 +29,8 @@ public class HQLQueryParameterNamedLimitTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
@@ -42,12 +41,6 @@ public class HQLQueryParameterNamedLimitTest extends BaseReactiveTest {
 				.thenCompose( v -> s.persist( almond ) )
 				.thenCompose( v -> s.flush() ) )
 		);
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, openSession()
-				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterNamedTest.java
@@ -5,15 +5,15 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -30,22 +30,14 @@ public class HQLQueryParameterNamedTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
 	public void populateDb(TestContext context) {
 		test( context, getMutinySessionFactory()
 				.withTransaction( (session, transaction) -> session.persistAll( spelt, rye, almond ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, getSessionFactory()
-				.withTransaction( (s, t) -> s.createQuery( "delete Flour" ).executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalLimitTest.java
@@ -5,16 +5,17 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
-import java.util.Objects;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 /**
@@ -31,10 +32,8 @@ public class HQLQueryParameterPositionalLimitTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
@@ -45,12 +44,6 @@ public class HQLQueryParameterPositionalLimitTest extends BaseReactiveTest {
 				.thenCompose( v -> s.persist( almond ) )
 				.thenCompose( v -> s.flush() ) )
 		);
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context,openSession()
-				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryParameterPositionalTest.java
@@ -6,16 +6,16 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 
@@ -33,21 +33,14 @@ public class HQLQueryParameterPositionalTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
 	public void populateDb(TestContext context) {
 		test( context, getMutinySessionFactory()
 				.withTransaction( (session, transaction) -> session.persistAll( spelt, rye, almond ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Flour" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLQueryTest.java
@@ -5,15 +5,15 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,22 +27,14 @@ public class HQLQueryTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
 	public void populateDb(TestContext context) {
 		test( context, getMutinySessionFactory()
 				.withTransaction( (session, transaction) -> session.persistAll( spelt, rye, almond ) ) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, openSession()
-				.thenCompose( s -> s.createQuery( "delete Flour" ).executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/HQLUpdateQueryTest.java
@@ -5,15 +5,15 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,10 +33,8 @@ public class HQLUpdateQueryTest extends BaseReactiveTest {
 	Flour almond = new Flour( 3, "Almond", "made from ground almonds.", "Gluten free" );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
@@ -47,12 +45,6 @@ public class HQLUpdateQueryTest extends BaseReactiveTest {
 				.thenCompose( v -> s.persist( almond ) )
 				.thenCompose( v -> s.flush() )
 		) );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, openSession()
-				.thenCompose( s -> s.createQuery("delete Flour").executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentifierGenerationTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentifierGenerationTypeTest.java
@@ -6,15 +6,15 @@
 package org.hibernate.reactive;
 
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -27,17 +27,8 @@ import io.vertx.ext.unit.TestContext;
 public class IdentifierGenerationTypeTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( LongEntity.class );
-		configuration.addAnnotatedClass( IntegerEntity.class );
-		configuration.addAnnotatedClass( ShortEntity.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( LongEntity.class, IntegerEntity.class, ShortEntity.class ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( LongEntity.class, IntegerEntity.class, ShortEntity.class );
 	}
 
 	/*

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorDynamicInsertTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorDynamicInsertTest.java
@@ -17,6 +17,7 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
@@ -40,9 +41,13 @@ public class IdentityGeneratorDynamicInsertTest extends BaseReactiveTest {
 	private static final int ENTITY_NUMBER = 100;
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( EntityWithIdentity.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( EntityWithIdentity.class );
 		configuration.setProperty( AvailableSettings.USE_GET_GENERATED_KEYS, "false" );
 		return configuration;
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTest.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Column;
@@ -41,9 +42,13 @@ public class IdentityGeneratorTest extends BaseReactiveTest {
 	private static final int ENTITY_NUMBER = 100;
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( EntityWithIdentity.class );
+	}
+
+	@Override
 	protected org.hibernate.cfg.Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( EntityWithIdentity.class );
 		configuration.setProperty( AvailableSettings.USE_GET_GENERATED_KEYS, "false" );
 		return configuration;
 	}
@@ -69,9 +74,9 @@ public class IdentityGeneratorTest extends BaseReactiveTest {
 	public void testIdentityGenerator(TestContext context) {
 		test( context, populateDb( context )
 				.thenCompose( v -> openSession() )
-				.thenCompose( session ->
-					  session.createQuery( "FROM EntityWithIdentity ORDER BY position ASC", EntityWithIdentity.class )
-					  .getResultList() )
+				.thenCompose( session -> session
+						.createQuery( "FROM EntityWithIdentity ORDER BY position ASC", EntityWithIdentity.class )
+						.getResultList() )
 				.thenAccept( list -> {
 					context.assertEquals( ENTITY_NUMBER, list.size() );
 					int i = 0;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeForCockroachDBTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -52,13 +54,15 @@ public class IdentityGeneratorTypeForCockroachDBTest extends BaseReactiveTest {
 	}
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( IntegerTypeEntity.class, LongTypeEntity.class, ShortTypeEntity.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		// It's the default but I want to highlight what we are testing
 		configuration.setProperty( AvailableSettings.USE_GET_GENERATED_KEYS, "false" );
-		configuration.addAnnotatedClass( IntegerTypeEntity.class );
-		configuration.addAnnotatedClass( LongTypeEntity.class );
-		configuration.addAnnotatedClass( ShortTypeEntity.class );
 		return configuration;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -15,7 +17,6 @@ import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -38,6 +39,11 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 	@Rule
 	public DatabaseSelectionRule skip = skipTestsFor( COCKROACHDB );
 
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( IntegerTypeEntity.class, LongTypeEntity.class, ShortTypeEntity.class );
+	}
+
 	/**
 	 * When {@link AvailableSettings#USE_GET_GENERATED_KEYS} is enabled, different
 	 * queries will be used for each datastore to get the id
@@ -57,15 +63,7 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 		Configuration configuration = super.constructConfiguration();
 		// It's the default but I want to highlight what we are testing
 		configuration.setProperty( AvailableSettings.USE_GET_GENERATED_KEYS, "false" );
-		configuration.addAnnotatedClass( IntegerTypeEntity.class );
-		configuration.addAnnotatedClass( LongTypeEntity.class );
-		configuration.addAnnotatedClass( ShortTypeEntity.class );
 		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( IntegerTypeEntity.class, ShortTypeEntity.class, LongTypeEntity.class ) );
 	}
 
 	private <U extends Number, T extends TypeIdentity<U>> void assertType(

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorWithColumnTransformerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorWithColumnTransformerTest.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Column;
@@ -52,9 +53,13 @@ public class IdentityGeneratorWithColumnTransformerTest extends BaseReactiveTest
 	private static final int ENTITY_NUMBER = 100;
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( EntityWithIdentity.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( EntityWithIdentity.class );
 		configuration.setProperty( AvailableSettings.USE_SQL_COMMENTS, ENABLE_COMMENTS );
 		return configuration;
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InsertOrderingReferenceSeveralDifferentSubclassBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InsertOrderingReferenceSeveralDifferentSubclassBase.java
@@ -5,9 +5,6 @@
  */
 package org.hibernate.reactive;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
-
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.CascadeType;
@@ -29,11 +26,13 @@ import org.hibernate.reactive.provider.Settings;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 import org.hibernate.reactive.testing.SqlStatementTracker;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
 
 /**
  * Test ORDER_INSERTS property value during batching.
@@ -123,12 +122,6 @@ public abstract class InsertOrderingReferenceSeveralDifferentSubclassBase extend
 	@Override
 	protected void addServices(StandardServiceRegistryBuilder builder) {
 		sqlTracker.registerService( builder );
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		deleteEntities( "SubclassZero", "SubclassOne", "SubclassTwo", "UnrelatedEntity" );
-		sqlTracker.clear();
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/JoinedSubclassInheritanceTest.java
@@ -5,17 +5,28 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.persistence.*;
-import java.util.Date;
-import java.util.Objects;
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
 
@@ -26,17 +37,8 @@ public class JoinedSubclassInheritanceTest extends BaseReactiveTest {
 	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( ORACLE );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( SpellBook.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class, SpellBook.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyInitializationExceptionWithMutiny.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyInitializationExceptionWithMutiny.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
@@ -18,9 +19,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.hibernate.LazyInitializationException;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,11 +30,8 @@ import io.vertx.ext.unit.TestContext;
 public class LazyInitializationExceptionWithMutiny extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Artist.class );
-		configuration.addAnnotatedClass( Painting.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Artist.class, Painting.class );
 	}
 
 	@Before
@@ -44,14 +40,6 @@ public class LazyInitializationExceptionWithMutiny extends BaseReactiveTest {
 		Artist artemisia = new Artist( "Artemisia Gentileschi" );
 		getMutinySessionFactory()
 				.withTransaction( (session, tx) -> session.persist( artemisia ) )
-				.subscribe().with( success -> async.complete(), context::fail );
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		Async async = context.async();
-		getMutinySessionFactory()
-				.withTransaction( (session, tx) -> session.createQuery( "delete from Artist" ).executeUpdate() )
 				.subscribe().with( success -> async.complete(), context::fail );
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyInitializationExceptionWithStage.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyInitializationExceptionWithStage.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletionException;
@@ -19,9 +20,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.hibernate.LazyInitializationException;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -31,25 +30,14 @@ import io.vertx.ext.unit.TestContext;
 public class LazyInitializationExceptionWithStage extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Artist.class );
-		configuration.addAnnotatedClass( Painting.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Artist.class, Painting.class );
 	}
 
 	@Before
 	public void populateDB(TestContext context) {
 		Artist artemisia = new Artist( "Artemisia Gentileschi" );
 		test( context, getSessionFactory().withTransaction( (session, tx) -> session.persist( artemisia ) ) );
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, getSessionFactory()
-				.withTransaction( (session, tx) ->
-					  session.createQuery( "delete from Artist" )
-							  .executeUpdate() ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyManyToOneAssociationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyManyToOneAssociationTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.DiscriminatorValue;
 import javax.persistence.Entity;
@@ -18,9 +20,7 @@ import javax.persistence.Table;
 
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.FetchProfile;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -30,16 +30,8 @@ import static org.hibernate.Hibernate.isInitialized;
 public class LazyManyToOneAssociationTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( Book.class, Author.class ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToManyAssociationWithFetchTest.java
@@ -9,10 +9,8 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.FetchMode;
 import org.hibernate.annotations.FetchProfile;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -25,21 +23,15 @@ import javax.persistence.NamedEntityGraph;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
 public class LazyOneToManyAssociationWithFetchTest extends BaseReactiveTest {
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Writer", "Tome" ) );
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Author.class, Book.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToOneWithJoinColumnTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOneToOneWithJoinColumnTest.java
@@ -5,23 +5,28 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
+import java.util.Collection;
+import java.util.List;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
 
 import org.junit.Test;
 
-import javax.persistence.*;
+import io.vertx.ext.unit.TestContext;
 
 public class LazyOneToOneWithJoinColumnTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Endpoint.class );
-		configuration.addAnnotatedClass( EndpointWebhook.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Endpoint.class, EndpointWebhook.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOrderedElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyOrderedElementCollectionForEmbeddableTypeListTest.java
@@ -5,23 +5,23 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
 import javax.persistence.Embeddable;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OrderBy;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+
+import org.hibernate.Hibernate;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 /**
  * Tests @{@link ElementCollection} on a {@link java.util.Set} of basic types.
@@ -48,15 +48,9 @@ public class LazyOrderedElementCollectionForEmbeddableTypeListTest extends BaseR
 
 	private Person thePerson;
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Person" ) );
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
 	}
 
 	@Before

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyPropertyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyPropertyTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.junit.Test;
@@ -22,6 +21,7 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 import javax.persistence.metamodel.Attribute;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 import static java.util.Collections.singleton;
@@ -31,16 +31,12 @@ import static javax.persistence.FetchType.LAZY;
 public class LazyPropertyTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test
 	public void testLazyProperty(TestContext context) {
-
 		Author author1 = new Author("Iain M. Banks");
 		Author author2 = new Author("Neal Stephenson");
 		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1);
@@ -74,7 +70,6 @@ public class LazyPropertyTest extends BaseReactiveTest {
 				)
 		);
 	}
-
 
 	@Entity(name="Author")
 	@Table(name="authors")

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyReplaceOrphanedEntityTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyReplaceOrphanedEntityTest.java
@@ -7,6 +7,8 @@ package org.hibernate.reactive;
 
 import java.io.Serializable;
 import java.time.OffsetDateTime;
+import java.util.Collection;
+import java.util.List;
 import java.util.UUID;
 import javax.persistence.CascadeType;
 import javax.persistence.Column;
@@ -22,9 +24,7 @@ import javax.persistence.InheritanceType;
 import javax.persistence.JoinColumn;
 import javax.persistence.OneToOne;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -37,12 +37,8 @@ public class LazyReplaceOrphanedEntityTest extends BaseReactiveTest {
 	private Campaign theCampaign;
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Campaign.class );
-		configuration.addAnnotatedClass( ExecutionDate.class );
-		configuration.addAnnotatedClass( Schedule.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Campaign.class, ExecutionDate.class, Schedule.class );
 	}
 
 	@Before
@@ -51,11 +47,6 @@ public class LazyReplaceOrphanedEntityTest extends BaseReactiveTest {
 		theCampaign.setSchedule( new ExecutionDate(OffsetDateTime.now(), "ALPHA") );
 
 		test( context, getMutinySessionFactory().withTransaction( (s, t) -> s.persist( theCampaign ) ) );
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, deleteEntities( "Campaign", "Schedule" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyUniqueKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyUniqueKeyTest.java
@@ -6,9 +6,10 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.CascadeType;
@@ -20,80 +21,92 @@ import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 
 public class LazyUniqueKeyTest extends BaseReactiveTest {
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass(Foo.class);
-        configuration.addAnnotatedClass(Bar.class);
-        return configuration;
-    }
 
-    @Test
-    public void testFindSelect(TestContext context) {
-        Foo foo = new Foo(new Bar("unique"));
-        test(context, getSessionFactory()
-                .withTransaction( (session, transaction)
-                        -> session.persist(foo)
-                        .thenCompose( v -> session.flush() )
-                        .thenAccept( v -> session.clear() )
-                        .thenCompose( v -> session.find(Foo.class, foo.id) )
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Foo.class, Bar.class );
+	}
+
+	@Test
+	public void testFindSelect(TestContext context) {
+		Foo foo = new Foo( new Bar( "unique" ) );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session
+						.persist( foo )
+						.thenCompose( v -> session.flush() )
+						.thenAccept( v -> session.clear() )
+						.thenCompose( v -> session.find( Foo.class, foo.id ) )
 //                        .thenApply( result -> {
 //                            context.assertFalse( Hibernate.isInitialized(result.bar) );
 //                            return result;
 //                        } )
-                        .thenCompose( result -> session.fetch(result.bar) )
-                        .thenAccept( bar -> context.assertEquals("unique", bar.key ) )
-                ) );
-    }
+						.thenCompose( result -> session.fetch( result.bar ) )
+						.thenAccept( bar -> context.assertEquals( "unique", bar.key ) ) )
+		);
+	}
 
-    @Test
-    public void testMergeDetached(TestContext context) {
-        Bar bar = new Bar("unique2");
-        test(context, getSessionFactory()
-                .withTransaction( (session, tx) -> session.persist(bar) )
-                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.merge( new Foo(bar) ) ) )
-                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique2", b.key ) )
-                ) ) );
-    }
+	@Test
+	public void testMergeDetached(TestContext context) {
+		Bar bar = new Bar( "unique2" );
+		test( context, getSessionFactory()
+				.withTransaction( (session, tx) -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session -> session.merge( new Foo( bar ) ) ) )
+				.thenCompose( result -> getSessionFactory()
+						.withTransaction( session -> session.fetch( result.bar )
+								.thenAccept( b -> context.assertEquals( "unique2", b.key ) )
+				) ) );
+	}
 
-    @Test
-    public void testMergeReference(TestContext context) {
-        Bar bar = new Bar("unique3");
-        test(context, getSessionFactory()
-                .withTransaction( (session, tx) -> session.persist(bar) )
-                .thenCompose( i -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.merge( new Foo( session.getReference(Bar.class, bar.id) ) ) ) )
-                .thenCompose( result -> getSessionFactory().withTransaction( (session, transaction)
-                        -> session.fetch(result.bar).thenAccept( b -> context.assertEquals("unique3", b.key ) )
-                ) ) );
-    }
+	@Test
+	public void testMergeReference(TestContext context) {
+		Bar bar = new Bar( "unique3" );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session-> session.merge( new Foo( session.getReference( Bar.class, bar.id ) ) ) )
+				)
+				.thenCompose( result -> getSessionFactory()
+						.withTransaction( session-> session.fetch( result.bar )
+						.thenAccept( b -> context.assertEquals( "unique3", b.key ) )
+				) ) );
+	}
 
-    @Entity(name="Foo")
-    static class Foo {
-        Foo(Bar bar) {
-            this.bar = bar;
-        }
-        Foo(){}
-        @GeneratedValue @Id
-        long id;
-        @ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
-        @Fetch(FetchMode.SELECT)
-        @JoinColumn(name="bar_key", referencedColumnName = "nat_key")
-        Bar bar;
-    }
+	@Entity(name = "Foo")
+	static class Foo {
+		Foo(Bar bar) {
+			this.bar = bar;
+		}
 
-    @Entity(name="Bar")
-    static class Bar implements Serializable {
-        Bar(String key) {
-            this.key = key;
-        }
-        Bar(){}
-        @GeneratedValue @Id
-        long id;
-        @Column(name="nat_key", unique = true)
-        String key;
-    }
+		Foo() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+		@ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.LAZY)
+		@Fetch(FetchMode.SELECT)
+		@JoinColumn(name = "bar_key", referencedColumnName = "nat_key")
+		Bar bar;
+	}
+
+	@Entity(name = "Bar")
+	static class Bar implements Serializable {
+		Bar(String key) {
+			this.key = key;
+		}
+
+		Bar() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+		@Column(name = "nat_key", unique = true)
+		String key;
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToManySetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToManySetTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -16,85 +17,98 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.Table;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class ManyToManySetTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        book1.authors.add(author);
-        book2.authors.add(author);
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		book1.authors.add( author );
+		book2.authors.add( author );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Book.class, book1.id)
-                                        .invoke( b -> context.assertFalse( Hibernate.isInitialized(b.authors) ) )
-                                        .chain( b -> session.fetch(b.authors) )
-                                        .invoke( authors -> context.assertEquals( 1, authors.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Book.class, book1.id )
+										.invoke( b -> context.assertFalse( Hibernate.isInitialized( b.authors ) ) )
+										.chain( b -> session.fetch( b.authors ) )
+										.invoke( authors -> context.assertEquals( 1, authors.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="MTMSBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "MTMSBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
+		Book() {
+		}
 
-        @ManyToMany
-        Set<Author> authors = new HashSet<>();
-    }
+		@GeneratedValue
+		@Id
+		long id;
 
-    @Entity(name="Author")
-    @Table(name="MTMSAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@Basic(optional = false)
+		String title;
 
-        @Basic(optional = false)
-        String name;
+		@ManyToMany
+		Set<Author> authors = new HashSet<>();
+	}
 
-        @ManyToMany(mappedBy = "authors")
-        Set<Book> books = new HashSet<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "MTMSAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@ManyToMany(mappedBy = "authors")
+		Set<Book> books = new HashSet<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToManyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToManyTest.java
@@ -5,11 +5,9 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -17,153 +15,169 @@ import javax.persistence.Id;
 import javax.persistence.ManyToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
-import java.util.ArrayList;
-import java.util.List;
+
+import org.hibernate.Hibernate;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 public class ManyToManyTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(0) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book1.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book2.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add( books.remove(0) ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> a.books = null )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertTrue( books.isEmpty() ) )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 0 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book1.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book2.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( books.remove( 0 ) ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> a.books = null )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertTrue( books.isEmpty() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="MTMBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "MTMBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="MTMAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @ManyToMany @OrderBy("id")
-        List<Book> books = new ArrayList<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "MTMAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@ManyToMany
+		@OrderBy("id")
+		List<Book> books = new ArrayList<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToOneMergeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ManyToOneMergeTest.java
@@ -6,6 +6,8 @@
 package org.hibernate.reactive;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -14,9 +16,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -25,11 +25,8 @@ import io.vertx.ext.unit.TestContext;
 public class ManyToOneMergeTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( AcademicYearDetailsDBO.class );
-		configuration.addAnnotatedClass( CampusDBO.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( AcademicYearDetailsDBO.class, CampusDBO.class );
 	}
 
 	@Before
@@ -54,16 +51,6 @@ public class ManyToOneMergeTest extends BaseReactiveTest {
 								campusDBO, campusDBO2,
 								academicYearDetailsDBO
 						) )
-		);
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context,
-				getMutinySessionFactory()
-						.withTransaction( (session, transaction) ->
-								session.createQuery("delete from AcademicYearDetailsDBO").executeUpdate()
-										.chain( v -> session.createQuery("delete from CampusDBO").executeUpdate() ) )
 		);
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Column;
@@ -34,6 +35,11 @@ public class MultilineImportsTest extends BaseReactiveTest {
 	}
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Hero.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		// Testing the model from the Quarkus workshops (a smaller extract of):
@@ -41,7 +47,6 @@ public class MultilineImportsTest extends BaseReactiveTest {
 		configuration.setProperty( AvailableSettings.HBM2DDL_IMPORT_FILES, "/complexMultilineImports.sql" );
 		configuration.setProperty( Settings.HBM2DDL_AUTO, "create" );
 		configuration.setProperty( Settings.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR, "org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor" );
-		configuration.addAnnotatedClass( Hero.class );
 		return configuration;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultipleContextTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultipleContextTest.java
@@ -5,13 +5,14 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Locale;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
@@ -52,10 +53,8 @@ public class MultipleContextTest extends BaseReactiveTest {
 	public DatabaseSelectionRule rule = runOnlyFor( POSTGRESQL );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Competition.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Competition.class );
 	}
 
 	@After

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinyExceptionsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinyExceptionsTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -22,10 +24,14 @@ import io.vertx.ext.unit.TestContext;
 public class MutinyExceptionsTest extends BaseReactiveTest {
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Person.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		configuration.setProperty( AvailableSettings.NATIVE_EXCEPTION_HANDLING_51_COMPLIANCE, "false" );
-		configuration.addAnnotatedClass( Person.class );
 		return configuration;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySequenceGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySequenceGeneratorTest.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -14,15 +13,15 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.SequenceGenerator;
 import javax.persistence.Version;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 
 public class MutinySequenceGeneratorTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SequenceId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SequenceId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinySessionTest.java
@@ -5,6 +5,7 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -15,10 +16,8 @@ import javax.persistence.Table;
 import javax.persistence.metamodel.EntityType;
 
 import org.hibernate.LockMode;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.mutiny.Mutiny;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
@@ -28,23 +27,14 @@ import io.vertx.ext.unit.TestContext;
 public class MutinySessionTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( GuineaPig.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "GuineaPig" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( GuineaPig.class );
 	}
 
 	private Uni<Void> populateDB() {
 		return getMutinySessionFactory()
-				.withSession(
-						session -> session.persist( new GuineaPig(5, "Aloi") )
-								.chain(session::flush)
-				);
+				.withSession( session -> session.persist( new GuineaPig( 5, "Aloi" ) )
+						.chain( session::flush ) );
 	}
 
 	private Uni<String> selectNameFromId(Integer id) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NaturalIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NaturalIdTest.java
@@ -5,9 +5,13 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
+
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.annotations.NaturalId;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Entity;
@@ -19,48 +23,51 @@ import static org.hibernate.reactive.common.Identifier.id;
 
 public class NaturalIdTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass(Thing.class);
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Thing.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Thing thing1 = new Thing();
-        thing1.naturalKey = "abc123";
-        thing1.version = 1;
-        Thing thing2 = new Thing();
-        thing2.naturalKey = "abc123";
-        thing2.version = 2;
-        test( context,
-                getSessionFactory()
-                        .withSession( session -> session.persist(thing1, thing2).thenCompose( v -> session.flush() ) )
-                        .thenCompose( v -> getSessionFactory().withSession(
-                                session -> session.find( Thing.class, composite(
-                                        id("naturalKey", "abc123"),
-                                        id("version", 1)
-                                ) )
-                        ) )
-                        .thenAccept( t -> {
-                            context.assertNotNull(t);
-                            context.assertEquals(thing1.id, t.id);
-                        } )
-                        .thenCompose( v -> getSessionFactory().withSession(
-                                session -> session.find( Thing.class, composite(
-                                        id(Thing.class, "naturalKey", "abc123"),
-                                        id(Thing.class, "version", 3)
-                                ) )
-                        ) )
-                        .thenAccept(context::assertNull)
-        );
-    }
+	@Test
+	public void test(TestContext context) {
+		Thing thing1 = new Thing();
+		thing1.naturalKey = "abc123";
+		thing1.version = 1;
+		Thing thing2 = new Thing();
+		thing2.naturalKey = "abc123";
+		thing2.version = 2;
+		test(
+				context,
+				getSessionFactory()
+						.withSession( session -> session.persist( thing1, thing2 ).thenCompose( v -> session.flush() ) )
+						.thenCompose( v -> getSessionFactory().withSession(
+								session -> session.find( Thing.class, composite(
+										id( "naturalKey", "abc123" ),
+										id( "version", 1 )
+								) )
+						) )
+						.thenAccept( t -> {
+							context.assertNotNull( t );
+							context.assertEquals( thing1.id, t.id );
+						} )
+						.thenCompose( v -> getSessionFactory().withSession(
+								session -> session.find( Thing.class, composite(
+										id( Thing.class, "naturalKey", "abc123" ),
+										id( Thing.class, "version", 3 )
+								) )
+						) )
+						.thenAccept( context::assertNull )
+		);
+	}
 
-    @Entity
-    static class Thing {
-        @Id @GeneratedValue long id;
-        @NaturalId String naturalKey;
-        @NaturalId int version;
-    }
+	@Entity
+	static class Thing {
+		@Id
+		@GeneratedValue
+		long id;
+		@NaturalId
+		String naturalKey;
+		@NaturalId
+		int version;
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ORMReactivePersistenceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ORMReactivePersistenceTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -39,10 +41,8 @@ public class ORMReactivePersistenceTest extends BaseReactiveTest {
 	private SessionFactory ormFactory;
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Flour.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Flour.class );
 	}
 
 	@Before
@@ -61,8 +61,6 @@ public class ORMReactivePersistenceTest extends BaseReactiveTest {
 	@After
 	public void cleanDb(TestContext context) {
 		ormFactory.close();
-
-		test( context, deleteEntities( "Flour" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManyMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManyMapTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -16,81 +17,94 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class OneToManyMapTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.put("a", book1);
-        author.books.put("b", book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.put( "a", book1 );
+		author.books.put( "b", book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 2, books.size() );
-                                            context.assertEquals( book1.title, books.get("a").title );
-                                            context.assertEquals( book2.title, books.get("b").title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> {
-                                            context.assertEquals( 2, a.books.size() );
-                                            context.assertEquals( book1.title, a.books.get("a").title );
-                                            context.assertEquals( book2.title, a.books.get("b").title );
-                                        } )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 2, books.size() );
+											context.assertEquals( book1.title, books.get( "a" ).title );
+											context.assertEquals( book2.title, books.get( "b" ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> {
+															  context.assertEquals( 2, a.books.size() );
+															  context.assertEquals( book1.title, a.books.get( "a" ).title );
+															  context.assertEquals( book2.title, a.books.get( "b" ).title );
+														  } )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="OTMMBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "OTMMBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="OTMMAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @OneToMany
-        Map<String,Book> books = new HashMap<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "OTMMAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@OneToMany
+		Map<String, Book> books = new HashMap<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManySetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManySetTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -16,73 +17,86 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 public class OneToManySetTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="OTMSBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "OTMSBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="OTMSAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @OneToMany
-        Set<Book> books = new HashSet<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "OTMSAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@OneToMany
+		Set<Book> books = new HashSet<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToManyTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -18,165 +19,184 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderBy;
 import javax.persistence.Table;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class OneToManyTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResultOrNull()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select a from Author a left join fetch a.books where 1=0", Author.class )
-                                        .getSingleResultOrNull()
-                                        .invoke(context::assertNull)
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(0) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book1.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book2.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add( books.remove(0) ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> a.books = null )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertTrue( books.isEmpty() ) )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResultOrNull()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select a from Author a left join fetch a.books where 1=0",
+																  Author.class
+														  )
+														  .getSingleResultOrNull()
+														  .invoke( context::assertNull )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 0 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book1.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book2.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( books.remove( 0 ) ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> a.books = null )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertTrue( books.isEmpty() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="OTMBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "OTMBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="OTMAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @OneToMany @OrderBy("id")
-        List<Book> books = new ArrayList<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "OTMAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@OneToMany
+		@OrderBy("id")
+		List<Book> books = new ArrayList<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneIdClassParentEmbeddedIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneIdClassParentEmbeddedIdTest.java
@@ -5,16 +5,24 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
-import javax.persistence.*;
 import java.io.Serializable;
 import java.util.Objects;
+import javax.persistence.Embeddable;
+import javax.persistence.EmbeddedId;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.OneToOne;
+
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 public class OneToOneIdClassParentEmbeddedIdTest extends BaseReactiveTest {
+
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
@@ -41,7 +49,7 @@ public class OneToOneIdClassParentEmbeddedIdTest extends BaseReactiveTest {
 									context.assertNotNull( optionalAnEntity );
 									context.assertEquals( anEntity, optionalAnEntity );
 									context.assertEquals( otherEntity, optionalAnEntity.otherEntity );
-								})
+								} )
 						)
 		);
 	}
@@ -64,16 +72,20 @@ public class OneToOneIdClassParentEmbeddedIdTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
 			AnEntity anEntity = (AnEntity) o;
-			return otherEntity.equals(anEntity.otherEntity) &&
-					Objects.equals(name, anEntity.name);
+			return otherEntity.equals( anEntity.otherEntity ) &&
+					Objects.equals( name, anEntity.name );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(otherEntity, name);
+			return Objects.hash( otherEntity, name );
 		}
 	}
 
@@ -90,15 +102,19 @@ public class OneToOneIdClassParentEmbeddedIdTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
 			OtherEntityId that = (OtherEntityId) o;
 			return id == that.id;
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(id);
+			return Objects.hash( id );
 		}
 	}
 
@@ -119,16 +135,20 @@ public class OneToOneIdClassParentEmbeddedIdTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
 			OtherEntity that = (OtherEntity) o;
-			return id.equals(that.id) &&
-					Objects.equals(name, that.name);
+			return id.equals( that.id ) &&
+					Objects.equals( name, that.name );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(id, name);
+			return Objects.hash( id, name );
 		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneIdClassParentIdClassTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneIdClassParentIdClassTest.java
@@ -5,19 +5,22 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.io.Serializable;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.OneToOne;
-import java.io.Serializable;
-import java.util.Objects;
+
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 public class OneToOneIdClassParentIdClassTest extends BaseReactiveTest {
+
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
@@ -44,7 +47,7 @@ public class OneToOneIdClassParentIdClassTest extends BaseReactiveTest {
 									context.assertNotNull( optionalAnEntity );
 									context.assertEquals( anEntity, optionalAnEntity );
 									context.assertEquals( otherEntity, optionalAnEntity.otherEntity );
-								})
+								} )
 						)
 		);
 	}
@@ -67,16 +70,20 @@ public class OneToOneIdClassParentIdClassTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
 			AnEntity anEntity = (AnEntity) o;
-			return otherEntity.equals(anEntity.otherEntity) &&
-					Objects.equals(name, anEntity.name);
+			return otherEntity.equals( anEntity.otherEntity ) &&
+					Objects.equals( name, anEntity.name );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(otherEntity, name);
+			return Objects.hash( otherEntity, name );
 		}
 	}
 
@@ -109,16 +116,20 @@ public class OneToOneIdClassParentIdClassTest extends BaseReactiveTest {
 
 		@Override
 		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
 			OtherEntity that = (OtherEntity) o;
 			return id == that.id &&
-					Objects.equals(name, that.name);
+					Objects.equals( name, that.name );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(id, name);
+			return Objects.hash( id, name );
 		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneLazyOrphanRemovalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneLazyOrphanRemovalTest.java
@@ -5,26 +5,23 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.cfg.Configuration;
-
-import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
 
 public class OneToOneLazyOrphanRemovalTest extends BaseReactiveTest {
+
+
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Car.class );
-		configuration.addAnnotatedClass( PaintColor.class );
-		configuration.addAnnotatedClass( Engine.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Car.class, PaintColor.class, Engine.class );
 	}
 
 	@Before
@@ -34,11 +31,6 @@ public class OneToOneLazyOrphanRemovalTest extends BaseReactiveTest {
 		final Car car = new Car( 1, engine, color );
 		test( context, getSessionFactory()
 				.withTransaction( (session, tx) -> session.persist( color, engine, car ) ) );
-	}
-
-	@After
-	public void deleteAll(TestContext context) {
-		test( context, deleteEntities( "Car", "PaintColor", "Engine" ) );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneNoIdClassTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOneNoIdClassTest.java
@@ -5,18 +5,21 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.io.Serializable;
+import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
-import java.io.Serializable;
-import java.util.Objects;
+
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 public class OneToOneNoIdClassTest extends BaseReactiveTest {
+
 	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOnePrimaryKeyJoinColumnTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OneToOnePrimaryKeyJoinColumnTest.java
@@ -5,15 +5,15 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 import javax.persistence.PrimaryKeyJoinColumn;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -21,16 +21,8 @@ import io.vertx.ext.unit.TestContext;
 public class OneToOnePrimaryKeyJoinColumnTest  extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Person.class );
-		configuration.addAnnotatedClass( PersonDetails.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "PersonDetails", "Person" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( PersonDetails.class, Person.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OptimisticLockingTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OptimisticLockingTest.java
@@ -5,11 +5,13 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
+
 import io.vertx.ext.unit.TestContext;
 
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.OptimisticLocking;
-import org.hibernate.cfg.Configuration;
 
 import org.junit.Test;
 
@@ -23,11 +25,8 @@ import static org.hibernate.annotations.OptimisticLockType.DIRTY;
 public class OptimisticLockingTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Mergeable1.class );
-		configuration.addAnnotatedClass( Mergeable2.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Mergeable1.class, Mergeable2.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedEmbeddableCollectionTest.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import javax.persistence.Basic;
@@ -19,10 +20,8 @@ import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -33,222 +32,233 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2
 
 public class OrderedEmbeddableCollectionTest extends BaseReactiveTest {
 
-    @Rule // This exposes a strange bug in the DB2 client
-    public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
+	@Rule // This exposes a strange bug in the DB2 client
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Author.class );
+	}
 
-    @After
-    public void cleanDb(TestContext context) {
-        test( context, deleteEntities( "Author" ) );
-    }
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 0 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( book1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( book1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( books.remove( 0 ) ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> a.books = null )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertTrue( books.isEmpty() ) )
+								)
+						)
+		);
+	}
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(0) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add(book1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add(book1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add( books.remove(0) ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> a.books = null )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertTrue( books.isEmpty() ) )
-                                )
-                        )
-        );
-    }
+	@Test
+	public void testMultipleRemovesFromCollection(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Book book3 = new Book( "Third Book" );
+		Book book4 = new Book( "Fourth Book" );
+		Book book5 = new Book( "Fifth Book" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
+		author.books.add( book3 );
+		author.books.add( book4 );
+		author.books.add( book5 );
 
-    @Test
-    public void testMultipleRemovesFromCollection(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Book book3 = new Book( "Third Book");
-        Book book4 = new Book( "Fourth Book");
-        Book book5 = new Book( "Fifth Book");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
-        author.books.add(book3);
-        author.books.add(book4);
-        author.books.add(book5);
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 5, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 5, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											books.remove( 1 ); // Remove book2
+											books.remove( 1 ); // Now, remove book3
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 3, books.size() );
+											context.assertEquals( book4.title, books.get( 1 ).title );
+											Assertions.assertThat( books ).containsExactly( book1, book4, book5 );
+										} )
+								)
+						)
+		);
+	}
 
-        test(context,
-             getMutinySessionFactory()
-                     .withTransaction( (session, transaction) -> session.persistAll(author) )
-                     .chain( () -> getMutinySessionFactory()
-                             .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                     .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                     .chain( a -> session.fetch(a.books) )
-                                     .invoke( books -> context.assertEquals( 5, books.size() ) )
-                             )
-                     )
-                     .chain( () -> getMutinySessionFactory()
-                             .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                     .getSingleResult()
-                                     .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                     .invoke( a -> context.assertEquals( 5, a.books.size() ) )
-                             )
-                     )
-                     .chain( () -> getMutinySessionFactory()
-                             .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                     .chain( a -> session.fetch(a.books) )
-                                     .invoke( books -> {
-                                         books.remove( 1 ); // Remove book2
-                                         books.remove( 1 ); // Now, remove book3
-                                     } )
-                             )
-                     )
-                     .chain( () -> getMutinySessionFactory()
-                             .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                     .chain( a -> session.fetch(a.books) )
-                                     .invoke( books -> {
-                                         context.assertEquals( 3, books.size() );
-                                         context.assertEquals( book4.title, books.get(1).title );
-                                         Assertions.assertThat( books ).containsExactly( book1, book4, book5 );
-                                     } )
-                             )
-                     )
-        );
-    }
+	@Embeddable
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-    @Embeddable
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @Basic(optional = false)
-        String title;
-        @Override
-        public boolean equals(Object o) {
-            if ( this == o ) {
-                return true;
-            }
-            if ( o == null || getClass() != o.getClass() ) {
-                return false;
-            }
-            Book book = (Book) o;
-            return Objects.equals( title, book.title );
-        }
-        @Override
-        public int hashCode() {
-            return Objects.hash( title );
-        }
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="ECAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@Basic(optional = false)
+		String title;
 
-        @Basic(optional = false)
-        String name;
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Book book = (Book) o;
+			return Objects.equals( title, book.title );
+		}
 
-        @ElementCollection
-        @CollectionTable(name="ECBook")
-        @OrderColumn(name="list_index")
-        List<Book> books = new ArrayList<>();
-    }
+		@Override
+		public int hashCode() {
+			return Objects.hash( title );
+		}
+	}
+
+	@Entity(name = "Author")
+	@Table(name = "ECAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@ElementCollection
+		@CollectionTable(name = "ECBook")
+		@OrderColumn(name = "list_index")
+		List<Book> books = new ArrayList<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedManyToManyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedManyToManyTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -18,153 +19,165 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class OrderedManyToManyTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(0) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.add( books.remove(0) ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> a.books = null )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertTrue( books.isEmpty() ) )
-                                )
-                        )
-        );
-    }
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 0 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.add( books.remove( 0 ) ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> a.books = null )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertTrue( books.isEmpty() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="IMTMBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "IMTMBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="IMTMAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @ManyToMany
-        @OrderColumn(name="list_index")
-        List<Book> books = new ArrayList<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "IMTMAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@ManyToMany
+		@OrderColumn(name = "list_index")
+		List<Book> books = new ArrayList<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedOneToManyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrderedOneToManyTest.java
@@ -6,8 +6,9 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
+
 import org.hibernate.Hibernate;
-import org.hibernate.cfg.Configuration;
+
 import org.junit.Test;
 
 import javax.persistence.Basic;
@@ -18,100 +19,102 @@ import javax.persistence.OneToMany;
 import javax.persistence.OrderColumn;
 import javax.persistence.Table;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 public class OrderedOneToManyTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Book.class );
-        configuration.addAnnotatedClass( Author.class );
-        return configuration;
-    }
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
+	}
 
-    @Test
-    public void test(TestContext context) {
-        Book book1 = new Book("Feersum Endjinn");
-        Book book2 = new Book("Use of Weapons");
-        Author author = new Author("Iain M Banks");
-        author.books.add(book1);
-        author.books.add(book2);
+	@Test
+	public void test(TestContext context) {
+		Book book1 = new Book( "Feersum Endjinn" );
+		Book book2 = new Book( "Use of Weapons" );
+		Author author = new Author( "Iain M Banks" );
+		author.books.add( book1 );
+		author.books.add( book2 );
 
-        test(context,
-                getMutinySessionFactory()
-                        .withTransaction( (session, transaction) -> session.persistAll(book1, book2, author) )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.createQuery("select distinct a from Author a left join fetch a.books", Author.class )
-                                        .getSingleResult()
-                                        .invoke( a -> context.assertTrue( Hibernate.isInitialized(a.books) ) )
-                                        .invoke( a -> context.assertEquals( 2, a.books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(0) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> books.remove(1) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> {
-                                            context.assertEquals( 1, books.size() );
-                                            context.assertEquals( book2.title, books.get(0).title );
-                                        } )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .chain( books -> session.find(Book.class, book1.id).invoke(books::add) )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> context.assertFalse( Hibernate.isInitialized(a.books) ) )
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
-                                )
-                        )
-                        //TODO: this is broken, but I suspect it is broken in core also!
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( (session, transaction) -> session.persistAll( book1, book2, author ) )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.createQuery(
+																  "select distinct a from Author a left join fetch a.books",
+																  Author.class
+														  )
+														  .getSingleResult()
+														  .invoke( a -> context.assertTrue( Hibernate.isInitialized( a.books ) ) )
+														  .invoke( a -> context.assertEquals( 2, a.books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 0 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> books.remove( 1 ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> {
+											context.assertEquals( 1, books.size() );
+											context.assertEquals( book2.title, books.get( 0 ).title );
+										} )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.chain( books -> session.find( Book.class, book1.id ).invoke( books::add ) )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> context.assertFalse( Hibernate.isInitialized( a.books ) ) )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertEquals( 2, books.size() ) )
+								)
+						)
+						//TODO: this is broken, but I suspect it is broken in core also!
 //                        .chain( () -> getMutinySessionFactory()
 //                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
 //                                        .chain( a -> session.fetch(a.books) )
@@ -125,46 +128,57 @@ public class OrderedOneToManyTest extends BaseReactiveTest {
 //                                        .invoke( books -> context.assertEquals( 2, books.size() ) )
 //                                )
 //                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .invoke( a -> a.books = null )
-                                )
-                        )
-                        .chain( () -> getMutinySessionFactory()
-                                .withTransaction( (session, transaction) -> session.find(Author.class, author.id)
-                                        .chain( a -> session.fetch(a.books) )
-                                        .invoke( books -> context.assertTrue( books.isEmpty() ) )
-                                )
-                        )
-        );
-    }
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.invoke( a -> a.books = null )
+								)
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( (session, transaction) -> session.find( Author.class, author.id )
+										.chain( a -> session.fetch( a.books ) )
+										.invoke( books -> context.assertTrue( books.isEmpty() ) )
+								)
+						)
+		);
+	}
 
-    @Entity(name="Book")
-    @Table(name="OTMBook")
-    static class Book {
-        Book(String title) {
-            this.title = title;
-        }
-        Book() {}
-        @GeneratedValue @Id long id;
+	@Entity(name = "Book")
+	@Table(name = "OTMBook")
+	static class Book {
+		Book(String title) {
+			this.title = title;
+		}
 
-        @Basic(optional = false)
-        String title;
-    }
+		Book() {
+		}
 
-    @Entity(name="Author")
-    @Table(name="OTMAuthor")
-    static class Author {
-        Author(String name) {
-            this.name = name;
-        }
-        public Author() {}
-        @GeneratedValue @Id long id;
+		@GeneratedValue
+		@Id
+		long id;
 
-        @Basic(optional = false)
-        String name;
+		@Basic(optional = false)
+		String title;
+	}
 
-        @OneToMany @OrderColumn(name="list_index")
-        List<Book> books = new ArrayList<>();
-    }
+	@Entity(name = "Author")
+	@Table(name = "OTMAuthor")
+	static class Author {
+		Author(String name) {
+			this.name = name;
+		}
+
+		public Author() {
+		}
+
+		@GeneratedValue
+		@Id
+		long id;
+
+		@Basic(optional = false)
+		String name;
+
+		@OneToMany
+		@OrderColumn(name = "list_index")
+		List<Book> books = new ArrayList<>();
+	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrphanRemovalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/OrphanRemovalTest.java
@@ -5,17 +5,19 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.util.HashSet;
+import java.util.Set;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
-import java.util.HashSet;
-import java.util.Set;
+
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 import static javax.persistence.CascadeType.PERSIST;
 import static javax.persistence.CascadeType.REMOVE;
@@ -24,123 +26,137 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class OrphanRemovalTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Version.class );
-        configuration.addAnnotatedClass( Product.class );
-        configuration.addAnnotatedClass( Shop.class );
-        return configuration;
-    }
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Version.class );
+		configuration.addAnnotatedClass( Product.class );
+		configuration.addAnnotatedClass( Shop.class );
+		return configuration;
+	}
 
-    @Test
-    public void testOrphan(TestContext context) {
-        Shop shop = new Shop("shop");
-        Product product = new Product("ap1", shop);
-        product.addVersion(new Version(product));
-        shop.addProduct(product);
-        shop.addProduct(new Product("ap2", shop));
-        shop.addProduct(new Product("ap3", shop));
-        shop.addProduct(new Product("ap4", shop));
+	@Test
+	public void testOrphan(TestContext context) {
+		Shop shop = new Shop( "shop" );
+		Product product = new Product( "ap1", shop );
+		product.addVersion( new Version( product ) );
+		shop.addProduct( product );
+		shop.addProduct( new Product( "ap2", shop ) );
+		shop.addProduct( new Product( "ap3", shop ) );
+		shop.addProduct( new Product( "ap4", shop ) );
 
-        test(context,
-                getSessionFactory()
-                        .withTransaction((session, transaction) -> session.persist(shop))
-                        .thenCompose(v -> getSessionFactory().withTransaction((session, transaction) -> session.find(Shop.class, shop.id)
-                                .thenCompose( result -> session.fetch(result.products).thenApply(products -> result) )
-                                .thenAccept(result -> {
-                                    // update
-                                    result.products.clear();
-                                    result.addProduct(new Product("bp5", result));
-                                    result.addProduct(new Product("bp6", result));
-                                    result.addProduct(new Product("bp7", result));
-                                })
-                        ))
-                        .thenCompose(v -> getSessionFactory().withTransaction((session, transaction) ->
-                                session.createQuery("select count(*) from Product", Long.class)
-                                        .getSingleResult().thenAccept( result -> context.assertEquals( 3L, result ) )
-                        ))
-                        .thenCompose(v -> getSessionFactory().withTransaction((session, transaction) ->
-                                session.createQuery("select name from Product" )
-                                        .getResultList().thenAccept(list -> assertThat( list ).containsExactlyInAnyOrder( "bp5", "bp6", "bp7"))
-                        ))
-        );
-    }
+		test(
+				context,
+				getSessionFactory()
+						.withTransaction( session -> session.persist( shop ) )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( session -> session.find( Shop.class, shop.id )
+								.thenCompose( result -> session.fetch( result.products )
+										.thenApply( products -> result ) )
+										.thenAccept( result -> {
+											// update
+											result.products.clear();
+											result.addProduct( new Product( "bp5", result ) );
+											result.addProduct( new Product( "bp6", result ) );
+											result.addProduct( new Product( "bp7", result ) );
+										} )
+						) )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( session -> session
+										.createQuery( "select count(*) from Product", Long.class )
+										.getSingleResult()
+										.thenAccept( result -> context.assertEquals( 3L, result ) )
+						) )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( session -> session
+										.createQuery( "select name from Product" )
+										.getResultList()
+										.thenAccept( list -> assertThat( list )
+												.containsExactlyInAnyOrder( "bp5", "bp6", "bp7" ) )
+						) )
+		);
+	}
 
-    @Entity(name = "ProductVersion")
-    public static class Version {
-        @Id @GeneratedValue
-        private long id;
+	@Entity(name = "ProductVersion")
+	public static class Version {
+		@Id
+		@GeneratedValue
+		private long id;
 
-        @ManyToOne
-        private Product product;
+		@ManyToOne
+		private Product product;
 
-        public Version(Product product) {
-            this.product = product;
-        }
+		public Version(Product product) {
+			this.product = product;
+		}
 
-        Version() {}
+		Version() {
+		}
 
-        @Override
-        public String toString() {
-            return Version.class.getSimpleName() + ":" + id + ":" + product;
-        }
-    }
+		@Override
+		public String toString() {
+			return Version.class.getSimpleName() + ":" + id + ":" + product;
+		}
+	}
 
-    @Entity(name = "Product")
-    public static class Product {
+	@Entity(name = "Product")
+	public static class Product {
 
-        @Id @GeneratedValue
-        private long id;
-        private String name;
+		@Id
+		@GeneratedValue
+		private long id;
+		private String name;
 
-        Product(String name, Shop shop) {
-            this.name = name;
-            this.shop = shop;
-        }
+		Product(String name, Shop shop) {
+			this.name = name;
+			this.shop = shop;
+		}
 
-        Product() {}
+		Product() {
+		}
 
-        @ManyToOne
-        private Shop shop;
+		@ManyToOne
+		private Shop shop;
 
-        @OneToMany(mappedBy = "product", cascade = {PERSIST, REMOVE})
-        private Set<Version> versions = new HashSet<>();
+		@OneToMany(mappedBy = "product", cascade = { PERSIST, REMOVE })
+		private Set<Version> versions = new HashSet<>();
 
-        public void addVersion(Version version) {
-            versions.add(version);
-        }
+		public void addVersion(Version version) {
+			versions.add( version );
+		}
 
-        @Override
-        public String toString() {
-            return Product.class.getSimpleName() + ":" + id + ":" + name + ":" + shop;
-        }
-    }
+		@Override
+		public String toString() {
+			return Product.class.getSimpleName() + ":" + id + ":" + name + ":" + shop;
+		}
+	}
 
-    @Entity(name = "Shop")
-    public static class Shop {
+	@Entity(name = "Shop")
+	public static class Shop {
 
-        @Id @GeneratedValue
-        private long id;
-        private String name;
+		@Id
+		@GeneratedValue
+		private long id;
+		private String name;
 
-        Shop(String name) {
-            this.name = name;
-        }
+		Shop(String name) {
+			this.name = name;
+		}
 
-        Shop() {}
+		Shop() {
+		}
 
-        @OneToMany(mappedBy = "shop", cascade = {PERSIST, REMOVE}, orphanRemoval = true)
-        private Set<Product> products = new HashSet<>();
+		@OneToMany(mappedBy = "shop", cascade = { PERSIST, REMOVE }, orphanRemoval = true)
+		private Set<Product> products = new HashSet<>();
 
-        public void addProduct(Product product) {
-            products.add(product);
-        }
+		public void addProduct(Product product) {
+			products.add( product );
+		}
 
-        @Override
-        public String toString() {
-            return Shop.class.getSimpleName() + ":" + id + ":" + name;
-        }
-    }
+		@Override
+		public String toString() {
+			return Shop.class.getSimpleName() + ":" + id + ":" + name;
+		}
+	}
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import javax.persistence.ColumnResult;
 import javax.persistence.Entity;
@@ -30,9 +31,6 @@ import javax.persistence.criteria.Join;
 import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Root;
 
-import org.hibernate.cfg.Configuration;
-
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -44,16 +42,8 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 public class QueryTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass(Author.class);
-		configuration.addAnnotatedClass(Book.class);
-		return configuration;
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, deleteEntities( "Book", "Author" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -815,6 +815,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 							context.assertTrue( session.currentTransaction().isMarkedForRollback() );
 							context.assertTrue( transaction.isMarkedForRollback() );
 							return session.withTransaction( t -> {
+								context.assertEquals( t, transaction );
 								context.assertTrue( t.isMarkedForRollback() );
 								return session.createQuery( "from GuineaPig" ).getResultList();
 							} );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive;
 
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import javax.persistence.Entity;
@@ -17,11 +18,9 @@ import javax.persistence.Version;
 import javax.persistence.metamodel.EntityType;
 
 import org.hibernate.LockMode;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.common.AffectedEntities;
 import org.hibernate.reactive.stage.Stage;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -29,25 +28,18 @@ import io.vertx.ext.unit.TestContext;
 public class ReactiveSessionTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( GuineaPig.class );
-		return configuration;
+	protected Set<Class<?>> annotatedEntities() {
+		return Set.of( GuineaPig.class );
 	}
 
 	private CompletionStage<Void> populateDB() {
 		return getSessionFactory()
-				.withTransaction( (s, tx) -> s.persist( new GuineaPig( 5, "Aloi" ) ) );
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, deleteEntities( "GuineaPig" ) );
+				.withTransaction( s -> s.persist( new GuineaPig( 5, "Aloi" ) ) );
 	}
 
 	private CompletionStage<String> selectNameFromId(Integer id) {
 		return getSessionFactory().withSession(
-				session -> session.createQuery("SELECT name FROM GuineaPig WHERE id = " + id )
+				session -> session.createQuery( "SELECT name FROM GuineaPig WHERE id = " + id )
 						.getResultList()
 						.thenApply( ReactiveSessionTest::nameFromResult )
 		);
@@ -114,8 +106,8 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				openSession().thenCompose( session -> session
 						.persist( guineaPig )
 						.thenCompose( v -> session.flush() )
-						.thenAccept( v -> session.detach(guineaPig) )
-						.thenAccept( v -> context.assertFalse( session.contains(guineaPig) ) )
+						.thenAccept( v -> session.detach( guineaPig ) )
+						.thenAccept( v -> context.assertFalse( session.contains( guineaPig ) ) )
 						.thenCompose( v -> session.find( GuineaPig.class, guineaPig.getId() ) )
 						.thenAccept( actualPig -> {
 							assertThatPigsAreEqual( context, guineaPig, actualPig );
@@ -156,7 +148,10 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 								.thenCompose( pig -> session.refresh( pig, LockMode.PESSIMISTIC_WRITE )
 										.thenAccept( vv -> {
 											assertThatPigsAreEqual( context, expectedPig, pig );
-											context.assertEquals(session.getLockMode( pig ), LockMode.PESSIMISTIC_WRITE );
+											context.assertEquals(
+													session.getLockMode( pig ),
+													LockMode.PESSIMISTIC_WRITE
+											);
 										} )
 								)
 						) )
@@ -172,26 +167,26 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() )
 								.thenCompose( pig -> {
-									session.setReadOnly(pig, true);
-									pig.setName("XXXX");
+									session.setReadOnly( pig, true );
+									pig.setName( "XXXX" );
 									return session.flush()
-											.thenCompose( v -> session.refresh(pig) )
+											.thenCompose( v -> session.refresh( pig ) )
 											.thenAccept( v -> {
-												context.assertEquals(expectedPig.name, pig.name);
-												context.assertEquals(true, session.isReadOnly(pig));
+												context.assertEquals( expectedPig.name, pig.name );
+												context.assertEquals( true, session.isReadOnly( pig ) );
 											} );
 								} )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() )
 								.thenCompose( pig -> {
-									session.setReadOnly(pig, false);
-									pig.setName("XXXX");
+									session.setReadOnly( pig, false );
+									pig.setName( "XXXX" );
 									return session.flush()
-											.thenCompose( v -> session.refresh(pig) )
+											.thenCompose( v -> session.refresh( pig ) )
 											.thenAccept( v -> {
-												context.assertEquals("XXXX", pig.name);
-												context.assertEquals(false, session.isReadOnly(pig));
+												context.assertEquals( "XXXX", pig.name );
+												context.assertEquals( false, session.isReadOnly( pig ) );
 											} );
 								} )
 						)
@@ -209,7 +204,10 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 										.lock( pig, LockMode.PESSIMISTIC_READ )
 										.thenAccept( v -> {
 											assertThatPigsAreEqual( context, expectedPig, pig );
-											context.assertEquals( session.getLockMode( pig ), LockMode.PESSIMISTIC_READ );
+											context.assertEquals(
+													session.getLockMode( pig ),
+													LockMode.PESSIMISTIC_READ
+											);
 										} )
 								)
 						)
@@ -243,25 +241,35 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				populateDB()
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() )
-								.thenCompose( pig -> session.lock(pig, LockMode.PESSIMISTIC_FORCE_INCREMENT).thenApply( v -> pig ) )
+								.thenCompose( pig -> session.lock( pig, LockMode.PESSIMISTIC_FORCE_INCREMENT )
+										.thenApply( v -> pig ) )
 								.thenAccept( actualPig -> {
 									assertThatPigsAreEqual( context, expectedPig, actualPig );
-									context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_FORCE_INCREMENT );
+									context.assertEquals(
+											session.getLockMode( actualPig ),
+											LockMode.PESSIMISTIC_FORCE_INCREMENT
+									);
 									context.assertEquals( actualPig.version, 1 );
 								} )
-								.thenCompose( v -> session.createQuery("select version from GuineaPig").getSingleResult() )
-								.thenAccept( version -> context.assertEquals(1, version) )
+								.thenCompose( v -> session.createQuery( "select version from GuineaPig" )
+										.getSingleResult() )
+								.thenAccept( version -> context.assertEquals( 1, version ) )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() )
-								.thenCompose( pig -> session.lock(pig, LockMode.PESSIMISTIC_FORCE_INCREMENT).thenApply( v -> pig ) )
+								.thenCompose( pig -> session.lock( pig, LockMode.PESSIMISTIC_FORCE_INCREMENT )
+										.thenApply( v -> pig ) )
 								.thenAccept( actualPig -> {
 									assertThatPigsAreEqual( context, expectedPig, actualPig );
-									context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_FORCE_INCREMENT );
+									context.assertEquals(
+											session.getLockMode( actualPig ),
+											LockMode.PESSIMISTIC_FORCE_INCREMENT
+									);
 									context.assertEquals( actualPig.version, 2 );
 								} )
-								.thenCompose( v -> session.createQuery("select version from GuineaPig").getSingleResult() )
-								.thenAccept( version -> context.assertEquals(2, version) )
+								.thenCompose( v -> session.createQuery( "select version from GuineaPig" )
+										.getSingleResult() )
+								.thenAccept( version -> context.assertEquals( 2, version ) )
 						)
 		);
 	}
@@ -273,13 +281,20 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId(), LockMode.PESSIMISTIC_FORCE_INCREMENT )
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.FORCE ); //grrr, lame
-											context.assertEquals( 1, actualPig.version );
-										} )
-								)
+											  (session, transaction) -> session.find(
+															  GuineaPig.class,
+															  expectedPig.getId(),
+															  LockMode.PESSIMISTIC_FORCE_INCREMENT
+													  )
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.FORCE
+														  ); //grrr, lame
+														  context.assertEquals( 1, actualPig.version );
+													  } )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -294,13 +309,20 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId(), LockMode.OPTIMISTIC_FORCE_INCREMENT )
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.OPTIMISTIC_FORCE_INCREMENT );
-											context.assertEquals( 0, actualPig.version );
-										} )
-								)
+											  (session, transaction) -> session.find(
+															  GuineaPig.class,
+															  expectedPig.getId(),
+															  LockMode.OPTIMISTIC_FORCE_INCREMENT
+													  )
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.OPTIMISTIC_FORCE_INCREMENT
+														  );
+														  context.assertEquals( 0, actualPig.version );
+													  } )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -315,15 +337,21 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
-										.thenCompose( actualPig -> session.lock( actualPig, LockMode.OPTIMISTIC_FORCE_INCREMENT )
-												.thenAccept( vv -> {
-													assertThatPigsAreEqual( context, expectedPig, actualPig );
-													context.assertEquals( session.getLockMode( actualPig ), LockMode.OPTIMISTIC_FORCE_INCREMENT );
-													context.assertEquals( 0, actualPig.version );
-												} )
-										)
-								)
+											  (session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
+													  .thenCompose( actualPig -> session.lock(
+																					actualPig,
+																					LockMode.OPTIMISTIC_FORCE_INCREMENT
+																			)
+																			.thenAccept( vv -> {
+																				assertThatPigsAreEqual( context, expectedPig, actualPig );
+																				context.assertEquals(
+																						session.getLockMode( actualPig ),
+																						LockMode.OPTIMISTIC_FORCE_INCREMENT
+																				);
+																				context.assertEquals( 0, actualPig.version );
+																			} )
+													  )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -338,15 +366,21 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
-										.thenCompose( actualPig -> session.lock( actualPig, LockMode.PESSIMISTIC_FORCE_INCREMENT )
-												.thenAccept( vv -> {
-													assertThatPigsAreEqual( context, expectedPig, actualPig );
-													context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_FORCE_INCREMENT );
-													context.assertEquals( 1, actualPig.version );
-												} )
-										)
-								)
+											  (session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
+													  .thenCompose( actualPig -> session.lock(
+																					actualPig,
+																					LockMode.PESSIMISTIC_FORCE_INCREMENT
+																			)
+																			.thenAccept( vv -> {
+																				assertThatPigsAreEqual( context, expectedPig, actualPig );
+																				context.assertEquals(
+																						session.getLockMode( actualPig ),
+																						LockMode.PESSIMISTIC_FORCE_INCREMENT
+																				);
+																				context.assertEquals( 1, actualPig.version );
+																			} )
+													  )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -361,13 +395,20 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId(), LockMode.OPTIMISTIC )
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.OPTIMISTIC );
-											context.assertEquals( 0, actualPig.version );
-										} )
-								)
+											  (session, transaction) -> session.find(
+															  GuineaPig.class,
+															  expectedPig.getId(),
+															  LockMode.OPTIMISTIC
+													  )
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.OPTIMISTIC
+														  );
+														  context.assertEquals( 0, actualPig.version );
+													  } )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -382,15 +423,18 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
-										.thenCompose( actualPig -> session.lock( actualPig, LockMode.OPTIMISTIC )
-											.thenAccept( vv -> {
-												assertThatPigsAreEqual( context, expectedPig, actualPig );
-												context.assertEquals( session.getLockMode( actualPig ), LockMode.OPTIMISTIC );
-												context.assertEquals( 0, actualPig.version );
-											} )
-										)
-								)
+											  (session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
+													  .thenCompose( actualPig -> session.lock( actualPig, LockMode.OPTIMISTIC )
+															  .thenAccept( vv -> {
+																  assertThatPigsAreEqual( context, expectedPig, actualPig );
+																  context.assertEquals(
+																		  session.getLockMode( actualPig ),
+																		  LockMode.OPTIMISTIC
+																  );
+																  context.assertEquals( 0, actualPig.version );
+															  } )
+													  )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -405,14 +449,21 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								// does a select ... for share
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId(), LockMode.PESSIMISTIC_READ )
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_READ );
-											context.assertEquals( 0, actualPig.version );
-										} )
-								)
+											  // does a select ... for share
+											  (session, transaction) -> session.find(
+															  GuineaPig.class,
+															  expectedPig.getId(),
+															  LockMode.PESSIMISTIC_READ
+													  )
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.PESSIMISTIC_READ
+														  );
+														  context.assertEquals( 0, actualPig.version );
+													  } )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -427,16 +478,19 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								// does a select ... for share
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
-										.thenCompose( actualPig -> session.lock( actualPig, LockMode.PESSIMISTIC_READ )
-												.thenAccept( vv -> {
-													assertThatPigsAreEqual( context, expectedPig, actualPig );
-													context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_READ );
-													context.assertEquals( 0, actualPig.version );
-												} )
-										)
-								)
+											  // does a select ... for share
+											  (session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
+													  .thenCompose( actualPig -> session.lock( actualPig, LockMode.PESSIMISTIC_READ )
+															  .thenAccept( vv -> {
+																  assertThatPigsAreEqual( context, expectedPig, actualPig );
+																  context.assertEquals(
+																		  session.getLockMode( actualPig ),
+																		  LockMode.PESSIMISTIC_READ
+																  );
+																  context.assertEquals( 0, actualPig.version );
+															  } )
+													  )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -451,14 +505,21 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								// does a select ... for update
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId(), LockMode.PESSIMISTIC_WRITE )
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_WRITE );
-											context.assertEquals( 0, actualPig.version );
-										} )
-								)
+											  // does a select ... for update
+											  (session, transaction) -> session.find(
+															  GuineaPig.class,
+															  expectedPig.getId(),
+															  LockMode.PESSIMISTIC_WRITE
+													  )
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.PESSIMISTIC_WRITE
+														  );
+														  context.assertEquals( 0, actualPig.version );
+													  } )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -473,16 +534,19 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								// does a select ... for update
-								(session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
-										.thenCompose( actualPig -> session.lock( actualPig, LockMode.PESSIMISTIC_WRITE )
-												.thenAccept( vv -> {
-													assertThatPigsAreEqual( context, expectedPig, actualPig );
-													context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_WRITE );
-													context.assertEquals( 0, actualPig.version );
-												} )
-										)
-								)
+											  // does a select ... for update
+											  (session, transaction) -> session.find( GuineaPig.class, expectedPig.getId() )
+													  .thenCompose( actualPig -> session.lock( actualPig, LockMode.PESSIMISTIC_WRITE )
+															  .thenAccept( vv -> {
+																  assertThatPigsAreEqual( context, expectedPig, actualPig );
+																  context.assertEquals(
+																		  session.getLockMode( actualPig ),
+																		  LockMode.PESSIMISTIC_WRITE
+																  );
+																  context.assertEquals( 0, actualPig.version );
+															  } )
+													  )
+									  )
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session.find( GuineaPig.class, expectedPig.getId() ) )
@@ -497,14 +561,17 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				context,
 				populateDB()
 						.thenCompose( v -> getSessionFactory().withTransaction(
-								(session, tx) -> session.createQuery( "from GuineaPig pig", GuineaPig.class)
-										.setLockMode(LockMode.PESSIMISTIC_WRITE)
-										.getSingleResult()
-										.thenAccept( actualPig -> {
-											assertThatPigsAreEqual( context, expectedPig, actualPig );
-											context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_WRITE );
-										} )
-								)
+											  (session, tx) -> session.createQuery( "from GuineaPig pig", GuineaPig.class )
+													  .setLockMode( LockMode.PESSIMISTIC_WRITE )
+													  .getSingleResult()
+													  .thenAccept( actualPig -> {
+														  assertThatPigsAreEqual( context, expectedPig, actualPig );
+														  context.assertEquals(
+																  session.getLockMode( actualPig ),
+																  LockMode.PESSIMISTIC_WRITE
+														  );
+													  } )
+									  )
 						)
 		);
 	}
@@ -517,12 +584,15 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				populateDB()
 						.thenCompose(
 								v -> getSessionFactory().withTransaction(
-										(session, tx) -> session.createQuery( "from GuineaPig pig", GuineaPig.class)
-												.setLockMode("pig", LockMode.PESSIMISTIC_WRITE )
+										(session, tx) -> session.createQuery( "from GuineaPig pig", GuineaPig.class )
+												.setLockMode( "pig", LockMode.PESSIMISTIC_WRITE )
 												.getSingleResult()
 												.thenAccept( actualPig -> {
 													assertThatPigsAreEqual( context, expectedPig, actualPig );
-													context.assertEquals( session.getLockMode( actualPig ), LockMode.PESSIMISTIC_WRITE );
+													context.assertEquals(
+															session.getLockMode( actualPig ),
+															LockMode.PESSIMISTIC_WRITE
+													);
 												} )
 								)
 						)
@@ -564,10 +634,12 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				openSession()
 						.thenCompose(
 								s -> s.withTransaction(
-										t -> s.persist( new GuineaPig( 10, "Tulip" ) )
-												.thenCompose( v -> s.flush() )
-												.thenAccept( v -> { throw new RuntimeException(); } )
-								)
+												t -> s.persist( new GuineaPig( 10, "Tulip" ) )
+														.thenCompose( v -> s.flush() )
+														.thenAccept( v -> {
+															throw new RuntimeException();
+														} )
+										)
 										.thenCompose( v -> s.close() )
 						)
 						.handle( (v, e) -> null )
@@ -583,10 +655,10 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				openSession()
 						.thenCompose(
 								s -> s.withTransaction(
-										t -> s.persist( new GuineaPig( 10, "Tulip" ) )
-												.thenCompose( vv -> s.flush() )
-												.thenAccept( vv -> t.markForRollback() )
-								)
+												t -> s.persist( new GuineaPig( 10, "Tulip" ) )
+														.thenCompose( vv -> s.flush() )
+														.thenAccept( vv -> t.markForRollback() )
+										)
 										.thenCompose( v -> s.close() )
 						)
 						.thenCompose( vv -> selectNameFromId( 10 ) )
@@ -608,7 +680,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						)
 						.thenCompose( v -> selectNameFromId( 5 ) )
 						.thenAccept( context::assertNull )
-						.handle((r, e) -> context.assertNotNull(e))
+						.handle( (r, e) -> context.assertNotNull( e ) )
 		);
 	}
 
@@ -619,11 +691,11 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 				populateDB()
 						.thenCompose( v -> openSession() )
 						.thenCompose( session ->
-							session.find( GuineaPig.class, 5 )
-								.thenCompose( session::remove )
-								.thenCompose( v -> session.flush() )
-								.thenCompose( v -> selectNameFromId( 5 ) )
-								.thenAccept( context::assertNull ) )
+											  session.find( GuineaPig.class, 5 )
+													  .thenCompose( session::remove )
+													  .thenCompose( v -> session.flush() )
+													  .thenCompose( v -> selectNameFromId( 5 ) )
+													  .thenAccept( context::assertNull ) )
 		);
 	}
 
@@ -687,41 +759,47 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 
 	@Test
 	public void testSessionWithNativeAffectedEntities(TestContext context) {
-		GuineaPig pig = new GuineaPig(3,"Rorshach");
-		AffectedEntities affectsPigs = new AffectedEntities(GuineaPig.class);
+		GuineaPig pig = new GuineaPig( 3, "Rorshach" );
+		AffectedEntities affectsPigs = new AffectedEntities( GuineaPig.class );
 		test(
 				context,
 				openSession().thenCompose( s -> s
-						.persist(pig)
-						.thenCompose( v -> s.createNativeQuery("select * from pig where name=:n", GuineaPig.class, affectsPigs)
-								.setParameter("n", pig.name)
+						.persist( pig )
+						.thenCompose( v -> s.createNativeQuery(
+										"select * from pig where name=:n",
+										GuineaPig.class,
+										affectsPigs
+								)
+								.setParameter( "n", pig.name )
 								.getResultList() )
 						.thenAccept( list -> {
 							context.assertFalse( list.isEmpty() );
-							context.assertEquals(1, list.size());
-							assertThatPigsAreEqual(context, pig, list.get(0));
+							context.assertEquals( 1, list.size() );
+							assertThatPigsAreEqual( context, pig, list.get( 0 ) );
 						} )
-						.thenCompose( v -> s.find(GuineaPig.class, pig.id) )
+						.thenCompose( v -> s.find( GuineaPig.class, pig.id ) )
 						.thenAccept( p -> {
-							assertThatPigsAreEqual(context, pig, p);
+							assertThatPigsAreEqual( context, pig, p );
 							p.name = "X";
 						} )
-						.thenCompose( v -> s.createNativeQuery("update pig set name='Y' where name='X'", affectsPigs).executeUpdate() )
-						.thenAccept( rows -> context.assertEquals(1, rows) )
-						.thenCompose( v -> s.refresh(pig) )
-						.thenAccept( v -> context.assertEquals(pig.name, "Y") )
+						.thenCompose( v -> s.createNativeQuery( "update pig set name='Y' where name='X'", affectsPigs )
+								.executeUpdate() )
+						.thenAccept( rows -> context.assertEquals( 1, rows ) )
+						.thenCompose( v -> s.refresh( pig ) )
+						.thenAccept( v -> context.assertEquals( pig.name, "Y" ) )
 						.thenAccept( v -> pig.name = "Z" )
-						.thenCompose( v -> s.createNativeQuery("delete from pig where name='Z'", affectsPigs).executeUpdate() )
-						.thenAccept( rows -> context.assertEquals(1, rows) )
-						.thenCompose( v -> s.createNativeQuery("select id from pig").getResultList() )
+						.thenCompose( v -> s.createNativeQuery( "delete from pig where name='Z'", affectsPigs )
+								.executeUpdate() )
+						.thenAccept( rows -> context.assertEquals( 1, rows ) )
+						.thenCompose( v -> s.createNativeQuery( "select id from pig" ).getResultList() )
 						.thenAccept( list -> context.assertTrue( list.isEmpty() ) ) )
 		);
 	}
 
 	@Test
 	public void testMetamodel(TestContext context) {
-		EntityType<GuineaPig> pig = getSessionFactory().getMetamodel().entity(GuineaPig.class);
-		context.assertNotNull(pig);
+		EntityType<GuineaPig> pig = getSessionFactory().getMetamodel().entity( GuineaPig.class );
+		context.assertNotNull( pig );
 		context.assertEquals( 3, pig.getAttributes().size() );
 		context.assertEquals( "GuineaPig", pig.getName() );
 	}
@@ -729,7 +807,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 	@Test
 	public void testTransactionPropagation(TestContext context) {
 		test( context, getSessionFactory().withTransaction(
-				(session, transaction) -> session.createQuery("from GuineaPig").getResultList()
+				(session, transaction) -> session.createQuery( "from GuineaPig" ).getResultList()
 						.thenCompose( list -> {
 							context.assertNotNull( session.currentTransaction() );
 							context.assertFalse( session.currentTransaction().isMarkedForRollback() );
@@ -738,7 +816,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 							context.assertTrue( transaction.isMarkedForRollback() );
 							return session.withTransaction( t -> {
 								context.assertTrue( t.isMarkedForRollback() );
-								return session.createQuery("from GuineaPig").getResultList();
+								return session.createQuery( "from GuineaPig" ).getResultList();
 							} );
 						} )
 		) );
@@ -748,11 +826,11 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 	public void testSessionPropagation(TestContext context) {
 		test( context, getSessionFactory().withSession( session -> {
 			context.assertEquals( false, session.isDefaultReadOnly() );
-			session.setDefaultReadOnly(true);
-			return session.createQuery("from GuineaPig").getResultList()
-					.thenCompose( list -> getSessionFactory().withSession(s -> {
+			session.setDefaultReadOnly( true );
+			return session.createQuery( "from GuineaPig" ).getResultList()
+					.thenCompose( list -> getSessionFactory().withSession( s -> {
 						context.assertEquals( true, s.isDefaultReadOnly() );
-						return s.createQuery("from GuineaPig").getResultList();
+						return s.createQuery( "from GuineaPig" ).getResultList();
 					} ) );
 		} ) );
 	}
@@ -762,15 +840,15 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 		test(
 				context,
 				getSessionFactory()
-						.withTransaction((s, t) -> s.persist( new GuineaPig( 10, "Tulip" ) ))
-						.thenCompose(v -> getSessionFactory()
-								.withTransaction((s, t) -> s.persist( new GuineaPig( 10, "Tulip" ) ))
-						).handle((i, t) -> {
-					context.assertNotNull(t);
-					context.assertTrue(t instanceof CompletionException);
-					context.assertTrue(t.getCause() instanceof PersistenceException);
-					return null;
-				})
+						.withTransaction( (s, t) -> s.persist( new GuineaPig( 10, "Tulip" ) ) )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( (s, t) -> s.persist( new GuineaPig( 10, "Tulip" ) ) )
+						).handle( (i, t) -> {
+							context.assertNotNull( t );
+							context.assertTrue( t instanceof CompletionException );
+							context.assertTrue( t.getCause() instanceof PersistenceException );
+							return null;
+						} )
 		);
 	}
 
@@ -822,8 +900,8 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 		context.assertEquals( expected.getName(), actual.getName() );
 	}
 
-	@Entity(name="GuineaPig")
-	@Table(name="pig")
+	@Entity(name = "GuineaPig")
+	@Table(name = "pig")
 	public static class GuineaPig {
 		@Id
 		private Integer id;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessProxyUpdateTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessProxyUpdateTest.java
@@ -6,6 +6,8 @@
 package org.hibernate.reactive;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -18,9 +20,7 @@ import javax.persistence.Table;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LazyInitializationException;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -41,16 +41,8 @@ import static org.hibernate.reactive.testing.ReactiveAssertions.assertThrown;
 public class ReactiveStatelessProxyUpdateTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SampleEntity.class );
-		configuration.addAnnotatedClass( SampleJoinEntity.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "SampleEntity", "SampleJoinEntity" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SampleEntity.class, SampleJoinEntity.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveStatelessSessionTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -18,9 +20,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaUpdate;
 import javax.persistence.criteria.Root;
 
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -29,15 +29,8 @@ import io.vertx.ext.unit.TestContext;
 public class ReactiveStatelessSessionTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( GuineaPig.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "GuineaPig" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( GuineaPig.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
@@ -8,23 +8,21 @@ package org.hibernate.reactive;
 import io.vertx.ext.unit.TestContext;
 import org.hibernate.Hibernate;
 import org.hibernate.LockMode;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.stage.Stage;
 import org.junit.Test;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 
 
 public class ReferenceTest extends BaseReactiveTest {
 
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Author.class, Book.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SecondaryTableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SecondaryTableTest.java
@@ -6,29 +6,21 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 
 
 public class SecondaryTableTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SecondaryTableTest.Book.class );
-		configuration.addAnnotatedClass( SecondaryTableTest.Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( Book.class, Author.class ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SequenceGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SequenceGeneratorTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -30,10 +32,8 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 public class SequenceGeneratorTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SequenceId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SequenceId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SingleTableInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SingleTableInheritanceTest.java
@@ -6,13 +6,13 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 
-import org.junit.After;
 import org.junit.Test;
 
 import javax.persistence.*;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
@@ -20,17 +20,8 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 public class SingleTableInheritanceTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SingleTableInheritanceTest.Book.class );
-		configuration.addAnnotatedClass( SingleTableInheritanceTest.SpellBook.class );
-		configuration.addAnnotatedClass( SingleTableInheritanceTest.Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class, SpellBook.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StageExceptionsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StageExceptionsTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.concurrent.CompletionException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -14,7 +16,6 @@ import javax.persistence.PersistenceException;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.provider.Settings;
-import org.hibernate.reactive.util.impl.CompletionStages;
 
 import org.junit.Test;
 
@@ -24,10 +25,14 @@ import io.vertx.ext.unit.TestContext;
 public class StageExceptionsTest extends BaseReactiveTest {
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( MyPerson.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		Configuration configuration = super.constructConfiguration();
 		configuration.setProperty( Settings.NATIVE_EXCEPTION_HANDLING_51_COMPLIANCE, "false" );
-		configuration.addAnnotatedClass( MyPerson.class );
 		return configuration;
 	}
 
@@ -43,10 +48,12 @@ public class StageExceptionsTest extends BaseReactiveTest {
 				)
 				.handle( (res, err) -> {
 					context.assertNotNull( err );
-					context.assertTrue( err.getClass().isAssignableFrom( CompletionException.class) );
-					context.assertTrue( expectedException.isAssignableFrom( err.getCause().getClass() ),
-							"Expected " + expectedException.getName() + " but was " + err );
-					return CompletionStages.voidFuture();
+					context.assertTrue( err.getClass().isAssignableFrom( CompletionException.class ) );
+					context.assertTrue(
+							expectedException.isAssignableFrom( err.getCause().getClass() ),
+							"Expected " + expectedException.getName() + " but was " + err
+					);
+					return null;
 				} )
 		);
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StatisticsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StatisticsTest.java
@@ -5,165 +5,164 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.stat.EntityStatistics;
-import org.hibernate.stat.QueryStatistics;
-import org.hibernate.stat.Statistics;
-import org.junit.After;
-import org.junit.Test;
-
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
+
+import org.hibernate.cfg.Configuration;
+import org.hibernate.stat.EntityStatistics;
+import org.hibernate.stat.QueryStatistics;
+import org.hibernate.stat.Statistics;
+
+import org.junit.After;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.cfg.AvailableSettings.GENERATE_STATISTICS;
 
 
 public class StatisticsTest extends BaseReactiveTest {
 
-    @Override
-    protected Configuration constructConfiguration() {
-        Configuration configuration = super.constructConfiguration();
-        configuration.addAnnotatedClass( Named.class );
-        configuration.setProperty( GENERATE_STATISTICS, "true" );
-        return configuration;
-    }
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		configuration.addAnnotatedClass( Named.class );
+		configuration.setProperty( GENERATE_STATISTICS, "true" );
+		return configuration;
+	}
 
-    @After
-    public void cleanDB(TestContext context) {
-        getSessionFactory().close();
-    }
+	@After
+	public void cleanDB(TestContext context) {
+		getSessionFactory().close();
+	}
 
-    @Test
-    public void testMutinyStatistics(TestContext context) {
-        Statistics statistics = getMutinySessionFactory().getStatistics();
-        test( context,
-                getMutinySessionFactory()
-                        .withTransaction(
-                                (s, t) -> s.persistAll( new Named("foo"), new Named("bar"), new Named("baz") )
-                        )
-                        .chain( ()->
-                                getMutinySessionFactory().withTransaction(
-                                        (s, t) -> s.find(Named.class, 1).chain(s::remove)
-                                ) )
-                        .invoke( v-> {
-                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
-                            context.assertEquals( 1L, statistics.getEntityLoadCount() );
-                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+	@Test
+	public void testMutinyStatistics(TestContext context) {
+		Statistics statistics = getMutinySessionFactory().getStatistics();
+		test(
+				context,
+				getMutinySessionFactory()
+						.withTransaction( s -> s
+								.persistAll( new Named( "foo" ), new Named( "bar" ), new Named( "baz" ) )
+						)
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( s -> s.find( Named.class, 1 ).chain( s::remove ) )
+						)
+						.invoke( v -> {
+							context.assertEquals( 3L, statistics.getEntityInsertCount() );
+							context.assertEquals( 1L, statistics.getEntityLoadCount() );
+							context.assertEquals( 1L, statistics.getEntityDeleteCount() );
 
-                            context.assertEquals( 2L, statistics.getFlushCount() );
-                            context.assertEquals( 2L, statistics.getSessionOpenCount() );
-                            context.assertEquals( 2L, statistics.getSessionCloseCount() );
+							context.assertEquals( 2L, statistics.getFlushCount() );
+							context.assertEquals( 2L, statistics.getSessionOpenCount() );
+							context.assertEquals( 2L, statistics.getSessionCloseCount() );
 //                            context.assertEquals( 2L, statistics.getTransactionCount() );
 //                            context.assertEquals( 2L, statistics.getConnectCount() );
 //                            context.assertEquals( 5L, statistics.getPrepareStatementCount() );
 
-                            EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
-                            context.assertEquals( 3L, entityStatistics.getInsertCount() );
-                            context.assertEquals( 1L, entityStatistics.getLoadCount() );
-                            context.assertEquals( 1L, entityStatistics.getDeleteCount() );
+							EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
+							context.assertEquals( 3L, entityStatistics.getInsertCount() );
+							context.assertEquals( 1L, entityStatistics.getLoadCount() );
+							context.assertEquals( 1L, entityStatistics.getDeleteCount() );
 
-                            context.assertEquals( 0, statistics.getQueries().length );
-                        } )
-                        .chain( ()->
-                                getMutinySessionFactory().withTransaction(
-                                        (s, t) -> s.createQuery("from Named").getResultList()
-                                ) )
-                        .invoke( v-> {
-                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
-                            context.assertEquals( 3L, statistics.getEntityLoadCount() );
-                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
-                            context.assertEquals( 1L, statistics.getQueryExecutionCount() );
+							context.assertEquals( 0, statistics.getQueries().length );
+						} )
+						.chain( () -> getMutinySessionFactory()
+								.withTransaction( s -> s.createQuery( "from Named" ).getResultList() ) )
+						.invoke( v -> {
+							context.assertEquals( 3L, statistics.getEntityInsertCount() );
+							context.assertEquals( 3L, statistics.getEntityLoadCount() );
+							context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+							context.assertEquals( 1L, statistics.getQueryExecutionCount() );
 
-                            context.assertEquals( 1, statistics.getQueries().length );
+							context.assertEquals( 1, statistics.getQueries().length );
 
-                            QueryStatistics queryStatistics = statistics.getQueryStatistics("from Named");
-                            context.assertEquals( 1L, queryStatistics.getExecutionCount() );
-                            context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
+							QueryStatistics queryStatistics = statistics.getQueryStatistics( "from Named" );
+							context.assertEquals( 1L, queryStatistics.getExecutionCount() );
+							context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
 //                            context.assertNotEquals( 0L, queryStatistics.getExecutionMaxTime() );
 
-                            context.assertEquals( 3L, statistics.getFlushCount() );
-                            context.assertEquals( 3L, statistics.getSessionOpenCount() );
-                            context.assertEquals( 3L, statistics.getSessionCloseCount() );
+							context.assertEquals( 3L, statistics.getFlushCount() );
+							context.assertEquals( 3L, statistics.getSessionOpenCount() );
+							context.assertEquals( 3L, statistics.getSessionCloseCount() );
 //                            context.assertEquals( 3L, statistics.getTransactionCount() );
 //                            context.assertEquals( 3L, statistics.getConnectCount() );
 //                            context.assertEquals( 6L, statistics.getPrepareStatementCount() );
-                        } )
-        );
-    }
+						} )
+		);
+	}
 
-    @Test
-    public void testStageStatistics(TestContext context) {
-        Statistics statistics = getSessionFactory().getStatistics();
-        test( context,
-                getSessionFactory()
-                        .withTransaction(
-                                (s, t) -> s.persist( new Named("foo"), new Named("bar"), new Named("baz") )
-                        )
-                        .thenCompose( v ->
-                                getSessionFactory().withTransaction(
-                                        (s, t) -> s.find(Named.class, 1).thenCompose(s::remove)
-                                ) )
-                        .thenAccept( v-> {
-                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
-                            context.assertEquals( 1L, statistics.getEntityLoadCount() );
-                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+	@Test
+	public void testStageStatistics(TestContext context) {
+		Statistics statistics = getSessionFactory().getStatistics();
+		test(
+				context,
+				getSessionFactory()
+						.withTransaction( s -> s
+								.persist( new Named( "foo" ), new Named( "bar" ), new Named( "baz" ) ) )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( s -> s.find( Named.class, 1 ).thenCompose( s::remove ) ) )
+						.thenAccept( v -> {
+							context.assertEquals( 3L, statistics.getEntityInsertCount() );
+							context.assertEquals( 1L, statistics.getEntityLoadCount() );
+							context.assertEquals( 1L, statistics.getEntityDeleteCount() );
 
-                            context.assertEquals( 2L, statistics.getFlushCount() );
-                            context.assertEquals( 2L, statistics.getSessionOpenCount() );
-                            context.assertEquals( 2L, statistics.getSessionCloseCount() );
+							context.assertEquals( 2L, statistics.getFlushCount() );
+							context.assertEquals( 2L, statistics.getSessionOpenCount() );
+							context.assertEquals( 2L, statistics.getSessionCloseCount() );
 //                            context.assertEquals( 2L, statistics.getTransactionCount() );
 //                            context.assertEquals( 2L, statistics.getConnectCount() );
 //                            context.assertEquals( 5L, statistics.getPrepareStatementCount() );
 
-                            EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
-                            context.assertEquals( 3L, entityStatistics.getInsertCount() );
-                            context.assertEquals( 1L, entityStatistics.getLoadCount() );
-                            context.assertEquals( 1L, entityStatistics.getDeleteCount() );
+							EntityStatistics entityStatistics = statistics.getEntityStatistics( Named.class.getName() );
+							context.assertEquals( 3L, entityStatistics.getInsertCount() );
+							context.assertEquals( 1L, entityStatistics.getLoadCount() );
+							context.assertEquals( 1L, entityStatistics.getDeleteCount() );
 
-                            context.assertEquals( 0, statistics.getQueries().length );
-                        } )
-                        .thenCompose( v ->
-                                getSessionFactory().withTransaction(
-                                        (s, t) -> s.createQuery("from Named").getResultList()
-                                ) )
-                        .thenAccept( v-> {
-                            context.assertEquals( 3L, statistics.getEntityInsertCount() );
-                            context.assertEquals( 3L, statistics.getEntityLoadCount() );
-                            context.assertEquals( 1L, statistics.getEntityDeleteCount() );
-                            context.assertEquals( 1L, statistics.getQueryExecutionCount() );
+							context.assertEquals( 0, statistics.getQueries().length );
+						} )
+						.thenCompose( v -> getSessionFactory()
+								.withTransaction( s -> s
+										.createQuery( "from Named" ).getResultList() ) )
+						.thenAccept( v -> {
+							context.assertEquals( 3L, statistics.getEntityInsertCount() );
+							context.assertEquals( 3L, statistics.getEntityLoadCount() );
+							context.assertEquals( 1L, statistics.getEntityDeleteCount() );
+							context.assertEquals( 1L, statistics.getQueryExecutionCount() );
 
-                            context.assertEquals( 1, statistics.getQueries().length );
+							context.assertEquals( 1, statistics.getQueries().length );
 
-                            QueryStatistics queryStatistics = statistics.getQueryStatistics("from Named");
-                            context.assertEquals( 1L, queryStatistics.getExecutionCount() );
-                            context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
+							QueryStatistics queryStatistics = statistics.getQueryStatistics( "from Named" );
+							context.assertEquals( 1L, queryStatistics.getExecutionCount() );
+							context.assertEquals( 2L, queryStatistics.getExecutionRowCount() );
 //                            context.assertNotEquals( 0L, queryStatistics.getExecutionMaxTime() );
 
-                            context.assertEquals( 3L, statistics.getFlushCount() );
-                            context.assertEquals( 3L, statistics.getSessionOpenCount() );
-                            context.assertEquals( 3L, statistics.getSessionCloseCount() );
+							context.assertEquals( 3L, statistics.getFlushCount() );
+							context.assertEquals( 3L, statistics.getSessionOpenCount() );
+							context.assertEquals( 3L, statistics.getSessionCloseCount() );
 //                            context.assertEquals( 3L, statistics.getTransactionCount() );
 //                            context.assertEquals( 3L, statistics.getConnectCount() );
 //                            context.assertEquals( 6L, statistics.getPrepareStatementCount() );
-                        } )
-        );
-    }
+						} )
+		);
+	}
 
-    @Entity(name="Named")
-    @Table(name = "named_thing")
-    static class Named {
-        @Id @GeneratedValue
-        Integer id;
-        String name;
+	@Entity(name = "Named")
+	@Table(name = "named_thing")
+	static class Named {
+		@Id
+		@GeneratedValue
+		Integer id;
+		String name;
 
-        public Named(String name) {
-            this.name = name;
-        }
+		public Named(String name) {
+			this.name = name;
+		}
 
-        public Named() {}
-    }
+		public Named() {
+		}
+	}
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
@@ -5,13 +5,9 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.Hibernate;
-import org.hibernate.annotations.Fetch;
-import org.hibernate.annotations.FetchMode;
-import org.hibernate.cfg.Configuration;
-import org.junit.Test;
-
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import javax.persistence.CascadeType;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -29,9 +25,15 @@ import javax.persistence.PreUpdate;
 import javax.persistence.Table;
 import javax.persistence.Transient;
 import javax.persistence.Version;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
+
+import org.hibernate.Hibernate;
+import org.hibernate.annotations.Fetch;
+import org.hibernate.annotations.FetchMode;
+import org.hibernate.cfg.Configuration;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 
 public class SubselectFetchTest extends BaseReactiveTest {
@@ -47,39 +49,43 @@ public class SubselectFetchTest extends BaseReactiveTest {
 	@Test
 	public void testQuery(TestContext context) {
 
-		Node basik = new Node("Child");
-		basik.parent = new Node("Parent");
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.elements.add(new Element(basik));
-		basik.parent.elements.add(new Element(basik.parent));
-		basik.parent.elements.add(new Element(basik.parent));
+		Node basik = new Node( "Child" );
+		basik.parent = new Node( "Parent" );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.elements.add( new Element( basik ) );
+		basik.parent.elements.add( new Element( basik.parent ) );
+		basik.parent.elements.add( new Element( basik.parent ) );
 
-		test( context,
+		test(
+				context,
 				openSession()
-						.thenCompose(s -> s.persist(basik).thenCompose(v -> s.flush()))
+						.thenCompose( s -> s.persist( basik ).thenCompose( v -> s.flush() ) )
 						.thenCompose( v -> openSession() )
-						.thenCompose(s -> s.createQuery("from Node n order by id", Node.class)
+						.thenCompose( s -> s.createQuery( "from Node n order by id", Node.class )
 								.getResultList()
 								.thenCompose( list -> {
-									context.assertEquals(list.size(), 2);
-									Node n1 = list.get(0);
-									Node n2 = list.get(1);
-									context.assertFalse( Hibernate.isInitialized(n1.elements) );
-									context.assertFalse( Hibernate.isInitialized(n2.elements) );
+									context.assertEquals( list.size(), 2 );
+									Node n1 = list.get( 0 );
+									Node n2 = list.get( 1 );
+									context.assertFalse( Hibernate.isInitialized( n1.elements ) );
+									context.assertFalse( Hibernate.isInitialized( n2.elements ) );
 									return s.fetch( n1.elements ).thenAccept( elements -> {
-										context.assertTrue( Hibernate.isInitialized(elements) );
-										context.assertTrue( Hibernate.isInitialized(n1.elements) );
-										context.assertTrue( Hibernate.isInitialized(n2.elements) );
+										context.assertTrue( Hibernate.isInitialized( elements ) );
+										context.assertTrue( Hibernate.isInitialized( n1.elements ) );
+										context.assertTrue( Hibernate.isInitialized( n2.elements ) );
 									} );
-								})
+								} )
 						)
 		);
 	}
 
-	@Entity(name = "Element") @Table(name="Element")
+	@Entity(name = "Element")
+	@Table(name = "Element")
 	public static class Element {
-		@Id @GeneratedValue Integer id;
+		@Id
+		@GeneratedValue
+		Integer id;
 
 		@ManyToOne(fetch = FetchType.LAZY)
 		Node node;
@@ -88,43 +94,53 @@ public class SubselectFetchTest extends BaseReactiveTest {
 			this.node = node;
 		}
 
-		Element() {}
+		Element() {
+		}
 	}
 
-	@Entity(name = "Node") @Table(name="Node")
+	@Entity(name = "Node")
+	@Table(name = "Node")
 	public static class Node {
 
-		@Id @GeneratedValue Integer id;
-		@Version Integer version;
+		@Id
+		@GeneratedValue
+		Integer id;
+		@Version
+		Integer version;
 		String string;
 
-		@ManyToOne(fetch = FetchType.LAZY,
-				cascade = {CascadeType.PERSIST,
-						CascadeType.REFRESH,
-						CascadeType.MERGE,
-						CascadeType.REMOVE})
+		@ManyToOne(fetch = FetchType.LAZY, cascade = {
+				CascadeType.PERSIST, CascadeType.REFRESH, CascadeType.MERGE, CascadeType.REMOVE
+		})
 		Node parent;
 
 		@OneToMany(fetch = FetchType.LAZY,
-				cascade = {CascadeType.PERSIST,
-						CascadeType.REMOVE},
+				cascade = { CascadeType.PERSIST, CascadeType.REMOVE },
 				mappedBy = "node")
 		@Fetch(FetchMode.SUBSELECT)
 		List<Element> elements = new ArrayList<>();
 
-		@Transient boolean prePersisted;
-		@Transient boolean postPersisted;
-		@Transient boolean preUpdated;
-		@Transient boolean postUpdated;
-		@Transient boolean postRemoved;
-		@Transient boolean preRemoved;
-		@Transient boolean loaded;
+		@Transient
+		boolean prePersisted;
+		@Transient
+		boolean postPersisted;
+		@Transient
+		boolean preUpdated;
+		@Transient
+		boolean postUpdated;
+		@Transient
+		boolean postRemoved;
+		@Transient
+		boolean preRemoved;
+		@Transient
+		boolean loaded;
 
 		public Node(String string) {
 			this.string = string;
 		}
 
-		Node() {}
+		Node() {
+		}
 
 		@PrePersist
 		void prePersist() {
@@ -191,12 +207,12 @@ public class SubselectFetchTest extends BaseReactiveTest {
 				return false;
 			}
 			Node node = (Node) o;
-			return Objects.equals(string, node.string);
+			return Objects.equals( string, node.string );
 		}
 
 		@Override
 		public int hashCode() {
-			return Objects.hash(string);
+			return Objects.hash( string );
 		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/TimestampTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/TimestampTest.java
@@ -9,7 +9,6 @@ import io.vertx.ext.unit.TestContext;
 
 import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
-import org.hibernate.cfg.Configuration;
 
 import org.junit.Test;
 
@@ -19,13 +18,14 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
+import java.util.List;
 
 public class TimestampTest extends BaseReactiveTest {
+
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Record.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Record.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDAsBinaryType.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDAsBinaryType.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 import javax.persistence.Column;
@@ -12,7 +14,6 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
 import org.junit.Rule;
@@ -36,10 +37,8 @@ public abstract class UUIDAsBinaryType extends BaseReactiveTest {
 		public DatabaseSelectionRule rule = runOnlyFor( MYSQL, MARIA );
 
 		@Override
-		protected Configuration constructConfiguration() {
-			Configuration configuration = super.constructConfiguration();
-			configuration.addAnnotatedClass( ExactSizeUUIDEntity.class );
-			return configuration;
+		protected Collection<Class<?>> annotatedEntities() {
+			return List.of( ExactSizeUUIDEntity.class );
 		}
 
 		@Test
@@ -109,10 +108,8 @@ public abstract class UUIDAsBinaryType extends BaseReactiveTest {
 		public DatabaseSelectionRule rule = skipTestsFor( MYSQL, MARIA, ORACLE );
 
 		@Override
-		protected Configuration constructConfiguration() {
-			Configuration configuration = super.constructConfiguration();
-			configuration.addAnnotatedClass( UUIDEntity.class );
-			return configuration;
+		protected Collection<Class<?>> annotatedEntities() {
+			return List.of( UUIDEntity.class );
 		}
 
 		@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDGeneratorTest.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive;
 
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
 import org.junit.Rule;
@@ -17,6 +16,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Version;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -29,10 +30,8 @@ public class UUIDGeneratorTest extends BaseReactiveTest {
 	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2, ORACLE );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( TableId.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( TableId.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnicodeCharsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnicodeCharsTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
@@ -29,10 +31,14 @@ import static org.hibernate.cfg.AvailableSettings.USE_NATIONALIZED_CHARACTER_DAT
 public class UnicodeCharsTest extends BaseReactiveTest {
 
 	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( UnicodeString.class );
+	}
+
+	@Override
 	protected Configuration constructConfiguration() {
 		final Configuration configuration = super.constructConfiguration();
 		configuration.getProperties().put( USE_NATIONALIZED_CHARACTER_DATA, true );
-		configuration.addAnnotatedClass( UnicodeString.class );
 		return configuration;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnionSubclassInheritanceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UnionSubclassInheritanceTest.java
@@ -5,17 +5,28 @@
  */
 package org.hibernate.reactive;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Objects;
+import javax.persistence.Column;
+import javax.persistence.DiscriminatorValue;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Inheritance;
+import javax.persistence.InheritanceType;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
-import javax.persistence.*;
-import java.util.Date;
-import java.util.Objects;
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
 
@@ -25,17 +36,8 @@ public class UnionSubclassInheritanceTest extends BaseReactiveTest {
 	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( ORACLE );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Book.class );
-		configuration.addAnnotatedClass( SpellBook.class );
-		configuration.addAnnotatedClass( Author.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, deleteEntities( "Book", "Author", "SpellBook" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class, Author.class, SpellBook.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/VertxEventLoopThreadTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/VertxEventLoopThreadTest.java
@@ -5,15 +5,16 @@
  */
 package org.hibernate.reactive;
 
+import java.util.Collection;
+import java.util.List;
 import javax.persistence.Entity;
 import javax.persistence.Id;
-
-import org.hibernate.cfg.Configuration;
 
 import org.junit.Test;
 
 import io.vertx.core.Context;
 import io.vertx.ext.unit.TestContext;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -32,10 +33,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class VertxEventLoopThreadTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Boardgame.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Boardgame.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/ColumnTypesMappingTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/ColumnTypesMappingTest.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.schema;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.type.NumericBooleanType;
 import org.hibernate.type.TrueFalseType;
@@ -30,7 +29,9 @@ import java.sql.Time;
 import java.sql.Timestamp;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Collection;
 import java.util.Date;
+import java.util.List;
 import java.util.TimeZone;
 
 /**
@@ -39,10 +40,8 @@ import java.util.TimeZone;
 public class ColumnTypesMappingTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( BasicTypesTestEntity.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( BasicTypesTestEntity.class );
 	}
 
 	private void testDatatype(TestContext context, String columnName, Class<?> type) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
@@ -44,8 +44,7 @@ public abstract class SchemaUpdateSqlServerTestBase extends BaseReactiveTest {
 	/**
 	 * Test INDIVIDUALLY option without setting the default catalog name
 	 */
-	public static class IndividuallySchemaUpdateSqlServerTest
-			extends SchemaUpdateSqlServerTestBase {
+	public static class IndividuallySchemaUpdateSqlServerTest extends SchemaUpdateSqlServerTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {
@@ -58,8 +57,7 @@ public abstract class SchemaUpdateSqlServerTestBase extends BaseReactiveTest {
 	/**
 	 * Test INDIVIDUALLY option when we set the catalog name to the default name
 	 */
-	public static class IndividuallySchemaUpdateWithCatalogTest
-			extends SchemaUpdateSqlServerTestBase {
+	public static class IndividuallySchemaUpdateWithCatalogTest extends SchemaUpdateSqlServerTestBase {
 
 		@Override
 		protected Configuration constructConfiguration(String hbm2DdlOption) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/BasicTypesAndCallbacksForAllDBsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/BasicTypesAndCallbacksForAllDBsTest.java
@@ -5,14 +5,6 @@
  */
 package org.hibernate.reactive.types;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.annotations.Type;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.reactive.BaseReactiveTest;
-import org.junit.After;
-import org.junit.Test;
-
-import javax.persistence.*;
 import java.io.Serializable;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -26,8 +18,45 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.GregorianCalendar;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TimeZone;
+import java.util.UUID;
 import java.util.function.Consumer;
+import javax.persistence.AttributeConverter;
+import javax.persistence.Column;
+import javax.persistence.Convert;
+import javax.persistence.Converter;
+import javax.persistence.Embeddable;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import javax.persistence.PostLoad;
+import javax.persistence.PostPersist;
+import javax.persistence.PostRemove;
+import javax.persistence.PostUpdate;
+import javax.persistence.PrePersist;
+import javax.persistence.PreRemove;
+import javax.persistence.PreUpdate;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.persistence.Transient;
+import javax.persistence.Version;
+
+import org.hibernate.annotations.Type;
+import org.hibernate.reactive.BaseReactiveTest;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 /**
  * Test all the types and lifecycle callbacks that we expect to work on all supported DBs
@@ -35,15 +64,8 @@ import java.util.function.Consumer;
 public class BasicTypesAndCallbacksForAllDBsTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
-	}
-
-	@After
-	public void deleteTable(TestContext context) {
-		test( context, deleteEntities( "Basic" ) );
+	protected Set<Class<?>> annotatedEntities() {
+		return Set.of( Basic.class );
 	}
 
 	private void testField(TestContext context, Basic original, Consumer<Basic> consumer) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JoinColumnsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JoinColumnsTest.java
@@ -6,7 +6,9 @@
 package org.hibernate.reactive.types;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
 import javax.persistence.Column;
@@ -22,10 +24,8 @@ import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import org.hibernate.TransientPropertyValueException;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 
-import org.junit.After;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
@@ -34,16 +34,8 @@ import io.vertx.ext.unit.TestContext;
 public class JoinColumnsTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( SampleEntity.class );
-		configuration.addAnnotatedClass( SampleJoinEntity.class );
-		return configuration;
-	}
-
-	@After
-	public void cleanDB(TestContext context) {
-		test( context, deleteEntities( "SampleJoinEntity", "SampleEntity" ) );
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SampleJoinEntity.class, SampleEntity.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JsonTypeTest.java
@@ -5,22 +5,24 @@
  */
 package org.hibernate.reactive.types;
 
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.reactive.BaseReactiveTest;
-import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Version;
-import java.util.Objects;
-import java.util.function.Consumer;
+
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
@@ -35,19 +37,8 @@ public class JsonTypeTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2, SQLSERVER, ORACLE);
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
-	}
-
-	@After
-	public void deleteTable(TestContext context) {
-		test( context,
-			  getSessionFactory().withSession(
-					  session -> session.createQuery( "delete from JsonEntity" ).executeUpdate()
-			  )
-		);
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LobTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LobTypeTest.java
@@ -5,14 +5,10 @@
  */
 package org.hibernate.reactive.types;
 
-import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
-import org.hibernate.reactive.BaseReactiveTest;
-import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.junit.After;
-import org.junit.Rule;
-import org.junit.Test;
-
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -20,8 +16,14 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 import javax.persistence.Version;
-import java.util.Objects;
-import java.util.function.Consumer;
+
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DatabaseSelectionRule;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
@@ -35,19 +37,8 @@ public class LobTypeTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2, SQLSERVER );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
-	}
-
-	@After
-	public void deleteTable(TestContext context) {
-		test( context,
-			  getSessionFactory().withSession(
-					  session -> session.createQuery( "delete from LobEntity" ).executeUpdate()
-			  )
-		);
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LongLobTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LongLobTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive.types;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import javax.persistence.Column;
@@ -14,7 +16,6 @@ import javax.persistence.Id;
 import javax.persistence.Lob;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
@@ -31,10 +32,8 @@ public class LongLobTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.runOnlyFor( MYSQL );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/SerializableExceptionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/SerializableExceptionTest.java
@@ -6,13 +6,14 @@
 package org.hibernate.reactive.types;
 
 import java.io.Serializable;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 
 import org.junit.Test;
@@ -29,10 +30,8 @@ import io.vertx.ext.unit.TestContext;
 public class SerializableExceptionTest extends BaseReactiveTest {
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/StringToJsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/StringToJsonTypeTest.java
@@ -7,10 +7,8 @@ package org.hibernate.reactive.types;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -21,6 +19,8 @@ import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import javax.persistence.Version;
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 
@@ -38,19 +38,8 @@ public class StringToJsonTypeTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2, SQLSERVER, MARIA, ORACLE );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
-	}
-
-	@After
-	public void deleteTable(TestContext context) {
-		test( context,
-			  getSessionFactory().withSession(
-					  session -> session.createQuery( "delete from JsonEntity" ).executeUpdate()
-			  )
-		);
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/UserJsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/UserJsonTypeTest.java
@@ -5,6 +5,8 @@
  */
 package org.hibernate.reactive.types;
 
+import java.util.Collection;
+import java.util.List;
 import java.util.Objects;
 import java.util.function.Consumer;
 import javax.persistence.Column;
@@ -15,11 +17,9 @@ import javax.persistence.Table;
 import javax.persistence.Version;
 
 import org.hibernate.annotations.Type;
-import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.testing.DatabaseSelectionRule;
 
-import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -39,19 +39,8 @@ public class UserJsonTypeTest extends BaseReactiveTest {
 	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2, SQLSERVER, ORACLE );
 
 	@Override
-	protected Configuration constructConfiguration() {
-		Configuration configuration = super.constructConfiguration();
-		configuration.addAnnotatedClass( Basic.class );
-		return configuration;
-	}
-
-	@After
-	public void deleteTable(TestContext context) {
-		test( context,
-			  getSessionFactory().withSession(
-					  session -> session.createQuery( "delete from JsonEntity" ).executeUpdate()
-			  )
-		);
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Basic.class );
 	}
 
 	@Test


### PR DESCRIPTION
Before upgrading Vert.x.
Should avoid the build getting stuck with Oracle
It also adds some trace logs to keep track when the connection is opened/closed and when the transaction is created, committed and rollbacked