### PR TITLE
Lazy field

### DIFF
--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Book.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Book.java
@@ -35,6 +35,9 @@ class Book {
 	@NotNull @Past
 	private LocalDate published;
 
+	@Basic(fetch = LAZY)
+	public byte[] coverImage;
+
 	@NotNull
 	@ManyToOne(fetch = LAZY)
 	private Author author;
@@ -44,6 +47,7 @@ class Book {
 		this.isbn = isbn;
 		this.author = author;
 		this.published = published;
+		this.coverImage = ("Cover image for '" + title + "'").getBytes();
 	}
 
 	Book() {}
@@ -66,5 +70,9 @@ class Book {
 
 	LocalDate getPublished() {
 		return published;
+	}
+
+	byte[] getCoverImage() {
+		return coverImage;
 	}
 }

--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/MutinyMain.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/MutinyMain.java
@@ -147,15 +147,19 @@ public class MutinyMain {
 					// retrieve a Book
 					session -> session.find( Book.class, book1.getId() )
 							// fetch a lazy field of the Book
-							.chain( book -> session.fetch( book, Book_.published )
-									// print the lazy field
+							.call( book -> session.fetch( book, Book_.published )
+									// print one lazy field
 									.invoke( published -> out.printf(
 											"'%s' was published in %d\n",
 											book.getTitle(),
 											published.getYear()
 									) )
 							)
-			)
+							.call( book -> session.fetch( book, Book_.coverImage )
+									// print the other lazy field
+									.invoke( coverImage -> out.println( new String( coverImage ) ) )
+							)
+					)
 					.await().indefinitely();
 
 			factory.withTransaction(


### PR DESCRIPTION
Fix #1386 
I've followed [the approach used by Hibernate ORM](https://github.com/hibernate/hibernate-orm/blob/1350c713a3c271d869d05fdf9e28fe2e57a4e25f/hibernate-core/src/main/java/org/hibernate/persister/entity/AbstractEntityPersister.java#L1267).

If I'm not mistaken, we are loading all the lazy properties as soon as we load the first one. Is this the correct behaviour?
Shouldn't we just load the lazy field required by the user?