### PR TITLE
Enable tests for MSSQL and Oracle

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,3 +250,4 @@ At present several minor limitations remain.
   supported.
 - With Db2:
   * [Automatic schema](http://hibernate.org/reactive/documentation/1.1/reference/html_single/#_automatic_schema_export) update and validation is not supported.
+  * `@Lob` annotation is not supported - See [this issue on the vertx-db2-client](https://github.com/eclipse-vertx/vertx-sql-client/issues/496)

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UUIDGeneratorTest.java
@@ -26,8 +26,8 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.*;
 
 public class UUIDGeneratorTest extends BaseReactiveTest {
 
-	@Rule // Storing UUID doesn't work with DB2, Searching a UUID doesn't work for Oracle
-	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2, ORACLE );
+	@Rule // Storing UUID doesn't work with DB2
+	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LobTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/LobTypeTest.java
@@ -26,7 +26,6 @@ import org.junit.Test;
 import io.vertx.ext.unit.TestContext;
 
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
-import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
 
 /**
  * Test types that we expect to work only on selected DBs.
@@ -34,7 +33,7 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQL
 public class LobTypeTest extends BaseReactiveTest {
 
 	@Rule
-	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2, SQLSERVER );
+	public DatabaseSelectionRule selectionRule = DatabaseSelectionRule.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {


### PR DESCRIPTION
The latest Vert.x SQL client solves a couple of issues:
* Searching the UUID in Oracle
* Storing `@Lob` for MSSQL

I've also updated the limitations for Db2 (`@Lob` doesn't work)