### PR TITLE
Fix IdentityGeneratorTypeTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTypeTest.java
@@ -41,7 +41,7 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
-		return List.of( IntegerTypeEntity.class, LongTypeEntity.class, ShortTypeEntity.class );
+		return List.of( IntegerTypeEntity.class, LongTypeEntity.class );
 	}
 
 	/**
@@ -96,10 +96,6 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 		assertType( context, IntegerTypeEntity.class, new IntegerTypeEntity(), 1 );
 	}
 
-	@Test
-	public void shortIdentityType(TestContext context) {
-		assertType( context, ShortTypeEntity.class, new ShortTypeEntity(), (short) 1 );
-	}
 
 	interface TypeIdentity<T extends Number> {
 		T getId();
@@ -127,19 +123,6 @@ public class IdentityGeneratorTypeTest extends BaseReactiveTest {
 
 		@Override
 		public Long getId() {
-			return id;
-		}
-	}
-
-	@Entity(name = "ShortTypeEntity")
-	@Table(name = "ShortTypeEntity")
-	static class ShortTypeEntity implements TypeIdentity<Short> {
-		@Id
-		@GeneratedValue(strategy = GenerationType.IDENTITY)
-		public Short id;
-
-		@Override
-		public Short getId() {
 			return id;
 		}
 	}


### PR DESCRIPTION
Simply remove the entity that uses a short type as an id because it conflicts with [this](https://github.com/hibernate/hibernate-orm/blob/6.2.0.CR1/hibernate-core/src/main/java/org/hibernate/dialect/identity/PostgreSQLIdentityColumnSupport.java#L37).