### PR TITLE
Test Hibernate Reactive against JDK 21 EA, JDK 19 GA

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,11 +145,10 @@ jobs:
         java:
           - { name: "11", java_version_numeric: 11 }
           - { name: "17", java_version_numeric: 17 }
-          - { name: "18", java_version_numeric: 18, from: 'jdk.java.net' }
-          # We want to enable preview features when testing early-access builds of OpenJDK:
+          # We want to enable preview features when testing newer builds of OpenJDK:
           # even if we don't use these features, just enabling them can cause side effects
           # and it's useful to test that.
-          - { name: "19-ea", java_version_numeric: 19, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "19", java_version_numeric: 19, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "20-ea", java_version_numeric: 20, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "21-ea", java_version_numeric: 21, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -151,6 +151,7 @@ jobs:
           # and it's useful to test that.
           - { name: "19-ea", java_version_numeric: 19, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "20-ea", java_version_numeric: 20, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "21-ea", java_version_numeric: 21, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:
     - uses: actions/checkout@v2
     - name: Get year/month for cache key


### PR DESCRIPTION
JDK 18 EOL'd on 2022-09-20
See https://endoflife.date/java