### PR TITLE
ProxyConnection can support batch update

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ProxyConnection.java
@@ -101,7 +101,7 @@ final class ProxyConnection implements ReactiveConnection {
 			Object[] paramValues,
 			boolean allowBatching,
 			Expectation expectation) {
-		return withConnection( conn -> conn.update( sql, paramValues, false, expectation ) );
+		return withConnection( conn -> conn.update( sql, paramValues, allowBatching, expectation ) );
 	}
 
 	@Override


### PR DESCRIPTION
Issue https://github.com/hibernate/hibernate-reactive/issues/1256
The ProxyConnection update method forces `allowbatching` to `false`, which makes batch update impossible. ProxyConnection is still used in quarkus, so I think it may be recommended to support batch update.