### PR TITLE
Disable LazyPropertyTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyPropertyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyPropertyTest.java
@@ -10,6 +10,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
 import org.hibernate.engine.spi.PersistentAttributeInterceptable;
 import org.hibernate.engine.spi.PersistentAttributeInterceptor;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import jakarta.persistence.Basic;
@@ -28,6 +29,8 @@ import static java.util.Collections.singleton;
 import static jakarta.persistence.CascadeType.PERSIST;
 import static jakarta.persistence.FetchType.LAZY;
 
+
+@Ignore // this fails with Hibernate ORM too
 public class LazyPropertyTest extends BaseReactiveTest {
 
 	@Override


### PR DESCRIPTION
This test also fails with plain old ORM 6:

```java
package org.hibernate.reactive;

import jakarta.persistence.Basic;
import jakarta.persistence.GeneratedValue;
import jakarta.persistence.ManyToOne;
import jakarta.persistence.OneToMany;
import jakarta.persistence.metamodel.Attribute;
import java.util.ArrayList;
import java.util.Collection;
import java.util.List;

import org.hibernate.Hibernate;
import org.hibernate.Session;
import org.hibernate.SessionFactory;
import org.hibernate.boot.registry.StandardServiceRegistry;
import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
import org.hibernate.bytecode.enhance.spi.interceptor.LazyAttributeLoadingInterceptor;
import org.hibernate.cfg.Configuration;
import org.hibernate.dialect.PostgreSQLDialect;
import org.hibernate.engine.spi.PersistentAttributeInterceptable;
import org.hibernate.engine.spi.PersistentAttributeInterceptor;
import org.hibernate.reactive.provider.Settings;
import org.hibernate.reactive.testing.DatabaseSelectionRule;

import org.junit.After;
import org.junit.Before;
import org.junit.Rule;
import org.junit.Test;

import io.vertx.ext.unit.TestContext;
import jakarta.persistence.Entity;
import jakarta.persistence.Id;
import jakarta.persistence.Table;

import static jakarta.persistence.CascadeType.PERSIST;
import static jakarta.persistence.FetchType.LAZY;
import static java.util.Collections.singleton;
import static org.assertj.core.api.Assertions.*;
import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;

/**
 * This test class verifies that data can be persisted and queried on the same database
 * using both JPA/hibernate and reactive session factories.
 */
public class ORMReactivePersistenceTest extends BaseReactiveTest {

	@Rule
	public DatabaseSelectionRule rule = DatabaseSelectionRule.runOnlyFor( POSTGRESQL );

	private SessionFactory ormFactory;

	@Override
	protected Collection<Class<?>> annotatedEntities() {
		return List.of(  Book.class, Author.class  );
	}

	@Before
	public void prepareOrmFactory() {
		Configuration configuration = constructConfiguration();
		configuration.setProperty( Settings.DRIVER, "org.postgresql.Driver" );
		configuration.setProperty( Settings.DIALECT, PostgreSQLDialect.class.getName() );

		StandardServiceRegistryBuilder builder = new StandardServiceRegistryBuilder()
				.applySettings( configuration.getProperties() );

		StandardServiceRegistry registry = builder.build();
		ormFactory = configuration.buildSessionFactory( registry );
	}

	@After
	public void closeOrmFactory() {
		ormFactory.close();
	}

	@Test
	public void testORMWithStageSession(TestContext context) {
		Author author1 = new Author("Iain M. Banks");
		Author author2 = new Author("Neal Stephenson");
		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1);
		Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2);
		Book book3 = new Book("0-553-08853-X", "Snow Crash", author2);
		author1.books.add(book1);
		author2.books.add(book2);
		author2.books.add(book3);

		Session session = ormFactory.openSession();
		session.beginTransaction();
		session.persist( author1 );
		session.persist( author2 );
		session.getTransaction().commit();
		session.close();

		Attribute<? super Book, ?> Book_isbn = getSessionFactory().getMetamodel()
				.entity(Book.class).getAttribute("isbn");

		session = ormFactory.openSession();
		Book book = session.find(Book.class, book1.id);
		assertThat( Hibernate.isPropertyInitialized(book, "isbn") ).isFalse();
	}

	@Entity(name="Author")
	@Table(name="authors")
	static class Author {
		@Id @GeneratedValue
		Integer id;

		String name;

		@OneToMany(mappedBy = "author", cascade = PERSIST)
		List<Book> books = new ArrayList<>();

		Author(String name) {
			this.name = name;
		}

		Author() {}
	}

	@Entity(name="Book")
	@Table(name="books")
	static class Book extends LazyAttributeLoadingInterceptor
			implements PersistentAttributeInterceptable {
		@Id
		@GeneratedValue
		Integer id;

		@Basic(fetch = LAZY)
		String isbn;

		public String getIsbn() {
			return isbn;
		}

		String title;

		@ManyToOne(fetch = LAZY)
		Author author;

		Book(String isbn, String title, Author author) {
			super("Book", 1, singleton("isbn"), null);
			this.title = title;
			this.isbn = isbn;
			this.author = author;
		}

		Book() {
			super("Book", 1, singleton("isbn"), null);
		}

		@Override
		public PersistentAttributeInterceptor $$_hibernate_getInterceptor() {
			return this;
		}
		@Override
		public void $$_hibernate_setInterceptor(PersistentAttributeInterceptor interceptor) {}
	}
}

```