### PR TITLE
Introduce batch single table batch support

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/ResultsCheckerUtil.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/ResultsCheckerUtil.java
@@ -1,0 +1,40 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.jdbc;
+
+import java.sql.SQLException;
+import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
+import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
+import org.hibernate.engine.jdbc.mutation.internal.ModelMutationHelper;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+
+public final class ResultsCheckerUtil {
+
+    private ResultsCheckerUtil() {
+    }
+
+
+    public static void checkResults(
+            SharedSessionContractImplementor session,
+            PreparedStatementDetails statementDetails,
+            OperationResultChecker resultChecker,
+            Integer affectedRowCount, int batchPosition) {
+        try {
+            ModelMutationHelper.checkResults( resultChecker, statementDetails, affectedRowCount, batchPosition);
+        }
+        catch (SQLException e) {
+            throw session.getJdbcServices().getSqlExceptionHelper()
+                    .convert(
+                    e,
+                    String.format(
+                            "Unable to execute mutation PreparedStatement against table `%s`",
+                            statementDetails.getMutatingTableDetails().getTableName()
+                    ),
+                    statementDetails.getSqlString()
+            );
+        }
+    }
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleBatched.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleBatched.java
@@ -5,17 +5,26 @@
  */
 package org.hibernate.reactive.engine.jdbc.mutation.internal;
 
+import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
+import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
+import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER_TRACE_ENABLED;
 import java.util.concurrent.CompletionStage;
-
 import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
+import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
 import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
+import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
 import org.hibernate.engine.jdbc.mutation.internal.MutationExecutorSingleBatched;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.reactive.adaptor.impl.PrepareStatementDetailsAdaptor;
+import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
+import org.hibernate.reactive.engine.jdbc.ResultsCheckerUtil;
 import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.sql.model.PreparableMutationOperation;
+import org.hibernate.sql.model.TableMapping;
 import org.hibernate.sql.model.ValuesAnalysis;
-
-import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 public class ReactiveMutationExecutorSingleBatched extends MutationExecutorSingleBatched implements
 		ReactiveMutationExecutor {
@@ -31,8 +40,41 @@ public class ReactiveMutationExecutorSingleBatched extends MutationExecutorSingl
 	@Override
 	public CompletionStage<Void> performReactiveBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
-			TableInclusionChecker inclusionChecker) {
-		super.performBatchedOperations( valuesAnalysis, inclusionChecker );
-		return voidFuture();
+			TableInclusionChecker inclusionChecker,
+			OperationResultChecker resultChecker,
+			SharedSessionContractImplementor session) {
+
+		PreparedStatementDetails statementDetails = getStatementGroup().getSingleStatementDetails();
+		JdbcValueBindings valueBindings = getJdbcValueBindings();
+
+		if ( statementDetails == null ) {
+			return voidFuture();
+		}
+
+		final TableMapping tableDetails = statementDetails.getMutatingTableDetails();
+		if ( inclusionChecker != null && !inclusionChecker.include( tableDetails ) ) {
+			if ( MODEL_MUTATION_LOGGER_TRACE_ENABLED ) {
+				MODEL_MUTATION_LOGGER.tracef( "Skipping execution of secondary insert : %s", tableDetails.getTableName() );
+			}
+			return voidFuture();
+		}
+
+		// If we get here the statement is needed - make sure it is resolved
+		Object[] paramValues = PreparedStatementAdaptor.bind(statement -> {
+			PreparedStatementDetails details = new PrepareStatementDetailsAdaptor( statementDetails, statement, session.getJdbcServices() );
+			valueBindings.beforeStatement( details );
+		} );
+
+		ReactiveConnection reactiveConnection = ( (ReactiveConnectionSupplier) session ).getReactiveConnection();
+		String sql = statementDetails.getSqlString();
+		return reactiveConnection
+				.update(sql, paramValues, true,
+						(rowCount, batchPosition, query) -> ResultsCheckerUtil.checkResults(session, statementDetails, resultChecker, rowCount, batchPosition))
+				.whenComplete( (o, throwable) -> { //TODO: is this part really needed?
+					if ( statementDetails.getStatement() != null ) {
+						statementDetails.releaseStatement( session );
+					}
+					valueBindings.afterStatement( tableDetails );
+				} );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorStandard.java
@@ -49,8 +49,10 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 	@Override
 	public CompletionStage<Void> performReactiveBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
-			TableInclusionChecker inclusionChecker) {
-		return ReactiveMutationExecutor.super.performReactiveBatchedOperations( valuesAnalysis, inclusionChecker );
+			TableInclusionChecker inclusionChecker, OperationResultChecker resultChecker,
+			SharedSessionContractImplementor session) {
+		return ReactiveMutationExecutor.super.performReactiveBatchedOperations( valuesAnalysis, inclusionChecker,
+                resultChecker, session);
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchingConnectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchingConnectionTest.java
@@ -71,7 +71,7 @@ public class BatchingConnectionTest extends ReactiveSessionTest {
 									assertThat( sqlTracker.getLoggedQueries() ).hasSize( 1 );
 									// Parameters are different for different dbs, so we cannot do an exact match
 									assertThat( sqlTracker.getLoggedQueries().get( 0 ) )
-											.startsWith( "insert into pig (name, version, id) values " );
+											.startsWith( "insert into pig (name,version,id) values " );
 									sqlTracker.clear();
 								} )
 						)
@@ -96,7 +96,7 @@ public class BatchingConnectionTest extends ReactiveSessionTest {
 											assertThat( sqlTracker.getLoggedQueries() ).hasSize( 1 );
 											// Parameters are different for different dbs, so we cannot do an exact match
 											assertThat( sqlTracker.getLoggedQueries().get( 0 ) )
-													.startsWith( "insert into pig (name, version, id) values " );
+													.matches("insert into pig \\(name,version,id\\) values (.*)" );
 											sqlTracker.clear();
 										} )
 								)
@@ -111,7 +111,9 @@ public class BatchingConnectionTest extends ReactiveSessionTest {
 											context.assertEquals( 3L, count);
 											assertThat( sqlTracker.getLoggedQueries() ).hasSize( 1 );
 											assertThat( sqlTracker.getLoggedQueries().get( 0 ) )
-													.matches( "update pig set name=.+, version=.+ where id=.+ and version=.+" );
+													.matches(
+															"update pig set name=.+,\\s*version=.+ where id=.+ and "
+																	+ "version=.+" );
 											sqlTracker.clear();
 										} )
 								) )


### PR DESCRIPTION
This change leverages the fact that when batching
is enabled, a BatchingConnection is provided
under the hood that takes care of all the necessary plumbing.

Before the change, **122** tests where failing, after this change the number drops to **87**