### PR TITLE
Fix lazy one to one with bytecode enhancements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ import java.util.regex.Pattern
 plugins {
     id 'java-library'
     id 'maven-publish'
-    id 'com.diffplug.spotless' version '6.1.2'
+    id 'com.diffplug.spotless' version '6.11.0'
     id 'nu.studer.credentials' version '2.1'
     id 'org.asciidoctor.jvm.convert' version '3.3.2' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.1.0'

--- a/integration-tests/bytecode-enhancements-it/README.md
+++ b/integration-tests/bytecode-enhancements-it/README.md
@@ -1,0 +1,9 @@
+This module will test bytecode enhancements with PostgreSQL.
+
+It duplicates some code from the tests in hibernate-reactive-core and enable bytecode enhancements via
+the Hibernate gradle plugin.
+
+Note that it will only enhance the entity if the classes are in the /src/main/java folder.
+
+It's not an elegant solution, but it's better than not having test.
+As soon as we figure out a better way, we will replace this module.

--- a/integration-tests/bytecode-enhancements-it/build.gradle
+++ b/integration-tests/bytecode-enhancements-it/build.gradle
@@ -1,0 +1,129 @@
+description = 'Bytecode enhancements integration tests'
+
+ext {
+    log4jVersion = '2.17.2'
+    assertjVersion = '3.22.0'
+}
+
+dependencies {
+    implementation project(':hibernate-reactive-core')
+
+    // JPA metamodel generation for criteria queries (optional)
+    annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernateOrmVersion}"
+
+    // Testing on one database should be enough
+    runtimeOnly "io.vertx:vertx-pg-client:${vertxVersion}"
+    // Allow authentication to PostgreSQL using SCRAM:
+    runtimeOnly 'com.ongres.scram:client:2.1'
+
+    // logging
+    runtimeOnly "org.apache.logging.log4j:log4j-core:${log4jVersion}"
+
+    // Testcontainers
+    testImplementation "org.testcontainers:postgresql:${testcontainersVersion}"
+
+    // Testing
+    testImplementation "org.assertj:assertj-core:${assertjVersion}"
+    testImplementation "io.vertx:vertx-unit:${vertxVersion}"
+}
+
+buildscript {
+    repositories {
+        // Example: ./gradlew build -PenableMavenLocalRepo
+        if ( project.hasProperty('enableMavenLocalRepo') ) {
+            // Useful for local development, it should be disabled otherwise
+            mavenLocal()
+        }
+
+        mavenCentral()
+
+        // Example: ./gradlew build -PenableJBossSnapshotsRep
+        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+            // Used only for testing with the latest Hibernate ORM snapshots.
+            maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
+        }
+    }
+    dependencies {
+        classpath "org.hibernate:hibernate-gradle-plugin:${hibernateOrmVersion}"
+    }
+}
+
+// Hibernate Gradle plugin to enable bytecode enhancements
+apply plugin: 'org.hibernate.orm'
+
+hibernate {
+    enhance {
+        enableLazyInitialization = true
+        enableDirtyTracking = true
+        enableAssociationManagement = false
+    }
+}
+
+// Print a summary of the results of the tests (number of failures, successes and skipped)
+// This is the same as the one in hibernate-reactive-core
+def loggingSummary(db, result, desc) {
+    if ( !desc.parent ) { // will match the outermost suite
+        def output = "${db} results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+        def repeatLength = output.length() + 1
+        logger.lifecycle '\n' + ('-' * repeatLength) + '\n' + output + '\n' + ('-' * repeatLength)
+    }
+}
+
+// Configuration for the tests
+// This is the same as the one in hibernate-reactive-core
+tasks.withType(Test) {
+    defaultCharacterEncoding = "UTF-8"
+    testLogging {
+        displayGranularity 1
+        showStandardStreams = project.hasProperty('showStandardOutput')
+        showStackTraces = true
+        exceptionFormat = 'full'
+        events 'PASSED', 'FAILED', 'SKIPPED'
+    }
+    systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
+    systemProperty 'org.hibernate.reactive.common.InternalStateAssertions.ENFORCE', 'true'
+
+    if ( project.hasProperty( 'includeTests' ) ) {
+        // Example: ./gradlew testAll -PincludeTests=DefaultPortTest
+        filter {
+            includeTestsMatching project.getProperty( 'includeTests' ) ?: '*'
+        }
+    }
+}
+
+test {
+    def selectedDb = project.hasProperty( 'db' )
+            ? project.getProperty( 'db' )
+            : 'PostgreSQL'
+
+    // We only want to test this on Postgres
+    onlyIf { selectedDb.toLowerCase().startsWith( 'p' ) }
+    afterSuite { desc, result ->
+        loggingSummary( 'PostgreSQL', result, desc )
+    }
+    doFirst {
+        systemProperty 'db', selectedDb
+    }
+}
+
+// Rule to recognize calls to testDb<dbName>
+// and run the tests on the selected db
+// Example:
+// gradle testDbMySQL testDbDB2
+tasks.addRule( "Pattern testDb<id>" ) { String taskName ->
+    if ( taskName.startsWith( "testDb" ) ) {
+        task( type: Test, taskName ) {
+            def dbName = taskName.substring( "testDb".length() )
+            description = "Run tests for ${dbName}"
+
+            // We only want to test this on Postgres
+            onlyIf { dbName.toLowerCase().startsWith( 'p' ) }
+            afterSuite { desc, result ->
+                loggingSummary( dbName, result, desc )
+            }
+            doFirst() {
+                systemProperty 'db', dbName
+            }
+        }
+    }
+}

