### PR TITLE
Restore correct configuration for UTCTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UTCTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UTCTest.java
@@ -25,6 +25,8 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.Id;
 
+import org.hibernate.cfg.AvailableSettings;
+import org.hibernate.cfg.Configuration;
 
 import org.junit.Test;
 
@@ -37,6 +39,13 @@ public class UTCTest extends BaseReactiveTest {
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
 		return List.of( Thing.class );
+	}
+
+	@Override
+	protected Configuration constructConfiguration() {
+		final Configuration configuration = super.constructConfiguration();
+		configuration.setProperty( AvailableSettings.JDBC_TIME_ZONE, "UTC" );
+		return configuration;
 	}
 
 	@Test


### PR DESCRIPTION
When I refactor the code I've delete the configuration without noticing that it sets some properties.
The test didn't fail for me because the time zone matches, I guess