### PR TITLE
Upgrade db versions for testing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
           - 3306:3306
       postgres:
         # Docker Hub image
-        image: postgres:14.2
+        image: postgres:15.0
         env:
           POSTGRES_DB: hreact
           POSTGRES_USER: hreact

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
        # Label used to access the service container
       mysql:
         # Docker Hub image
-        image: mysql:8.0.28
+        image: mysql:8.0.31
         env:
           MYSQL_ROOT_PASSWORD: hreact
           MYSQL_DATABASE: hreact

--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -59,7 +59,7 @@ jobs:
           - 3306:3306
       postgres:
         # Docker Hub image
-        image: postgres:14.2
+        image: postgres:15.0
         env:
           POSTGRES_DB: hreact
           POSTGRES_USER: hreact

--- a/.github/workflows/tracking-orm-5.build.yml
+++ b/.github/workflows/tracking-orm-5.build.yml
@@ -43,7 +43,7 @@ jobs:
       # Label used to access the service container
       mysql:
         # Docker Hub image
-        image: mysql:8.0.28
+        image: mysql:8.0.31
         env:
           MYSQL_ROOT_PASSWORD: hreact
           MYSQL_DATABASE: hreact

--- a/.github/workflows/tracking-vertx-4.build.yml
+++ b/.github/workflows/tracking-vertx-4.build.yml
@@ -57,7 +57,7 @@ jobs:
           - 3306:3306
       postgres:
         # Docker Hub image
-        image: postgres:14.2
+        image: postgres:15.0
         env:
           POSTGRES_DB: hreact
           POSTGRES_USER: hreact

--- a/.github/workflows/tracking-vertx-4.build.yml
+++ b/.github/workflows/tracking-vertx-4.build.yml
@@ -41,7 +41,7 @@ jobs:
       # Label used to access the service container
       mysql:
         # Docker Hub image
-        image: mysql:8.0.28
+        image: mysql:8.0.31
         env:
           MYSQL_ROOT_PASSWORD: hreact
           MYSQL_DATABASE: hreact

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Learn more at <http://hibernate.org/reactive>.
 Hibernate Reactive has been tested with:
 
 - Java 11, 17
-- PostgreSQL 14
+- PostgreSQL 15
 - MySQL 8
 - MariaDB 10
 - Db2 11.5

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Learn more at <http://hibernate.org/reactive>.
 
 Hibernate Reactive has been tested with:
 
