### PR TITLE
Merge and persist with reference

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerUniqueKeyTest.java
@@ -11,7 +11,7 @@ import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
-import org.junit.After;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import jakarta.persistence.CascadeType;
@@ -22,22 +22,19 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * @see LazyUniqueKeyTest
+ */
 public class EagerUniqueKeyTest extends BaseReactiveTest {
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
 		return List.of( Foo.class, Bar.class );
-	}
-
-	@After
-	public void cleanDb(TestContext context) {
-		test( context, getSessionFactory()
-				.withTransaction( s -> s.createQuery( "delete from Foo" ).executeUpdate()
-						.thenCompose( v -> s.createQuery( "delete from Bar" ).executeUpdate() ) ) );
 	}
 
 	@Test
@@ -65,20 +62,38 @@ public class EagerUniqueKeyTest extends BaseReactiveTest {
 						.withTransaction( session -> session.merge( new Foo( bar ) ) ) )
 				.thenCompose( result -> getSessionFactory()
 						.withTransaction( session -> session.fetch( result.getBar() )
-						.thenAccept( b -> context.assertEquals( "unique2", b.getKey()  ) )
-				) ) );
+								.thenAccept( b -> context.assertEquals( "unique2", b.getKey() ) )
+						) ) );
 	}
 
+	@Ignore // This also fails in ORM
 	@Test
 	public void testMergeReference(TestContext context) {
 		Bar bar = new Bar( "unique3" );
 		test( context, getSessionFactory()
 				.withTransaction( session -> session.persist( bar ) )
 				.thenCompose( i -> getSessionFactory()
-						.withTransaction( session -> session.merge( new Foo( session.getReference( Bar.class, bar.id ) )) ) )
+						.withTransaction( session -> session
+								.merge( new Foo( session.getReference( Bar.class, bar.getId() ) ) ) ) )
 				.thenCompose( result -> getSessionFactory().withTransaction( session -> session.fetch( result.getBar() )
 						.thenAccept( b -> context.assertEquals( "unique3", b.getKey() ) )
-				) ) );
+				) )
+		);
+	}
+
+	@Test
+	public void testPersistWithReference(TestContext context) {
+		Bar bar = new Bar( "uniquePersist" );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session -> {
+							Foo foo = new Foo( session.getReference( Bar.class, bar.getId() ) );
+							return session.persist( foo ).thenApply( v -> foo );
+						} ) )
+				.thenCompose( result -> getSessionFactory().withTransaction( session -> session.fetch( result.getBar() ) ) )
+				.thenAccept( b -> context.assertEquals( "uniquePersist", b.getKey() ) )
+		);
 	}
 
 	@Entity(name = "Foo")
@@ -90,8 +105,8 @@ public class EagerUniqueKeyTest extends BaseReactiveTest {
 		Foo() {
 		}
 
-		@GeneratedValue
 		@Id
+		@GeneratedValue
 		long id;
 		@ManyToOne(cascade = CascadeType.PERSIST, fetch = FetchType.EAGER)
 		@Fetch(FetchMode.JOIN)
@@ -124,8 +139,8 @@ public class EagerUniqueKeyTest extends BaseReactiveTest {
 		Bar() {
 		}
 
-		@GeneratedValue
 		@Id
+		@GeneratedValue
 		long id;
 		@Column(name = "nat_key", unique = true)
 		String key;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyUniqueKeyTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyUniqueKeyTest.java
@@ -10,6 +10,7 @@ import io.vertx.ext.unit.TestContext;
 import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
 import jakarta.persistence.CascadeType;
@@ -24,6 +25,9 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 
+/**
+ * @see EagerUniqueKeyTest
+ */
 public class LazyUniqueKeyTest extends BaseReactiveTest {
 
 	@Override
@@ -62,6 +66,7 @@ public class LazyUniqueKeyTest extends BaseReactiveTest {
 				) ) );
 	}
 
+	@Ignore // This also fails in ORM
 	@Test
 	public void testMergeReference(TestContext context) {
 		Bar bar = new Bar( "unique3" );
@@ -74,6 +79,23 @@ public class LazyUniqueKeyTest extends BaseReactiveTest {
 						.withTransaction( session-> session.fetch( result.bar )
 						.thenAccept( b -> context.assertEquals( "unique3", b.key ) )
 				) ) );
+	}
+
+	@Test
+	public void testPersistReference(TestContext context) {
+		Bar bar = new Bar( "unique3" );
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( bar ) )
+				.thenCompose( i -> getSessionFactory()
+						.withTransaction( session-> {
+							Foo foo = new Foo( session.getReference( Bar.class, bar.id ) );
+							return session.persist( foo ).thenApply( v -> foo );
+						} )
+				)
+				.thenCompose( result -> getSessionFactory()
+						.withTransaction( session-> session.fetch( result.bar )
+								.thenAccept( b -> context.assertEquals( "unique3", b.getKey() ) )
+						) ) );
 	}
 
 	@Entity(name = "Foo")
@@ -108,5 +130,13 @@ public class LazyUniqueKeyTest extends BaseReactiveTest {
 		long id;
 		@Column(name = "nat_key", unique = true)
 		String key;
+
+		public String getKey() {
+			return key;
+		}
+
+		public void setKey(String key) {
+			this.key = key;
+		}
 	}
 }


### PR DESCRIPTION
This is an unusual use case where the association is with an entity
column instead of the identifier. It's a specific case and the current
mapping, as it is, fails using regular Hibernate ORM anyway.

I've added a test with the persist that seems to work as expected.