### PR TITLE
Cleanup async iterators

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
@@ -318,7 +318,7 @@ public interface AsyncIterator<T> extends AsyncCloseable {
 	 */
 	default <U> AsyncIterator<U> thenCompose(
 			final Function<? super T, ? extends CompletionStage<U>> fn) {
-		return AsyncIterators.thenComposeImpl( this, fn, true, null );
+		return AsyncIterators.thenComposeImpl( this, fn, true );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
@@ -292,7 +292,7 @@ public interface AsyncIterator<T> extends AsyncCloseable {
 	 * from {@code this} iterator
 	 */
 	default <U> AsyncIterator<U> thenApply(final Function<? super T, ? extends U> fn) {
-		return AsyncIterators.thenApplyImpl( this, fn, true, null );
+		return AsyncIterators.thenApplyImpl( this, fn, true );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
@@ -292,7 +292,7 @@ public interface AsyncIterator<T> extends AsyncCloseable {
 	 * from {@code this} iterator
 	 */
 	default <U> AsyncIterator<U> thenApply(final Function<? super T, ? extends U> fn) {
-		return AsyncIterators.thenApplyImpl( this, fn, true );
+		return AsyncIterators.thenApplyImpl( this, fn );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterator.java
@@ -318,7 +318,7 @@ public interface AsyncIterator<T> extends AsyncCloseable {
 	 */
 	default <U> AsyncIterator<U> thenCompose(
 			final Function<? super T, ? extends CompletionStage<U>> fn) {
-		return AsyncIterators.thenComposeImpl( this, fn, true );
+		return AsyncIterators.thenComposeImpl( this, fn );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
@@ -90,9 +90,7 @@ class AsyncIterators {
 	static <T, U> AsyncIterator<U> thenComposeImpl(
 			final AsyncIterator<T> it,
 			final Function<? super T, ? extends CompletionStage<U>> f,
-			final boolean synchronous,
-			final Executor e) {
-		assert !synchronous || e == null;
+			final boolean synchronous) {
 
 		return new AsyncIterator<U>() {
 			@Override
@@ -100,9 +98,7 @@ class AsyncIterators {
 				final CompletionStage<Either<End, T>> nxt = it.nextStage();
 				return synchronous
 						? nxt.thenCompose( this::eitherFunction )
-						: e == null
-						? nxt.thenComposeAsync( this::eitherFunction )
-						: nxt.thenComposeAsync( this::eitherFunction, e );
+						: nxt.thenComposeAsync( this::eitherFunction );
 			}
 
 			/*

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
@@ -89,16 +89,13 @@ class AsyncIterators {
 
 	static <T, U> AsyncIterator<U> thenComposeImpl(
 			final AsyncIterator<T> it,
-			final Function<? super T, ? extends CompletionStage<U>> f,
-			final boolean synchronous) {
+			final Function<? super T, ? extends CompletionStage<U>> f) {
 
 		return new AsyncIterator<U>() {
 			@Override
 			public CompletionStage<Either<End, U>> nextStage() {
 				final CompletionStage<Either<End, T>> nxt = it.nextStage();
-				return synchronous
-						? nxt.thenCompose( this::eitherFunction )
-						: nxt.thenComposeAsync( this::eitherFunction );
+				return nxt.thenCompose( this::eitherFunction );
 			}
 
 			/*

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
@@ -61,9 +61,7 @@ class AsyncIterators {
 	static <T, U> AsyncIterator<U> thenApplyImpl(
 			final AsyncIterator<T> it,
 			final Function<? super T, ? extends U> f,
-			final boolean synchronous,
-			final Executor e) {
-		assert !synchronous || e == null;
+			final boolean synchronous) {
 		return new AsyncIterator<U>() {
 			@Override
 			public CompletionStage<Either<End, U>> nextStage() {
@@ -71,9 +69,7 @@ class AsyncIterators {
 
 				return synchronous
 						? next.thenApply( this::eitherFunction )
-						: e == null
-						? next.thenApplyAsync( this::eitherFunction )
-						: next.thenApplyAsync( this::eitherFunction, e );
+						: next.thenApplyAsync( this::eitherFunction );
 			}
 
 			Either<End, U> eitherFunction(final Either<End, T> either) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncIterators.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.util.async.impl;
 
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.Executor;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
@@ -60,16 +59,13 @@ class AsyncIterators {
 
 	static <T, U> AsyncIterator<U> thenApplyImpl(
 			final AsyncIterator<T> it,
-			final Function<? super T, ? extends U> f,
-			final boolean synchronous) {
+			final Function<? super T, ? extends U> f) {
 		return new AsyncIterator<U>() {
 			@Override
 			public CompletionStage<Either<End, U>> nextStage() {
 				final CompletionStage<Either<End, T>> next = it.nextStage();
 
-				return synchronous
-						? next.thenApply( this::eitherFunction )
-						: next.thenApplyAsync( this::eitherFunction );
+				return next.thenApply( this::eitherFunction );
 			}
 
 			Either<End, U> eitherFunction(final Either<End, T> either) {


### PR DESCRIPTION
Since it's hard to deal correctly with "thenComposeAsync" operations w/o violating our threading assumptions, I'm going to remove some instances in which we use these.

In particular I found some dead code here; seems these can be trivially deleted.