### PR TITLE
Refactoring of the code that starts the containers for testing

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/CockroachDBDatabase.java
@@ -9,16 +9,13 @@ import org.hibernate.HibernateException;
 
 import org.testcontainers.containers.CockroachContainer;
 import org.testcontainers.containers.Container;
-import org.testcontainers.utility.DockerImageName;
 
+import static org.hibernate.reactive.containers.DockerImage.imageName;
 import static org.testcontainers.shaded.org.apache.commons.lang.StringUtils.isNotBlank;
 
 class CockroachDBDatabase extends PostgreSQLDatabase {
 
 	public static CockroachDBDatabase INSTANCE = new CockroachDBDatabase();
-
-	public static final String IMAGE_NAME = "cockroachdb/cockroach";
-	public static final String IMAGE_VERSION = ":v21.2.4";
 
 	/**
 	 * Holds configuration for the CockroachDB database container. If the build is run with <code>-Pdocker</code> then
@@ -27,8 +24,7 @@ class CockroachDBDatabase extends PostgreSQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final CockroachContainer cockroachDb = new CockroachContainer(
-			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
+	public static final CockroachContainer cockroachDb = new CockroachContainer( imageName( "cockroachdb/cockroach", "v21.2.4" ) )
 			// Username, password and database are not supported by test container at the moment
 			// Testcontainers will use a database named 'postgres' and the 'root' user
 			.withReuse( true );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -29,14 +29,12 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.Db2Container;
-import org.testcontainers.utility.DockerImageName;
+
+import static org.hibernate.reactive.containers.DockerImage.imageName;
 
 class DB2Database implements TestableDatabase {
 
 	public static DB2Database INSTANCE = new DB2Database();
-
-	public static final String IMAGE_NAME = "ibmcom/db2";
-	public static final String IMAGE_VERSION = ":11.5.7.0";
 
 	public static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -84,8 +82,7 @@ class DB2Database implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	static final Db2Container db2 = new Db2Container(
-			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
+	static final Db2Container db2 = new Db2Container( imageName( "ibmcom/db2", "11.5.7.0" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DockerImage.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DockerImage.java
@@ -1,0 +1,31 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.containers;
+
+import org.testcontainers.utility.DockerImageName;
+
+/**
+ * A utility class with methods to generate {@link DockerImageName} for testcontainers.
+ * <p>
+ * Testcontainers might not work if the image required is available in multiple different registries (for example when
+ * using podman instead of docker).
+ * These methods make sure to pick a registry as default.
+ * </p>
+ */
+public final class DockerImage {
+
+	public static final String DEFAULT_REGISTRY = "docker.io";
+
+	public static DockerImageName imageName(String image, String version) {
+		return imageName( DEFAULT_REGISTRY, image, version );
+	}
+
+	public static DockerImageName imageName(String registry, String image, String version) {
+		return DockerImageName
+				.parse( registry + "/" + image + ":" + version )
+				.asCompatibleSubstituteFor( image );
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
@@ -30,6 +30,8 @@ import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.MSSQLServerContainer;
 
+import static org.hibernate.reactive.containers.DockerImage.imageName;
+
 /**
  * The JDBC driver syntax is:
  *     jdbc:sqlserver://[serverName[\instanceName][:portNumber]][;property=value[;property=value]]
@@ -38,9 +40,6 @@ import org.testcontainers.containers.MSSQLServerContainer;
  *     sqlserver://[user[:[password]]@]host[:port][/database][?attribute1=value1&attribute2=value2…​]
  */
 class MSSQLServerDatabase implements TestableDatabase {
-
-	public static final String IMAGE_NAME = "mcr.microsoft.com/mssql/server";
-	public static final String IMAGE_VERSION = ":2019-latest";
 
 	public static final MSSQLServerDatabase INSTANCE = new MSSQLServerDatabase();
 
@@ -92,7 +91,7 @@ class MSSQLServerDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( IMAGE_NAME + IMAGE_VERSION )
+	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( imageName( "mcr.microsoft.com", "mssql/server", "2019-latest" ) )
 			.acceptLicense()
 			.withPassword( PASSWORD )
 			.withReuse( true );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
@@ -5,12 +5,12 @@
  */
 package org.hibernate.reactive.containers;
 
+
+import static org.hibernate.reactive.containers.DockerImage.imageName;
+
 class MariaDatabase extends MySQLDatabase {
 
 	static MariaDatabase INSTANCE = new MariaDatabase();
-
-	public static final String IMAGE_NAME = "mariadb";
-	public static final String IMAGE_VERSION = ":10.7.1";
 
 	/**
 	 * Holds configuration for the MariaDB database container. If the build is run with <code>-Pdocker</code> then
@@ -19,7 +19,7 @@ class MariaDatabase extends MySQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final VertxMariaContainer maria = new VertxMariaContainer( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION )
+	public static final VertxMariaContainer maria = new VertxMariaContainer( imageName( "mariadb", "10.7.1" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -28,12 +28,11 @@ import org.hibernate.type.TrueFalseType;
 import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
+import static org.hibernate.reactive.containers.DockerImage.imageName;
+
 class MySQLDatabase implements TestableDatabase {
 
 	static MySQLDatabase INSTANCE = new MySQLDatabase();
-
-	public final static String IMAGE_NAME = "mysql";
-	public static final String IMAGE_VERSION = ":8.0.28";
 
 	private static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -81,7 +80,7 @@ class MySQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final VertxMySqlContainer mysql = new VertxMySqlContainer( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION )
+	public static final VertxMySqlContainer mysql = new VertxMySqlContainer( imageName( "mysql", "8.0.28") )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
@@ -29,7 +29,8 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.OracleContainer;
-import org.testcontainers.utility.DockerImageName;
+
+import static org.hibernate.reactive.containers.DockerImage.imageName;
 
 /**
  * Connection string for Oracle thin should be something like:
@@ -37,9 +38,6 @@ import org.testcontainers.utility.DockerImageName;
  * jdbc:oracle:thin:[<user>/<password>]@<host>[:<port>][/<databaseName>]
  */
 class OracleDatabase implements TestableDatabase {
-
-	public static final String IMAGE_NAME = "gvenzl/oracle-xe";
-	public static final String IMAGE_VERSION = ":21.3.0-slim";
 
 	public static final OracleDatabase INSTANCE = new OracleDatabase();
 
@@ -84,8 +82,7 @@ class OracleDatabase implements TestableDatabase {
 		}
 	}
 
-	public static final OracleContainer oracle = new OracleContainer(
-			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
+	public static final OracleContainer oracle = new OracleContainer( imageName( "gvenzl/oracle-xe", "21.3.0-slim" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
@@ -87,7 +87,14 @@ class OracleDatabase implements TestableDatabase {
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )
 			.withLogConsumer( of -> System.out.println( of.getUtf8String() ) )
-			.withReuse( true );
+			.withReuse( true )
+
+			// We need to limit the maximum amount of CPUs being used by the container;
+			// otherwise the hardcoded memory configuration of the DB might not be enough to successfully boot it.
+			// See https://github.com/gvenzl/oci-oracle-xe/issues/64
+			// I choose to limit it to "2 cpus": should be more than enough for any local testing needs,
+			// and keeps things simple.
+			.withCreateContainerCmdModifier( cmd -> cmd.getHostConfig().withCpuCount( 2l ) );
 
 	@Override
 	public String getJdbcUrl() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -29,14 +29,12 @@ import org.hibernate.type.YesNoType;
 import org.hibernate.type.descriptor.java.PrimitiveByteArrayTypeDescriptor;
 
 import org.testcontainers.containers.PostgreSQLContainer;
-import org.testcontainers.utility.DockerImageName;
+
+import static org.hibernate.reactive.containers.DockerImage.imageName;
 
 class PostgreSQLDatabase implements TestableDatabase {
 
 	public static PostgreSQLDatabase INSTANCE = new PostgreSQLDatabase();
-
-	public static final String IMAGE_NAME = "postgres";
-	public static final String IMAGE_VERSION = ":14.2";
 
 	private static Map<Class<?>, String> expectedDBTypeForClass = new HashMap<>();
 
@@ -84,8 +82,7 @@ class PostgreSQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>(
-			DockerImageName.parse( DOCKER_REPOSITORY + IMAGE_NAME + IMAGE_VERSION ).asCompatibleSubstituteFor( IMAGE_NAME ) )
+	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>( imageName( "postgres", "14.2" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/TestableDatabase.java
@@ -14,13 +14,11 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
  */
 public interface TestableDatabase {
 
-	String DOCKER_REPOSITORY = "docker.io/";
-
 	String getJdbcUrl();
 
 	String getUri();
 
-	/**
+ 	/**
 	 * @return the database scheme for the connection. Example: {@code mysql:}
 	 */
 	default String getScheme() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMariaContainer.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMariaContainer.java
@@ -26,8 +26,8 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 class VertxMariaContainer extends MariaDBContainer<VertxMariaContainer> {
 
-	public VertxMariaContainer(String dockerImageName) {
-		super( DockerImageName.parse( dockerImageName ).asCompatibleSubstituteFor( "mariadb" ) );
+	public VertxMariaContainer(DockerImageName dockerImageName) {
+		super( dockerImageName );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/VertxMySqlContainer.java
@@ -27,8 +27,8 @@ import org.testcontainers.utility.DockerImageName;
  */
 class VertxMySqlContainer extends MySQLContainer<VertxMySqlContainer> {
 
-	public VertxMySqlContainer(String dockerImageName) {
-		super( DockerImageName.parse( dockerImageName ).asCompatibleSubstituteFor( "mysql" )  );
+	public VertxMySqlContainer(DockerImageName dockerImageName) {
+		super( dockerImageName );
 	}
 
 	@Override


### PR DESCRIPTION
@Sanne I've tested this code with a fresh Fedora installation and only using Podman. It seems to work fine for me, except Db2 that starts but doesn't seem to work with Podman. But I think this is a known issue.
