### PR TITLE
WIP Async fixes

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/OneOffDelegatingExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/OneOffDelegatingExecutor.java
@@ -1,0 +1,50 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.context.impl;
+
+import java.util.Objects;
+import java.util.concurrent.Executor;
+
+/**
+ * When a CompletableFuture needs to be executed asynchronously
+ * via e.g. CompletableFuture.supplyAsync or .thenApplyAsync(task, Executor)
+ * one needs to be careful that subsequent stages aren't guaranteed to be run
+ * on the same executor, as execution is scheduled immediately, and
+ * there's a change for the task to be completed before the chain
+ * of downstream events has been enqueued.
+ * The simplest solution for this is to ensure the chain is fully defined
+ * before passing it to the Executor; sometimes this requires substantial
+ * refactoring, in which case this helper class can be useful:
+ * this Executor implementation delegates to an underlying Executor, but
+ * holds the single task until it's ready to be fired via {@link #runHeldTasks()}.
+ *
+ * This instance is to be used once, essentially to decorate a single use of
+ * asynchronous scheduling of a CompletableFuture, and is not threadsafe.
+ */
+public final class OneOffDelegatingExecutor implements Executor {
+	private final Executor delegateExecutor;
+	private Runnable deferredTask;
+
+	OneOffDelegatingExecutor(Executor delegate) {
+		Objects.requireNonNull(delegate);
+		this.delegateExecutor = delegate;
+	}
+
+	@Override
+	public void execute(Runnable runnable) {
+		Objects.requireNonNull(runnable);
+		this.deferredTask = runnable;
+	}
+
+	public void runHeldTasks() {
+		if ( this.deferredTask != null )
+			this.delegateExecutor.execute( this.deferredTask );
+		else {
+			throw new IllegalStateException( "No task has been scheduled yet" );
+		}
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionFactoryImpl.java
@@ -60,7 +60,7 @@ public class StageSessionFactoryImpl implements Stage.SessionFactory, Implemento
 	}
 
 	<T> CompletionStage<T> stage(Function<Void, CompletionStage<T>> stageSupplier) {
-		return voidFuture().thenComposeAsync( stageSupplier, context );
+		return voidFuture().thenCompose( stageSupplier );
 	}
 
 	@Override


### PR DESCRIPTION
This is another component to work towards a fix for #1276

It should be enough to fix the problem, BUT all users would be required to run every operation on the vertx thread. This is too unconvenient, so we'll also work on a follow up with the `OneOffDelegatingExecutor` (introduced here) to at least keep running a selected set of tasks in the deferred executor.

cc/ @DavideD 