### PR TITLE
Configure hibernate git user and email in the workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -239,6 +239,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - name: Set git username and email
+      run: |
+        git config --global user.email "hibernate@users.noreply.github.com"
+        git config --global user.name "hibernate"
     - name: Set up JDK 11
       uses: actions/setup-java@v2.2.0
       with:


### PR DESCRIPTION
Fix failures when publishing the docs on hibernate.org

It seems that the main issue is that I have to specify the user name and email.
I've used `hibernate` and `hibernate@users.noreply.github.com` and everything seems to work fine.

Sorry, it seems that when I've tested the changes  to the release, I've messed up somewhere.