### PR TITLE
Ensure we apply the exception converter consistently

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive.query.spi;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -183,6 +184,9 @@ public class ReactiveAbstractSelectionQuery<R> {
 	}
 
 	private R convertException(Throwable t) {
+		if ( t instanceof CompletionException ) {
+			t = t.getCause();
+		}
 		if ( t instanceof HibernateException ) {
 			throw getSession().getExceptionConverter().convert( (HibernateException) t, getLockOptions() );
 		}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/QueryTest.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
-import org.hibernate.NonUniqueResultException;
 
 import org.junit.Test;
 
@@ -583,7 +582,7 @@ public class QueryTest extends BaseReactiveTest {
 				.thenCompose( s -> s.persist( author1, author2 ).thenCompose( v -> s.flush() ) )
 				.thenCompose( v -> openSession() )
 				.thenCompose( s -> assertThrown(
-						org.hibernate.NonUniqueResultException.class,
+						jakarta.persistence.NonUniqueResultException.class,
 						s.createQuery( "from Author" ).getSingleResult()
 				) )
 		);
@@ -597,7 +596,7 @@ public class QueryTest extends BaseReactiveTest {
 				.thenCompose( s -> s.persist( author1, author2 ).thenCompose( v -> s.flush() ) )
 				.thenCompose( v -> openSession() )
 				.thenCompose( s -> assertThrown(
-						NonUniqueResultException.class,
+						jakarta.persistence.NonUniqueResultException.class,
 						s.createQuery( "from Author" ).getSingleResultOrNull()
 				) )
 		);


### PR DESCRIPTION
Thrown exceptions were being properly routed through the "convertException" utilities, but when it's wrapped in a CompletionException we'd fail to recognize it.