### PR TITLE
Enable ci tests using latest Hibernate snapshots

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        db: [ 'MariaDB', 'MySQL', 'PostgreSQL', 'DB2', 'CockroachDB', 'MSSQLServer', 'Oracle' ]
+#        db: [ 'MariaDB', 'MySQL', 'PostgreSQL', 'DB2', 'CockroachDB', 'MSSQLServer', 'Oracle' ]
+        db: [ 'MariaDB', 'MySQL', 'PostgreSQL', 'MSSQLServer' ]
     steps:
     - uses: actions/checkout@v2
     - name: Get year/month for cache key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,7 +123,7 @@ jobs:
         distribution: 'temurin'
         java-version: 11
     - name: Build and Test with ${{ matrix.db }}
-      run: ./gradlew build -x test -PshowStandardOutput -Pdocker -Pdb=${{ matrix.db }}
+      run: ./gradlew build -PshowStandardOutput -Pdocker -Pdb=${{ matrix.db }}
     - name: Upload reports (if build failed)
       uses: actions/upload-artifact@v2
       if: failure()
@@ -200,7 +200,7 @@ jobs:
         ${{ steps.testjdk-exportpath.outputs.path }}/bin/java -version
     - name: Build and Test with Java ${{ matrix.java.name }}
       run: |
-        ./gradlew build -x test -PshowStandardOutput -Pdocker -Ptest.jdk.version=${{ matrix.java.java_version_numeric }} \
+        ./gradlew build -PshowStandardOutput -Pdocker -Ptest.jdk.version=${{ matrix.java.java_version_numeric }} \
             -Porg.gradle.java.installations.paths=${{ steps.mainjdk-exportpath.outputs.path }},${{ steps.testjdk-exportpath.outputs.path }} \
             ${{ matrix.java.jvm_args && '-Ptest.jdk.launcher.args=' }}${{ matrix.java.jvm_args }}
     - name: Upload reports (if build failed)

--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,10 @@ ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
         hibernateOrmVersion = '6.2.0.CR4'
     }
+    if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
+        // Same as ORM as default
+        hibernateOrmGradlePluginVersion = project.hibernateOrmVersion
+    }
     // For ORM, we need a parsed version (to get the family, ...)
 
     // For ORM, we need a parsed version (to get the family for the documentation during release).
@@ -85,6 +89,7 @@ ext {
     testcontainersVersion = '1.17.5'
 
     logger.lifecycle "Hibernate ORM Version: " + project.hibernateOrmVersion
+    logger.lifecycle "Hibernate ORM Gradle plugin Version: " + project.hibernateOrmGradlePluginVersion
     logger.lifecycle "Vert.x Version: " + project.vertxVersion
     logger.lifecycle "Hibernate Reactive: " + project.version
 }

--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -27,24 +27,23 @@ dependencies {
 buildscript {
     repositories {
         // Example: ./gradlew build -PenableMavenLocalRepo
-        if ( project.hasProperty('enableMavenLocalRepo') ) {
+        if ( project.hasProperty( 'enableMavenLocalRepo' ) ) {
             // Useful for local development, it should be disabled otherwise
             mavenLocal()
         }
         maven {
-            url = uri("https://plugins.gradle.org/m2/")
+            url 'https://plugins.gradle.org/m2/'
         }
-
         mavenCentral()
 
         // Example: ./gradlew build -PenableJBossSnapshotsRep
-        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+        if ( project.hasProperty( 'enableJBossSnapshotsRep' ) ) {
             // Used only for testing with the latest Hibernate ORM snapshots.
             maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
         }
     }
     dependencies {
-        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmVersion}"
+        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmGradlePluginVersion}"
     }
 }
 

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -28,26 +28,26 @@ dependencies {
 buildscript {
     repositories {
         // Example: ./gradlew build -PenableMavenLocalRepo
-        if ( project.hasProperty('enableMavenLocalRepo') ) {
+        if ( project.hasProperty( 'enableMavenLocalRepo' ) ) {
             // Useful for local development, it should be disabled otherwise
             mavenLocal()
         }
         maven {
-            url = uri("https://plugins.gradle.org/m2/")
+            url 'https://plugins.gradle.org/m2/'
         }
-
         mavenCentral()
 
         // Example: ./gradlew build -PenableJBossSnapshotsRep
-        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+        if ( project.hasProperty( 'enableJBossSnapshotsRep' ) ) {
             // Used only for testing with the latest Hibernate ORM snapshots.
             maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
         }
     }
     dependencies {
-        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmVersion}"
+        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmGradlePluginVersion}"
     }
 }
+
 
 // Hibernate Gradle plugin to enable bytecode enhancements
 apply plugin: 'org.hibernate.orm'

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,10 +35,15 @@ enableSonatypeOpenSourceSnapshotsRep = true
 #enableJBossSnapshotsRep = true
 
 # Enable the maven local repository (for local development when needed) when present (value ignored)
-enableMavenLocalRepo = true
+#enableMavenLocalRepo = true
 
 # Override default Hibernate ORM version
 hibernateOrmVersion = 6.2.0-SNAPSHOT
+
+# Override default Hibernate ORM Gradle plugin version
+# Using the stable version because I don't know how to configure the build to download the snapshot version from
+# a remote repository
+hibernateOrmGradlePluginVersion = 6.2.0.CR4
 
 # If set to true, skip Hibernate ORM version parsing (default is true, if set to null)
 # this is required when using intervals or weird versions or the build will fail

--- a/integration-tests/bytecode-enhancements-it/build.gradle
+++ b/integration-tests/bytecode-enhancements-it/build.gradle
@@ -30,26 +30,26 @@ dependencies {
 buildscript {
     repositories {
         // Example: ./gradlew build -PenableMavenLocalRepo
-        if ( project.hasProperty('enableMavenLocalRepo') ) {
+        if ( project.hasProperty( 'enableMavenLocalRepo' ) ) {
             // Useful for local development, it should be disabled otherwise
             mavenLocal()
         }
         maven {
-            url = uri("https://plugins.gradle.org/m2/")
+            url 'https://plugins.gradle.org/m2/'
         }
-
         mavenCentral()
 
         // Example: ./gradlew build -PenableJBossSnapshotsRep
-        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+        if ( project.hasProperty( 'enableJBossSnapshotsRep' ) ) {
             // Used only for testing with the latest Hibernate ORM snapshots.
             maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
         }
     }
     dependencies {
-        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmVersion}"
+        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmGradlePluginVersion}"
     }
 }
+
 
 // Hibernate Gradle plugin to enable bytecode enhancements
 apply plugin: 'org.hibernate.orm'


### PR DESCRIPTION
This also changes to sonatype link to: https://oss.sonatype.org/content/repositories/snapshots/