-- Java 11, 17
+- Java 11, 17, 18
 - PostgreSQL 15
 - MySQL 8
 - MariaDB 10

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -51,7 +51,7 @@ dependencies {
     testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.0.7";
 
     // JDBC driver for Testcontainers with MYSQL Server
-    testRuntimeOnly "mysql:mysql-connector-java:8.0.28";
+    testRuntimeOnly "com.mysql:mysql-connector-j:8.0.31";
 
     // EHCache
     testRuntimeOnly "org.ehcache:ehcache:3.10.0"

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     testImplementation 'com.ongres.scram:client:2.1'
 
     // JDBC driver to test with ORM and PostgreSQL
-    testRuntimeOnly "org.postgresql:postgresql:42.4.1"
+    testRuntimeOnly "org.postgresql:postgresql:42.5.0"
 
     // JDBC driver for Testcontainers with MS SQL Server
     testRuntimeOnly "com.microsoft.sqlserver:mssql-jdbc:10.2.1.jre11"

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
@@ -91,7 +91,7 @@ class MSSQLServerDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( imageName( "mcr.microsoft.com", "mssql/server", "2019-latest" ) )
+	public static final MSSQLServerContainer<?> mssqlserver = new MSSQLServerContainer<>( imageName( "mcr.microsoft.com", "mssql/server", "2022-latest" ) )
 			.acceptLicense()
 			.withPassword( PASSWORD )
 			.withReuse( true );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MariaDatabase.java
@@ -21,7 +21,7 @@ class MariaDatabase extends MySQLDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MariaDBContainer<?> maria = new MariaDBContainer<>( imageName( "mariadb", "10.8.3" ) )
+	public static final MariaDBContainer<?> maria = new MariaDBContainer<>( imageName( "mariadb", "10.9.3" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -82,7 +82,7 @@ class MySQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MySQLContainer<?> mysql = new MySQLContainer<>( imageName( "mysql", "8.0.30") )
+	public static final MySQLContainer<?> mysql = new MySQLContainer<>( imageName( "mysql", "8.0.31") )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/integration-tests/verticle-postgres-it/src/main/java/org/hibernate/reactive/it/verticle/StartVerticle.java
+++ b/integration-tests/verticle-postgres-it/src/main/java/org/hibernate/reactive/it/verticle/StartVerticle.java
@@ -33,7 +33,7 @@ public class StartVerticle {
 	// These properties are in DatabaseConfiguration in core
 	public static final boolean USE_DOCKER = Boolean.getBoolean( "docker" );
 
-	public static final String IMAGE_NAME = "postgres:14.3";
+	public static final String IMAGE_NAME = "postgres:15.0";
 	public static final String USERNAME = "hreact";
 	public static final String PASSWORD = "hreact";
 	public static final String DB_NAME = "hreact";

--- a/podman.md
+++ b/podman.md
@@ -93,7 +93,7 @@ and schema to run the tests:
 ```
 podman run --rm --name HibernateTestingMySQL \
     -e MYSQL_ROOT_PASSWORD=hreact -e MYSQL_DATABASE=hreact -e MYSQL_USER=hreact -e MYSQL_PASSWORD=hreact \
-    -p 3306:3306 mysql:8.0.28
+    -p 3306:3306 mysql:8.0.31
 ```
 
 When the database has started, you can run the tests on MySQL with:

--- a/podman.md
+++ b/podman.md
@@ -66,7 +66,7 @@ and schema to run the tests:
 ```
 podman run --rm --name HibernateTestingMariaDB \
     -e MYSQL_ROOT_PASSWORD=hreact -e MYSQL_DATABASE=hreact -e MYSQL_USER=hreact -e MYSQL_PASSWORD=hreact \
-    -p 3306:3306 mariadb:10.7.3
+    -p 3306:3306 mariadb:10.9.3
 ```
 
 When the database has started, you can run the tests on MariaDB with:

--- a/podman.md
+++ b/podman.md
@@ -38,7 +38,7 @@ required credentials and schema to run the tests:
 ```
 podman run --rm --name HibernateTestingPGSQL \
     -e POSTGRES_USER=hreact -e POSTGRES_PASSWORD=hreact -e POSTGRES_DB=hreact \
-    -p 5432:5432 postgres:14.3
+    -p 5432:5432 postgres:15.0
 ```
 
 When the database has started, you can run the tests on PostgreSQL with:

--- a/podman.md
+++ b/podman.md
@@ -181,7 +181,7 @@ and schema to run the tests:
 [mssql]:https://www.microsoft.com/en-gb/sql-server/
 
 ```
-podman run --rm -it --name HibernateTestingMSSQL -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=~!HReact!~' -p 1433:1433 mcr.microsoft.com/mssql/server:2019-latest
+podman run --rm -it --name HibernateTestingMSSQL -e 'ACCEPT_EULA=Y' -e 'SA_PASSWORD=~!HReact!~' -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
 ```
 
 When the database has started, you can run the tests on MS SQL Server with:

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -15,7 +15,7 @@
 
 //// Testcontainer needs the JDBC drivers to start the container
 //// Hibernate Reactive doesn't need it
-//DEPS org.postgresql:postgresql:42.4.0
+//DEPS org.postgresql:postgresql:42.5.0
 
 import java.io.IOException;
 import javax.persistence.Entity;

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -69,7 +69,7 @@ public class {baseName} {
 	}
 
     @ClassRule
-    public final static MariaDBContainer<?> database = new MariaDBContainer<>( imageName( "docker.io", "mariadb", "10.7.3" ) );
+    public final static MariaDBContainer<?> database = new MariaDBContainer<>( imageName( "docker.io", "mariadb", "10.9.3" ) );
 
 	private Mutiny.SessionFactory sessionFactory;
 

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -15,7 +15,7 @@
 
 //// Testcontainer needs the JDBC drivers to start the container
 //// Hibernate Reactive doesn't need it
-//DEPS mysql:mysql-connector-java:8.0.28
+//DEPS com.mysql:mysql-connector-j:8.0.31
 
 import javax.persistence.Entity;
 import javax.persistence.Id;
@@ -72,7 +72,7 @@ public class {baseName} {
 	}
 
     @ClassRule
-    public final static MySQLContainer<?> database = new MySQLContainer<>( imageName( "docker.io", "mysql", "8.0.28" ) );
+    public final static MySQLContainer<?> database = new MySQLContainer<>( imageName( "docker.io", "mysql", "8.0.31" ) );
 
 	private Mutiny.SessionFactory sessionFactory;
 

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -67,7 +67,7 @@ public class {baseName} {
 	}
 
     @ClassRule
-    public final static PostgreSQLContainer database = new PostgreSQLContainer( imageName( "docker.io", "postgres", "14" ) );
+    public final static PostgreSQLContainer database = new PostgreSQLContainer( imageName( "docker.io", "postgres", "15.0" ) );
 
 	private Mutiny.SessionFactory sessionFactory;
 

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -22,7 +22,7 @@
 //// Testcontainer needs the JDBC drivers to start the containers
 //// Hibernate Reactive doesn't use them
 //DEPS org.postgresql:postgresql:42.5.0
-//DEPS mysql:mysql-connector-java:8.0.28
+//DEPS com.mysql:mysql-connector-j:8.0.31
 //DEPS org.mariadb.jdbc:mariadb-java-client:2.7.3
 //
 
@@ -229,7 +229,7 @@ public class ReactiveTest {
 	 */
 	enum Database {
 		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:14" ) ),
-		MYSQL( () -> new MySQLContainer( "mysql:8.0.28" ) ),
+		MYSQL( () -> new MySQLContainer( "mysql:8.0.31" ) ),
 		DB2( () -> new Db2Container( "docker.io/ibmcom/db2:11.5.7.0a" ).acceptLicense() ),
 		MARIADB( () -> new MariaDBContainer( "mariadb:10.9.3" ) ),
 		COCKROACHDB( () -> new CockroachContainer( "cockroachdb/cockroach:v21.2.4" ) );

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -21,7 +21,7 @@
 //
 //// Testcontainer needs the JDBC drivers to start the containers
 //// Hibernate Reactive doesn't use them
-//DEPS org.postgresql:postgresql:42.4.0
+//DEPS org.postgresql:postgresql:42.5.0
 //DEPS mysql:mysql-connector-java:8.0.28
 //DEPS org.mariadb.jdbc:mariadb-java-client:2.7.3
 //

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -231,7 +231,7 @@ public class ReactiveTest {
 		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:14" ) ),
 		MYSQL( () -> new MySQLContainer( "mysql:8.0.28" ) ),
 		DB2( () -> new Db2Container( "docker.io/ibmcom/db2:11.5.7.0a" ).acceptLicense() ),
-		MARIADB( () -> new MariaDBContainer( "mariadb:10.7.3" ) ),
+		MARIADB( () -> new MariaDBContainer( "mariadb:10.9.3" ) ),
 		COCKROACHDB( () -> new CockroachContainer( "cockroachdb/cockroach:v21.2.4" ) );
 
 		private final Supplier<JdbcDatabaseContainer<?>> containerSupplier;


### PR DESCRIPTION
Fix #1406 

~~This is a draft because I'm waiting for the latest mysql connector to be available on Maven central~~
Nevermind, the problem was that the GAV for the connector have changed: https://dev.mysql.com/doc/relnotes/connector-j/8.0/en/news-8-0-31.html

@Sanne Could you have a quick look and let me know if it's better if we test with different versions, please? Thanks