### PR TITLE
Introduce a NativeParametersRendering service to directly render PostgreSQL-compatible SELECT statements

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveServiceInitiators.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveServiceInitiators.java
@@ -27,6 +27,7 @@ import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExec
 import org.hibernate.reactive.id.factory.spi.ReactiveIdentifierGeneratorFactoryInitiator;
 import org.hibernate.reactive.pool.impl.ReactiveConnectionPoolInitiator;
 import org.hibernate.reactive.pool.impl.SqlClientPoolConfigurationInitiator;
+import org.hibernate.reactive.provider.service.NativeParametersRendering;
 import org.hibernate.reactive.provider.service.NoJdbcConnectionProviderInitiator;
 import org.hibernate.reactive.provider.service.NoJdbcEnvironmentInitiator;
 import org.hibernate.reactive.provider.service.NoJdbcMultiTenantConnectionProviderInitiator;
@@ -42,7 +43,6 @@ import org.hibernate.reactive.vertx.impl.VertxInstanceInitiator;
 import org.hibernate.resource.beans.spi.ManagedBeanRegistryInitiator;
 import org.hibernate.resource.transaction.internal.TransactionCoordinatorBuilderInitiator;
 import org.hibernate.service.internal.SessionFactoryServiceRegistryFactoryInitiator;
-import org.hibernate.sql.ast.internal.JdbcParameterRendererInitiator;
 import org.hibernate.tool.schema.internal.script.SqlScriptExtractorInitiator;
 
 import static java.util.Collections.unmodifiableList;
@@ -149,11 +149,11 @@ public final class ReactiveServiceInitiators {
 		// Custom for Hibernate Reactive: JdbcValuesMappingProducerProvider
 		serviceInitiators.add( ReactiveValuesMappingProducerProviderInitiator.INSTANCE );
 
-		//Custom for Hibernate Reactive: SqmMultiTableMutationStrategyProvider
+		// Custom for Hibernate Reactive: SqmMultiTableMutationStrategyProvider
 		serviceInitiators.add( ReactiveSqmMultiTableMutationStrategyProviderInitiator.INSTANCE );
 
-		// [standard] JdbcParameterRenderer FIXME this will need to be replaced
-		serviceInitiators.add( JdbcParameterRendererInitiator.INSTANCE );
+		// Custom for Hibernate Reactive: NativeParametersRendering [Could be used by ORM too? TBD]
+		serviceInitiators.add( NativeParametersRendering.INSTANCE );
 
 		// --- end of services defined by Hibernate ORM
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NativeParametersRendering.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NativeParametersRendering.java
@@ -1,0 +1,41 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.provider.service;
+
+import java.util.Map;
+
+import org.hibernate.boot.registry.StandardServiceInitiator;
+import org.hibernate.dialect.Dialect;
+import org.hibernate.dialect.DialectDelegateWrapper;
+import org.hibernate.dialect.PostgreSQLDialect;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+import org.hibernate.sql.ast.internal.JdbcParameterRendererStandard;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
+
+public class NativeParametersRendering implements StandardServiceInitiator<JdbcParameterRenderer> {
+	/**
+	 * Singleton access
+	 */
+	public static final NativeParametersRendering INSTANCE = new NativeParametersRendering();
+
+	@Override
+	public JdbcParameterRenderer initiateService(Map<String, Object> configurationValues, ServiceRegistryImplementor registry) {
+		final Dialect dialect = registry.getService( JdbcEnvironment.class ).getDialect();
+		final Dialect realDialect = DialectDelegateWrapper.extractRealDialect( dialect );
+		if ( realDialect instanceof PostgreSQLDialect ) {
+			return PostgreSQLParameterRenderer.INSTANCE;
+		}
+		//TODO: Create optimised implementations for the other most relevant dialects
+		return JdbcParameterRendererStandard.INSTANCE;
+	}
+
+	@Override
+	public Class<JdbcParameterRenderer> getServiceInitiated() {
+		return JdbcParameterRenderer.class;
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/PostgreSQLParameterRenderer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/PostgreSQLParameterRenderer.java
@@ -1,0 +1,57 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.provider.service;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.sql.ast.spi.JdbcParameterRenderer;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.type.descriptor.jdbc.JdbcType;
+
+/**
+ * Ensures the rendered SQL matches the syntax of parameters expected by
+ * the Vert.x PgClient: parameters are rendered with "$1", "$2", etc..
+ * rather than with "?" syntax.
+ * We also post-process rendered SQL in PostgresParameters as the current
+ * approach needs to be refined; as we close the gap, rendering correctly
+ * directly improves performance as the Parameters step can then be skipped.
+ * At the time of writing, this service is only invoked for SELECT operations;
+ * INSERT and DELETE seem to render SQL over an alternative path; UPDATE untested.
+ */
+public final class PostgreSQLParameterRenderer implements JdbcParameterRenderer {
+
+	/**
+	 * Singleton access
+	 */
+	public static final PostgreSQLParameterRenderer INSTANCE = new PostgreSQLParameterRenderer();
+
+	private static final int MAX_POSITION_PREPARED = 10;
+	private static final String[] RENDERED_PARAM = initConstants( MAX_POSITION_PREPARED );
+
+	private static String[] initConstants(int max) {
+		String[] arr = new String[max];
+		//index zero unused!
+		for ( int i = 1; i < max; i++ ) {
+			arr[i] = "$" + i;
+		}
+		return arr;
+	}
+
+	private static String render(final int position) {
+		assert position != 0;
+		if ( position < MAX_POSITION_PREPARED ) {
+			return RENDERED_PARAM[position];
+		}
+		else {
+			return "$" + position;
+		}
+	}
+
+	@Override
+	public void renderJdbcParameter(int position, JdbcType jdbcType, SqlAppender appender, Dialect dialect) {
+		jdbcType.appendWriteExpression( render( position ), appender, dialect );
+	}
+
+}


### PR DESCRIPTION
It turns out we can't get rid of the `Parameters` approach to avoid post-processing of SQL statements, but there's some progress.

This avoids some post-processing of the SQL generated by ORM core; it takes care of the PostgreSQL specific parameters format; not applicable yet for mutation operations.
