### PR TITLE
Ignore tests removing an element from a collection of elements

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -20,6 +20,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Test;
 
 import io.smallrye.mutiny.Uni;
@@ -118,6 +119,7 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 	}
 
 	@Test
+	@Ignore // see https://github.com/hibernate/hibernate-reactive/issues/1506
 	public void removeOneElementWithStageAPI(TestContext context) {
 		test( context, openSession()
 				.thenCompose( session -> session
@@ -132,6 +134,7 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 	}
 
 	@Test
+	@Ignore // see https://github.com/hibernate/hibernate-reactive/issues/1506
 	public void removeOneElementWithMutinyAPI(TestContext context) {
 		test( context, getMutinySessionFactory()
 				.withTransaction( (session, transaction) -> session
@@ -175,6 +178,7 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 	}
 
 	@Test
+	@Ignore // see https://github.com/hibernate/hibernate-reactive/issues/1506
 	public void removeAndAddElementWithStageAPI(TestContext context) {
 		test( context, getSessionFactory()
 				.withTransaction( (session, transaction) -> session
@@ -191,6 +195,7 @@ public class EagerElementCollectionForBasicTypeSetTest extends BaseReactiveTest 
 	}
 
 	@Test
+	@Ignore // see https://github.com/hibernate/hibernate-reactive/issues/1506
 	public void removeAndAddElementWithMutinyAPI(TestContext context){
 		test ( context, getMutinySessionFactory()
 				.withTransaction( (session, transaction) -> session


### PR DESCRIPTION
Removing an element, remove the whole collection.
This seems to also fail in regular ORM.

Ignoring tests for now as part of the issue