### PR TITLE
Improved patch to prevent type cache pollution on getting ReactiveQueryExecutor

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hibernate Reactive has been tested with:
 - CockroachDB 22.1
 - MS SQL Server 2019
 - Oracle 21.3
-- [Hibernate ORM][] 5.6.12.Final
+- [Hibernate ORM][] 5.6.14.Final
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.3.4
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.3.4
 - [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.3.4

--- a/build.gradle
+++ b/build.gradle
@@ -50,10 +50,10 @@ version = projectVersion
 // allows overriding the build using a parameter, which can be
 // useful to monitor compatibility for upcoming versions on CI:
 //
-// ./gradlew clean build -PhibernateOrmVersion=5.6.9-SNAPSHOT
+// ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '5.6.12.Final'
+        hibernateOrmVersion = '5.6.14.Final'
     }
     // For ORM, we need a parsed version (to get the family, ...)
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
@@ -15,7 +15,7 @@ import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
-import org.hibernate.reactive.session.ReactiveQueryExecutor;
+import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.reactive.session.impl.ReactiveSessionImpl;
 import org.hibernate.type.EntityType;
 import org.hibernate.type.ForeignKeyDirection;
@@ -46,7 +46,7 @@ public class EntityTypes {
                                            SharedSessionContractImplementor session) {
         if ( idOrUniqueKey != null && !isNull( entityType, owner, session ) ) {
             if ( entityType.isReferenceToPrimaryKey() ) {
-                return ((ReactiveQueryExecutor) session).reactiveInternalLoad(
+                return ReactiveQueryExecutorLookup.extract( session ).reactiveInternalLoad(
                         entityType.getAssociatedEntityName(),
                         (Serializable) idOrUniqueKey,
                         true,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ForeignKeys.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ForeignKeys.java
@@ -9,9 +9,9 @@ import org.hibernate.EntityMode;
 import org.hibernate.HibernateException;
 import org.hibernate.TransientObjectException;
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
+import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.engine.spi.EntityEntry;
-import org.hibernate.engine.spi.SelfDirtinessTracker;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.StringHelper;
@@ -181,8 +181,8 @@ public final class ForeignKeys {
 			// When bytecode-enhancement is used for dirty-checking, the change should
 			// only be tracked when returnedValue was nullified (1)).
 			if ( value != returnedValue && returnedValue == null
-					&& self instanceof SelfDirtinessTracker ) {
-				( (SelfDirtinessTracker) self ).$$_hibernate_trackChange( propertyName );
+					&& ManagedTypeHelper.isSelfDirtinessTracker( self ) ) {
+				ManagedTypeHelper.asSelfDirtinessTracker( self ).$$_hibernate_trackChange( propertyName );
 			}
 		}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveSaveEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveSaveEventListener.java
@@ -15,6 +15,7 @@ import org.hibernate.LockMode;
 import org.hibernate.NonUniqueObjectException;
 import org.hibernate.action.internal.AbstractEntityInsertAction;
 import org.hibernate.engine.internal.CascadePoint;
+import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityEntryExtraState;
@@ -115,9 +116,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 			boolean requiresImmediateIdAccess) {
 		callbackRegistry.preCreate( entity );
 
-		if ( entity instanceof SelfDirtinessTracker ) {
-			( (SelfDirtinessTracker) entity ).$$_hibernate_clearDirtyAttributes();
-		}
+		ManagedTypeHelper.processIfSelfDirtinessTracker( entity, SelfDirtinessTracker::$$_hibernate_clearDirtyAttributes );
 
 		EntityPersister persister = source.getEntityPersister( entityName, entity );
 		boolean autoincrement = persister.isIdentifierAssignedByInsert();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ReactiveLoader.java
@@ -19,7 +19,7 @@ import org.hibernate.loader.spi.AfterLoadAction;
 import org.hibernate.reactive.adaptor.impl.QueryParametersAdaptor;
 import org.hibernate.reactive.engine.impl.ReactivePersistenceContextAdapter;
 import org.hibernate.reactive.pool.impl.Parameters;
-import org.hibernate.reactive.session.ReactiveQueryExecutor;
+import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.transform.ResultTransformer;
 
 import java.sql.ResultSet;
@@ -128,12 +128,7 @@ public interface ReactiveLoader {
 			sql = parameters().processLimit( sql, parameterArray, LimitHelper.hasFirstRow( queryParameters.getRowSelection() ) );
 		}
 
-		//N.B. performance trap: always try to cast to ReactiveQueryExecutor even when only needing a ReactiveConnectionSupplier
-		//as we otherwise trigger a strong scalability issue.
-		//See also:
-		// - https://bugs.openjdk.org/browse/JDK-8180450
-		// - https://github.com/hibernate/hibernate-reactive/issues/1399
-		return ((ReactiveQueryExecutor) session).getReactiveConnection()
+		return ReactiveQueryExecutorLookup.extract( session ).getReactiveConnection()
 				.selectJdbc( sql, parameterArray );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -42,9 +42,10 @@ import org.hibernate.reactive.common.Identifier;
 import org.hibernate.reactive.common.ResultSetMapping;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
-import org.hibernate.reactive.session.ReactiveQueryExecutor;
 
 import io.smallrye.mutiny.Uni;
+
+import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.stat.Statistics;
 
 import static org.hibernate.internal.util.LockModeConverter.convertToLockMode;
@@ -2092,7 +2093,7 @@ public interface Mutiny {
 			throw LOG.sessionClosedLazyInitializationException();
 		}
 		return Uni.createFrom().completionStage(
-				( (ReactiveQueryExecutor) session ).reactiveFetch( association, false )
+				ReactiveQueryExecutorLookup.extract( session ).reactiveFetch( association, false )
 		);
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -32,6 +32,7 @@ import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.internal.AbstractPersistentCollection;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -2076,8 +2077,8 @@ public interface Mutiny {
 			//this unfortunately doesn't work for stateless session because the session ref gets set to null
 			session = ( (AbstractPersistentCollection) association ).getSession();
 		}
-		else if ( association instanceof PersistentAttributeInterceptable) {
-			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) association;
+		else if ( ManagedTypeHelper.isPersistentAttributeInterceptable( association ) ) {
+			final PersistentAttributeInterceptable interceptable = ManagedTypeHelper.asPersistentAttributeInterceptable( association );
 			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
 			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor) {
 				session = ( (EnhancementAsProxyLazinessInterceptor) interceptor ).getLinkedSession();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -66,8 +66,8 @@ import org.hibernate.reactive.mutiny.impl.MutinySessionFactoryImpl;
 import org.hibernate.reactive.mutiny.impl.MutinySessionImpl;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.impl.Parameters;
-import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.reactive.session.ReactiveSession;
+import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.impl.StageSessionImpl;
 import org.hibernate.reactive.tuple.MutinyValueGenerator;
@@ -137,7 +137,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 	}
 
 	default ReactiveConnection getReactiveConnection(SharedSessionContractImplementor session) {
-		return ((ReactiveConnectionSupplier) session).getReactiveConnection();
+		return ReactiveQueryExecutorLookup.extract( session ).getReactiveConnection();
 	}
 
 	String getSqlInsertGeneratedValuesSelectString();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -34,12 +34,12 @@ import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.dialect.CockroachDB192Dialect;
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.OptimisticLockStyle;
+import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.hibernate.engine.internal.Versioning;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SessionImplementor;
@@ -1206,8 +1206,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 			throw new AssertionFailure( "no lazy properties" );
 		}
 
-		final PersistentAttributeInterceptor interceptor =
-				( (PersistentAttributeInterceptable) entity ).$$_hibernate_getInterceptor();
+		final PersistentAttributeInterceptor interceptor = ManagedTypeHelper.asPersistentAttributeInterceptable( entity ).$$_hibernate_getInterceptor();
 		if ( interceptor == null ) {
 			throw new AssertionFailure( "Expecting bytecode interceptor to be non-null" );
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveQueryExecutorLookup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveQueryExecutorLookup.java
@@ -1,0 +1,38 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.session.impl;
+
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.reactive.session.ReactiveQueryExecutor;
+
+/**
+ * This is a dirty trick to mitigate the performance impact of JDK-8180450;
+ * hopefully temporary but we have no indication about a possible fix at
+ * the moment.
+ * The gist is that we need to avoid repeatedly checking for ReactiveSessionImpl
+ * to implement certain interfaces; we frequently need to cast the current
+ * {@see SharedSessionContractImplementor} to {@see ReactiveQueryExecutor}:
+ * let's take advantage of the fact that it's almost certainly going to be
+ * of a known concrete type, specifically a {@see ReactiveSessionImpl}.
+ * @link https://bugs.openjdk.org/browse/JDK-8180450
+ */
+public final class ReactiveQueryExecutorLookup {
+
+	/**
+	 * Extracts the ReactiveQueryExecutor from a Session.
+	 * @param session
+	 * @return
+	 */
+	public static ReactiveQueryExecutor extract(final SharedSessionContractImplementor session) {
+		if ( session instanceof org.hibernate.reactive.session.impl.ReactiveSessionImpl ) {
+			return (org.hibernate.reactive.session.impl.ReactiveSessionImpl) session;
+		}
+		else {
+			return (ReactiveQueryExecutor) session;
+		}
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -105,6 +105,8 @@ import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 
+import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
+import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttributeInterceptable;
 import static org.hibernate.engine.spi.PersistenceContext.NaturalIdHelper.INVALID_NATURAL_ID_REFERENCE;
 import static org.hibernate.reactive.common.InternalStateAssertions.assertUseOnEventLoop;
 import static org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister.forceInitialize;
@@ -276,8 +278,8 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 						.thenApply( v -> association );
 			}
 		}
-		else if ( association instanceof PersistentAttributeInterceptable) {
-			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) association;
+		else if ( isPersistentAttributeInterceptable( association ) ) {
+			final PersistentAttributeInterceptable interceptable = asPersistentAttributeInterceptable( association );
 			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
 			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor) {
 				EnhancementAsProxyLazinessInterceptor eapli = (EnhancementAsProxyLazinessInterceptor) interceptor;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -66,6 +66,8 @@ import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
+import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttributeInterceptable;
 import static org.hibernate.reactive.id.impl.IdentifierGeneration.assignIdIfNecessary;
 import static org.hibernate.reactive.id.impl.IdentifierGeneration.generateId;
 import static org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister.forceInitialize;
@@ -803,8 +805,8 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl
 						.thenApply( v -> association );
 			}
 		}
-		else if ( association instanceof PersistentAttributeInterceptable) {
-			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) association;
+		else if ( isPersistentAttributeInterceptable( association ) ) {
+			final PersistentAttributeInterceptable interceptable = asPersistentAttributeInterceptable( association );
 			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
 			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor) {
 				EnhancementAsProxyLazinessInterceptor eapli = (EnhancementAsProxyLazinessInterceptor) interceptor;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -33,6 +33,7 @@ import org.hibernate.LockMode;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.internal.AbstractPersistentCollection;
 import org.hibernate.collection.spi.PersistentCollection;
+import org.hibernate.engine.internal.ManagedTypeHelper;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -2070,8 +2071,8 @@ public interface Stage {
 		else if ( association instanceof PersistentCollection) {
 			session = ( (AbstractPersistentCollection) association ).getSession();
 		}
-		else if ( association instanceof PersistentAttributeInterceptable) {
-			final PersistentAttributeInterceptable interceptable = (PersistentAttributeInterceptable) association;
+		else if ( ManagedTypeHelper.isPersistentAttributeInterceptable( association ) ) {
+			final PersistentAttributeInterceptable interceptable = ManagedTypeHelper.asPersistentAttributeInterceptable( association );
 			final PersistentAttributeInterceptor interceptor = interceptable.$$_hibernate_getInterceptor();
 			if ( interceptor instanceof EnhancementAsProxyLazinessInterceptor) {
 				session = ( (EnhancementAsProxyLazinessInterceptor) interceptor ).getLinkedSession();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -43,7 +43,7 @@ import org.hibernate.reactive.common.Identifier;
 import org.hibernate.reactive.common.ResultSetMapping;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
-import org.hibernate.reactive.session.ReactiveQueryExecutor;
+import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.stat.Statistics;
 
@@ -2086,6 +2086,6 @@ public interface Stage {
 		if ( session == null ) {
 			throw LOG.sessionClosedLazyInitializationException();
 		}
-		return ( (ReactiveQueryExecutor) session ).reactiveFetch( association, false );
+		return ReactiveQueryExecutorLookup.extract( session ).reactiveFetch( association, false );
 	}
 }


### PR DESCRIPTION
Also requires an upgrade to Hibernate ORM 5.6.14.Final (upgrade included)