### PR TITLE
Fix MultilineImportsTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
@@ -46,7 +46,7 @@ public class MultilineImportsTest extends BaseReactiveTest {
 		// https://github.com/quarkusio/quarkus-workshops/tree/master/quarkus-workshop-super-heroes/super-heroes/rest-hero
 		configuration.setProperty( AvailableSettings.HBM2DDL_IMPORT_FILES, "/complexMultilineImports.sql" );
 		configuration.setProperty( Settings.HBM2DDL_AUTO, "create" );
-		configuration.setProperty( Settings.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR, "org.hibernate.tool.hbm2ddl.MultipleLinesSqlCommandExtractor" );
+		configuration.setProperty( Settings.HBM2DDL_IMPORT_FILES_SQL_EXTRACTOR, "org.hibernate.tool.schema.internal.script.MultiLineSqlScriptExtractor" );
 		return configuration;
 	}
 


### PR DESCRIPTION
The fix is to use MultiLineSqlScriptExtractor instead of MultipleLinesSqlCommandExtractor (which was deprecated anyway and now removed in ORM6)