### PR TITLE
specified default repository for docker image downloads in test DB's

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
@@ -9,6 +9,7 @@ import org.hibernate.HibernateException;
 
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.Container;
+import org.testcontainers.utility.DockerImageName;
 
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.isNotBlank;
 
@@ -16,7 +17,8 @@ class CockroachDBDatabase extends PostgreSQLDatabase {
 
 	public static CockroachDBDatabase INSTANCE = new CockroachDBDatabase();
 
-	public final static String IMAGE_NAME = "cockroachdb/cockroach:v21.2.4";
+	public static final String IMAGE_NAME = "cockroachdb/cockroach";
+	public static final String IMAGE_VERSION = ":v21.2.4";
 
 	/**
 	 * Holds configuration for the CockroachDB database container. If the build is run with <code>-Pdocker</code> then
@@ -25,7 +27,8 @@ class CockroachDBDatabase extends PostgreSQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final CockroachContainer cockroachDb = new CockroachContainer( IMAGE_NAME )
+	public static final CockroachContainer cockroachDb = new CockroachContainer(
+			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
 			// Username, password and database are not supported by test container at the moment
 			// Testcontainers will use a database named 'postgres' and the 'root' user
 			.withReuse( true );
@@ -100,4 +103,5 @@ class CockroachDBDatabase extends PostgreSQLDatabase {
 
 	private CockroachDBDatabase() {
 	}
+
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -29,12 +29,14 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.Db2Container;
+import org.testcontainers.utility.DockerImageName;
 
 class DB2Database implements TestableDatabase {
 
 	public static DB2Database INSTANCE = new DB2Database();
 
-	public static final String IMAGE_NAME = "ibmcom/db2:11.5.7.0";
+	public static final String IMAGE_NAME = "ibmcom/db2";
+	public static final String IMAGE_VERSION = ":11.5.7.0";
 
 	public static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -82,7 +84,8 @@ class DB2Database implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	static final Db2Container db2 = new Db2Container( IMAGE_NAME )
+	static final Db2Container db2 = new Db2Container(
+			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
@@ -39,7 +39,8 @@ import org.testcontainers.containers.MSSQLServerContainer;
  */
 class MSSQLServerDatabase implements TestableDatabase {
 
-	public static final String IMAGE_NAME = "mcr.microsoft.com/mssql/server:2019-latest";
+	public static final String IMAGE_NAME = "mcr.microsoft.com/mssql/server";
+	public static final String IMAGE_VERSION = ":2019-latest";
 
 	public static final MSSQLServerDatabase INSTANCE = new MSSQLServerDatabase();
 
@@ -91,7 +92,7 @@ class MSSQLServerDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( IMAGE_NAME )
+	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( IMAGE_NAME + IMAGE_VERSION )
 			.acceptLicense()
 			.withPassword( PASSWORD )
 			.withReuse( true );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
@@ -9,7 +9,8 @@ class MariaDatabase extends MySQLDatabase {
 
 	static MariaDatabase INSTANCE = new MariaDatabase();
 
-	public final static String IMAGE_NAME = "docker.io/mariadb:10.7.1";
+	public static final String IMAGE_NAME = "mariadb";
+	public static final String IMAGE_VERSION = ":10.7.1";
 
 	/**
 	 * Holds configuration for the MariaDB database container. If the build is run with <code>-Pdocker</code> then
@@ -18,7 +19,7 @@ class MariaDatabase extends MySQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final VertxMariaContainer maria = new VertxMariaContainer( IMAGE_NAME )
+	public static final VertxMariaContainer maria = new VertxMariaContainer( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -32,7 +32,8 @@ class MySQLDatabase implements TestableDatabase {
 
 	static MySQLDatabase INSTANCE = new MySQLDatabase();
 
-	public final static String IMAGE_NAME = "mysql:8.0.28";
+	public final static String IMAGE_NAME = "mysql";
+	public static final String IMAGE_VERSION = ":8.0.28";
 
 	private static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -80,7 +81,7 @@ class MySQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final VertxMySqlContainer mysql = new VertxMySqlContainer( IMAGE_NAME )
+	public static final VertxMySqlContainer mysql = new VertxMySqlContainer( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
@@ -29,6 +29,7 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.OracleContainer;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Connection string for Oracle thin should be something like:
@@ -37,7 +38,8 @@ import org.testcontainers.containers.OracleContainer;
  */
 class OracleDatabase implements TestableDatabase {
 
-	public static final String IMAGE_NAME = "gvenzl/oracle-xe:21.3.0-slim";
+	public static final String IMAGE_NAME = "gvenzl/oracle-xe";
+	public static final String IMAGE_VERSION = ":21.3.0-slim";
 
 	public static final OracleDatabase INSTANCE = new OracleDatabase();
 
@@ -82,7 +84,8 @@ class OracleDatabase implements TestableDatabase {
 		}
 	}
 
-	public static final OracleContainer oracle = new OracleContainer( IMAGE_NAME )
+	public static final OracleContainer oracle = new OracleContainer(
+			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
@@ -175,7 +178,7 @@ class OracleDatabase implements TestableDatabase {
 		if ( uri.startsWith( "jdbc:" ) ) {
 			jdbcUrl.substring( "jdbc:".length() );
 		}
-		uri = uri.replace( "thin:@", "thin:" + getCredentials() + "@");
+		uri = uri.replace( "thin:@", "thin:" + getCredentials() + "@" );
 		return uri;
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -29,12 +29,14 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.utility.DockerImageName;
 
 class PostgreSQLDatabase implements TestableDatabase {
 
 	public static PostgreSQLDatabase INSTANCE = new PostgreSQLDatabase();
 
-	public final static String IMAGE_NAME = "postgres:14.2";
+	public static final String IMAGE_NAME = "postgres";
+	public static final String IMAGE_VERSION = ":14.2";
 
 	private static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -82,7 +84,8 @@ class PostgreSQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>( IMAGE_NAME )
+	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>(
+			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
@@ -14,6 +14,8 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
  */
 public interface TestableDatabase {
 
+	String DOCKER_REPOSITORY = "docker.io/";
+
 	String getJdbcUrl();
 
 	String getUri();

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
@@ -16,6 +16,7 @@ import org.testcontainers.containers.MySQLContainer;
 import io.vertx.core.AsyncResult;
 import io.vertx.mysqlclient.MySQLPool;
 import io.vertx.sqlclient.SqlConnection;
+import org.testcontainers.utility.DockerImageName;
 
 /**
  * Normally the {@link MySQLContainer} checks for readiness by attempting to establish a JDBC connection
@@ -27,7 +28,7 @@ import io.vertx.sqlclient.SqlConnection;
 class VertxMySqlContainer extends MySQLContainer<VertxMySqlContainer> {
 
 	public VertxMySqlContainer(String dockerImageName) {
-		super( dockerImageName );
+		super( DockerImageName.parse( dockerImageName ).asCompatibleSubstituteFor( "mysql" )  );
 	}
 
 	@Override


### PR DESCRIPTION
see #1235 

Tweaked remaining test DB containers to default to `docker.io/` prefix