--- a/integration-tests/bytecode-enhancements-it/spotless.license.java
+++ b/integration-tests/bytecode-enhancements-it/spotless.license.java
@@ -1,0 +1,5 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */

--- a/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/Crew.java
+++ b/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/Crew.java
@@ -1,0 +1,63 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it;
+
+import javax.persistence.Basic;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+import static javax.persistence.FetchType.LAZY;
+
+@Entity
+public class Crew {
+	@Id
+	private Long id;
+
+	private String name;
+
+	@Basic(fetch = LAZY)
+	private String role;
+
+	@Basic(fetch = LAZY)
+	public String fate;
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getRole() {
+		return role;
+	}
+
+	public void setRole(String role) {
+		this.role = role;
+	}
+
+	public String getFate() {
+		return fate;
+	}
+
+	public void setFate(String fate) {
+		this.fate = fate;
+	}
+
+	@Override
+	public String toString() {
+		return id + ":" + name + ":" + role + ":" + fate;
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/lazytoone/Captain.java
+++ b/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/lazytoone/Captain.java
@@ -1,0 +1,79 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it.lazytoone;
+
+import java.util.Objects;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+@Entity(name = "Captain")
+@Table(name = "Captain")
+public class Captain {
+	@Id
+	@GeneratedValue
+	private Long id;
+	private String name;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	private Ship ship;
+
+	public Captain() {
+	}
+
+	public Captain(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Ship getShip() {
+		return ship;
+	}
+
+	public void setShip(Ship ship) {
+		this.ship = ship;
+	}
+
+	@Override
+	public String toString() {
+		return id + ":" + name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Captain captain = (Captain) o;
+		return Objects.equals( name, captain.name );
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash( name );
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/lazytoone/Ship.java
+++ b/integration-tests/bytecode-enhancements-it/src/main/java/org/hibernate/reactive/it/lazytoone/Ship.java
@@ -1,0 +1,99 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it.lazytoone;
+
+import java.util.Objects;
+import javax.persistence.Basic;
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.OneToOne;
+import javax.persistence.Table;
+
+import org.hibernate.annotations.LazyToOne;
+import org.hibernate.annotations.LazyToOneOption;
+
+@Entity(name = "Ship")
+@Table(name = "Ship")
+public class Ship {
+	@Id
+	@GeneratedValue
+	private Long id;
+
+	private String name;
+
+	@Basic(fetch = FetchType.LAZY)
+	private byte[] picture;
+
+	@LazyToOne(LazyToOneOption.NO_PROXY)
+	@OneToOne(fetch = FetchType.LAZY, mappedBy = "ship", cascade = CascadeType.ALL)
+	private Captain captain;
+
+	public Ship() {
+	}
+
+	public Ship(String name) {
+		this.name = name;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public void setId(Long id) {
+		this.id = id;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Captain getCaptain() {
+		return captain;
+	}
+
+	public void setCaptain(Captain captain) {
+		this.captain = captain;
+	}
+
+	public byte[] getPicture() {
+		return picture;
+	}
+
+	public void setPicture(byte[] picture) {
+		this.picture = picture;
+	}
+
+	@Override
+	public String toString() {
+		return id + ":" + name;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if ( this == o ) {
+			return true;
+		}
+		if ( o == null || getClass() != o.getClass() ) {
+			return false;
+		}
+		Ship ship = (Ship) o;
+		return Objects.equals( name, ship.name );
+	}
+
+	@Override
+	public int hashCode() {
+		int result = Objects.hash( name );
+		result = 31 * result;
+		return result;
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/BaseReactiveIT.java
+++ b/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/BaseReactiveIT.java
@@ -1,0 +1,285 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
+import javax.persistence.criteria.CriteriaQuery;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.registry.StandardServiceRegistry;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder;
+import org.hibernate.reactive.provider.Settings;
+import org.hibernate.reactive.stage.Stage;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.runner.RunWith;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.VertxOptions;
+import io.vertx.ext.unit.Async;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.RunTestOnContext;
+import io.vertx.ext.unit.junit.Timeout;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import org.testcontainers.containers.PostgreSQLContainer;
+
+import static org.hibernate.reactive.util.impl.CompletionStages.loop;
+import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
+
+/**
+ * Similar to BaseReactiveTest in the hibernate-reactive-core.
+ * Hopefully, one day we will reorganize the code better.
+ */
+@RunWith(VertxUnitRunner.class)
+public abstract class BaseReactiveIT {
+
+	// These properties are in DatabaseConfiguration in core
+	public static final boolean USE_DOCKER = Boolean.getBoolean( "docker" );
+
+	public static final String IMAGE_NAME = "postgres:15.0";
+	public static final String USERNAME = "hreact";
+	public static final String PASSWORD = "hreact";
+	public static final String DB_NAME = "hreact";
+
+	public static final PostgreSQLContainer<?> postgresql = new PostgreSQLContainer<>( IMAGE_NAME )
+			.withUsername( USERNAME )
+			.withPassword( PASSWORD )
+			.withDatabaseName( DB_NAME )
+			.withReuse( true );
+
+	@ClassRule
+	public static Timeout rule = Timeout.seconds( 10 * 60 );
+
+	private static SessionFactory ormSessionFactory;
+	@ClassRule
+	public static RunTestOnContext vertxContextRule = new RunTestOnContext( () -> {
+		VertxOptions options = new VertxOptions();
+		options.setBlockedThreadCheckInterval( 5 );
+		options.setBlockedThreadCheckIntervalUnit( TimeUnit.MINUTES );
+		return Vertx.vertx( options );
+	} );
+
+	/**
+	 * Configure properties defined in {@link Settings}.
+	 */
+	protected void setProperties(Configuration configuration) {
+		setDefaultProperties( configuration );
+	}
+
+	/**
+	 * Configure default properties common to most tests.
+	 */
+	public static void setDefaultProperties(Configuration configuration) {
+		configuration.setProperty( Settings.HBM2DDL_AUTO, "create" );
+		configuration.setProperty( Settings.URL, dbConnectionUrl( USE_DOCKER ) );
+		configuration.setProperty( Settings.USER, USERNAME );
+		configuration.setProperty( Settings.PASS, PASSWORD );
+
+		//Use JAVA_TOOL_OPTIONS='-Dhibernate.show_sql=true'
+		configuration.setProperty( Settings.SHOW_SQL, System.getProperty( Settings.SHOW_SQL, "true" ) );
+		configuration.setProperty( Settings.FORMAT_SQL, System.getProperty( Settings.FORMAT_SQL, "false" ) );
+		configuration.setProperty( Settings.HIGHLIGHT_SQL, System.getProperty( Settings.HIGHLIGHT_SQL, "true" ) );
+	}
+
+	private static String dbConnectionUrl(boolean enableDocker) {
+		if ( enableDocker ) {
+			// Calling start() will start the container (if not already started)
+			// It is required to call start() before obtaining the JDBC URL because it will contain a randomized port
+			postgresql.start();
+			return postgresql.getJdbcUrl();
+		}
+
+		// When we don't use testcontainers we expect a database on the default url
+		return "postgres://localhost:5432/" + DB_NAME;
+	}
+
+	protected static void test(TestContext context, CompletionStage<?> work) {
+		test( context.async(), context, work );
+	}
+
+	/**
+	 * These entities will be added to the configuration of the factory and
+	 * the rows in the mapping tables deleted after each test.
+	 * <p>
+	 * For more complicated configuration see {@link #constructConfiguration()}
+	 * or {@link #cleanDb()}.
+	 */
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of();
+	}
+
+	/**
+	 * XML mapping documents to be added to the configuration.
+	 */
+	protected Collection<String> mappings() {
+		return List.of();
+	}
+
+	/**
+	 * For when we need to create the {@link Async} in advance
+	 */
+	protected static void test(Async async, TestContext context, CompletionStage<?> work) {
+		work.whenComplete( (res, err) -> {
+			if ( err != null ) {
+				context.fail( err );
+			}
+			else {
+				async.complete();
+			}
+		} );
+	}
+
+	protected static void test(TestContext context, Uni<?> uni) {
+		test( context.async(), context, uni );
+	}
+
+	/**
+	 * For when we need to create the {@link Async} in advance
+	 */
+	public static void test(Async async, TestContext context, Uni<?> uni) {
+		uni.subscribe().with( res -> async.complete(), context::fail );
+	}
+
+	protected Configuration constructConfiguration() {
+		Configuration configuration = new Configuration();
+		addEntities( configuration );
+		setProperties( configuration );
+		return configuration;
+	}
+
+	protected void addEntities(Configuration configuration) {
+		for ( Class<?> entity: annotatedEntities() ) {
+			configuration.addAnnotatedClass( entity );
+		}
+		for ( String mapping: mappings() ) {
+			configuration.addResource( mapping );
+		}
+	}
+
+	public CompletionStage<Void> deleteEntities(Class<?>... entities) {
+		return getSessionFactory()
+				.withTransaction( s -> loop( entities, entityClass -> s
+						.createQuery( queryForDelete( entityClass ) )
+						.getResultList()
+						// This approach will also remove embedded collections and associated entities when possible
+						// (a `delete from` query will only remove the elements from one table)
+						.thenCompose( list -> s.remove( list.toArray( new Object[0] ) ) )
+				) );
+	}
+
+	private <T> CriteriaQuery<T> queryForDelete(Class<T> entityClass) {
+		final CriteriaQuery<T> query = getSessionFactory().getCriteriaBuilder().createQuery( entityClass );
+		query.from( entityClass );
+		return query;
+	}
+
+	@Before
+	public void before(TestContext context) {
+		test( context, setupSessionFactory( this::constructConfiguration ) );
+	}
+
+
+	/**
+	 * Set up one session factory shared by the tests in the class.
+	 */
+	protected CompletionStage<Void> setupSessionFactory(Configuration configuration) {
+		return setupSessionFactory( () -> configuration );
+	}
+
+	/**
+	 * Set up the session factory but create the configuration only if necessary.
+	 *
+	 * @param confSupplier supplies the configuration for the factory
+	 * @return a {@link CompletionStage} void that succeeds when the factory is ready.
+	 */
+	protected CompletionStage<Void> setupSessionFactory(Supplier<Configuration> confSupplier) {
+		CompletableFuture<Void> future = new CompletableFuture<>();
+		vertxContextRule.vertx()
+				.executeBlocking(
+						// schema generation is a blocking operation and so it causes an
+						// exception when run on the Vert.x event loop. So call it using
+						// Vertx.executeBlocking()
+						promise -> startFactoryManager( promise, confSupplier ),
+						event -> {
+							if ( event.succeeded() ) {
+								future.complete( null );
+							}
+							else {
+								future.completeExceptionally( event.cause() );
+							}
+						}
+				);
+		return future;
+	}
+
+	private void startFactoryManager(Promise<Object> p, Supplier<Configuration> confSupplier ) {
+		try {
+			ormSessionFactory = createHibernateSessionFactory( confSupplier.get() );
+			p.complete();
+		}
+		catch (Throwable e) {
+			p.fail( e );
+		}
+	}
+
+	private SessionFactory createHibernateSessionFactory(Configuration configuration) {
+		StandardServiceRegistryBuilder builder = new ReactiveServiceRegistryBuilder()
+				.applySettings( configuration.getProperties() );
+		addServices( builder );
+		StandardServiceRegistry registry = builder.build();
+		configureServices( registry );
+		return configuration.buildSessionFactory( registry );
+	}
+
+	protected void addServices(StandardServiceRegistryBuilder builder) {}
+
+	protected void configureServices(StandardServiceRegistry registry) {
+	}
+
+	@After
+	public void after(TestContext context) {
+		test( context, cleanDb() );
+	}
+
+	/**
+	 * Called after each test, remove all the entities defined in {@link #annotatedEntities()}
+	 */
+	protected CompletionStage<Void> cleanDb() {
+		final Collection<Class<?>> classes = annotatedEntities();
+		return classes.isEmpty()
+				? voidFuture()
+				: deleteEntities( classes.toArray( new Class<?>[0] ) );
+	}
+
+	@AfterClass
+	public static void closeFactory(TestContext context) {
+		if ( ormSessionFactory != null && ormSessionFactory.isOpen() ) {
+			ormSessionFactory.close();
+		}
+	}
+
+	protected static Stage.SessionFactory getSessionFactory() {
+		return ormSessionFactory.unwrap( Stage.SessionFactory.class );
+	}
+
+
+	protected static Mutiny.SessionFactory getMutinySessionFactory() {
+		return ormSessionFactory.unwrap( Mutiny.SessionFactory.class );
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/LazyBasicFieldTest.java
+++ b/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/LazyBasicFieldTest.java
@@ -1,0 +1,47 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test fetching of basic lazy fields when
+ * bytecode enhancements is enabled.
+ */
+public class LazyBasicFieldTest extends BaseReactiveIT {
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Crew.class );
+	}
+
+	@Test
+	public void testFetchBasicField(TestContext context) {
+		final Crew emily = new Crew();
+		emily.setId( 21L );
+		emily.setName( "Emily Jackson" );
+		emily.setRole( "Passenger" );
+		emily.setFate( "Unknown" );
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( session -> session.persist( emily ) )
+				.chain( () -> getMutinySessionFactory()
+						.withSession( session -> session
+								.find( Crew.class, emily.getId() )
+								.call( crew -> session.fetch( crew, Crew_.role )
+										.invoke( role -> assertThat( role ).isEqualTo( emily.getRole() ) ) )
+								.call( crew -> session.fetch( crew, Crew_.fate )
+										.invoke( fate -> assertThat( fate ).isEqualTo( emily.getFate() ) )
+								) ) )
+		);
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/LazyOneToOneBETest.java
+++ b/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/LazyOneToOneBETest.java
@@ -1,0 +1,101 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.it;
+
+import java.util.Collection;
+import java.util.List;
+import javax.persistence.metamodel.Attribute;
+
+import org.hibernate.reactive.it.lazytoone.Captain;
+import org.hibernate.reactive.it.lazytoone.Ship;
+import org.hibernate.reactive.mutiny.Mutiny;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Test bytecode enhancements on a lazy one-to-one bidirectional association
+ */
+public class LazyOneToOneBETest extends BaseReactiveIT {
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Ship.class, Captain.class );
+	}
+
+	@Test
+	public void testCascadeDelete(TestContext context) {
+		Captain robert = new Captain( "Robert Witterel" );
+		Ship obraDinn = new Ship( "Obra Dinn" );
+		obraDinn.setCaptain( robert );
+		robert.setShip( obraDinn );
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( session -> session.persistAll( obraDinn ) )
+				.chain( () -> getMutinySessionFactory()
+						.withTransaction( session -> session
+								.find( Ship.class, obraDinn.getId() )
+								.call( session::remove ) )
+				)
+				.chain( () -> getMutinySessionFactory()
+						.withSession( session -> session
+								.find( Ship.class, obraDinn.getId() )
+								.invoke( context::assertNull )
+								.chain( () -> session.find( Captain.class, robert.getId() ) )
+								.invoke( context::assertNull )
+						)
+				)
+		);
+	}
+
+	@Test
+	public void testFetchOnChildSide(TestContext context) {
+		Captain robert = new Captain( "Robert Witterel" );
+		Ship obraDinn = new Ship( "Obra Dinn" );
+		obraDinn.setCaptain( robert );
+		robert.setShip( obraDinn );
+
+		Attribute<? super Ship, ?> captainAttribute = getMutinySessionFactory()
+				.getMetamodel().entity( Ship.class ).getAttribute( "captain" );
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( session -> session.persist( obraDinn ) )
+				.chain( () -> getMutinySessionFactory()
+						.withSession( session -> session
+								.find( Ship.class, obraDinn.getId() )
+								.call( ship -> session.fetch( ship, captainAttribute ) )
+								.invoke( ship -> {
+									assertThat( ship ).isEqualTo( obraDinn );
+									assertThat( ship.getCaptain() ).isEqualTo( robert );
+								} )
+						)
+				)
+		);
+	}
+
+	@Test
+	public void testFetchOnParentSide(TestContext context) {
+		Captain robert = new Captain( "Robert Witterel" );
+		Ship obraDinn = new Ship( "Obra Dinn" );
+		obraDinn.setCaptain( robert );
+		robert.setShip( obraDinn );
+
+		test( context, getMutinySessionFactory()
+				.withTransaction( session -> session.persistAll( obraDinn ) )
+				.chain( () -> getMutinySessionFactory()
+						.withSession( session -> session
+								.find( Captain.class, robert.getId() )
+								.invoke( captain -> assertThat( captain ).isEqualTo( robert ) )
+								.chain( captain -> Mutiny.fetch( captain.getShip() ) )
+								.invoke( ship -> assertThat( ship ).isEqualTo( obraDinn ) )
+						)
+				)
+		);
+	}
+}

--- a/integration-tests/bytecode-enhancements-it/src/test/resources/log4j2.properties
+++ b/integration-tests/bytecode-enhancements-it/src/test/resources/log4j2.properties
@@ -1,0 +1,16 @@
+rootLogger.level = info
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = console
+
+# SQL logging disabled by default to speed test suite execution
+logger.hibernate.name = org.hibernate.SQL
+logger.hibernate.level = info
+
+# Setting level to TRACE will show parameters values
+logger.sql-parameters-values.name = org.hibernate.type
+logger.sql-parameters-values.level = INFO
+
+appender.console.name = console
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %highlight{[%p]} %m%n

--- a/integration-tests/verticle-postgres-it/build.gradle
+++ b/integration-tests/verticle-postgres-it/build.gradle
@@ -27,6 +27,24 @@ dependencies {
     testImplementation "io.vertx:vertx-unit:${vertxVersion}"
 }
 
+ buildscript {
+     repositories {
+         // Example: ./gradlew build -PenableMavenLocalRepo
+         if ( project.hasProperty('enableMavenLocalRepo') ) {
+             // Useful for local development, it should be disabled otherwise
+             mavenLocal()
+         }
+
+         mavenCentral()
+
+         // Example: ./gradlew build -PenableJBossSnapshotsRep
+         if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+             // Used only for testing with the latest Hibernate ORM snapshots.
+             maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
+         }
+     }
+ }
+
 // Print a summary of the results of the tests (number of failures, successes and skipped)
 // This is the same as the one in hibernate-reactive-core
 def loggingSummary(db, result, desc) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -85,6 +85,7 @@ include 'hibernate-reactive-core'
 include 'session-example'
 include 'native-sql-example'
 include 'verticle-postgres-it'
+include 'bytecode-enhancements-it'
 include 'documentation'
 include 'release'
 


### PR DESCRIPTION
Fix #1417 

This should make it possible [to fix the related issue on Quarkus](https://github.com/quarkusio/quarkus/issues/28975).

I've decided to add an additional module to the project to test with bytecode enhancements. Hopefully, in the future we will have something better, but it beats not having tests. I've heard Hibernate ORM has some nice utilities for this.

Not sure how we didn't notice before, but the problem was that in this particular scenario we run a query that returns a CompletionStage and we try to assign it to one of the field. Instead we need to assign the result when it's ready.