### PR TITLE
override clear() to clear reactiveActionQueue

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -1600,6 +1600,13 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 					}
 				});
 	}
+	
+	
+	@Override
+	public void clear() {
+		super.clear();
+		this.reactiveActionQueue.clear();
+	}
 
 	private void logRemoveOrphanBeforeUpdates(String timing, String entityName, Object entity,  StatefulPersistenceContext persistenceContext) {
 		if ( log.isTraceEnabled() ) {


### PR DESCRIPTION
[hibernate#1362](https://github.com/hibernate/hibernate-reactive/issues/1362) Override clear() to clear reactiveActionQueue