### PR TITLE
Work around lazy eager loading issue in clean DB for CompositeIdManyToOneTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdManyToOneTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdManyToOneTest.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import org.junit.After;
 import org.junit.Test;
 
 import io.vertx.ext.unit.TestContext;
@@ -28,6 +29,14 @@ public class CompositeIdManyToOneTest extends BaseReactiveTest {
     protected Collection<Class<?>> annotatedEntities() {
         return List.of( GroceryList.class, ShoppingItem.class);
     }
+
+    @After
+    public void cleanDb(TestContext context) {
+        test( context, getSessionFactory()
+                .withTransaction( s -> s.createQuery( "delete from ShoppingItem" ).executeUpdate()
+                        .thenCompose( v -> s.createQuery("delete from GroceryList ").executeUpdate())) );
+    }
+
 
     @Test
     public void reactivePersist(TestContext context) {
@@ -71,7 +80,7 @@ public class CompositeIdManyToOneTest extends BaseReactiveTest {
 //        @Id Long groceryListId;
         @Id private String itemName;
 
-        @Id @ManyToOne
+        @Id @ManyToOne(fetch = FetchType.LAZY)
         @JoinColumn(name = "grocerylistid")
         private GroceryList groceryList;
 


### PR DESCRIPTION
The point of this test is to test that persisting composite id works, but without this change the test actually fails when loading the entity (due to the eager loading issue that is still unresolved).

This change makes sure that the test only fails if the persist functionality does not work properly