### PR TITLE
Test for auto-flush and ordering of executions

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/PersistThenDeleteTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/PersistThenDeleteTest.java
@@ -1,0 +1,110 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Collection;
+import java.util.List;
+
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+public class PersistThenDeleteTest extends BaseReactiveTest {
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( PersistThenDeleteTest.Person.class );
+	}
+
+	@Test
+	public void testPersistThenDelete(TestContext context) {
+		test(context,
+			 getSessionFactory().withTransaction(
+							 (s, t) -> s.persist( newPerson( "foo" ), newPerson( "bar" ), newPerson( "baz" ) )
+					 )
+					 .thenCompose(
+							 v ->
+							 getSessionFactory().withTransaction(
+											 (s, t) -> s.createQuery( "from Person" ).getResultList().thenAccept( l ->
+											 context.assertEquals( 3, l.size() )
+											 )
+							 )
+					 )
+					 .thenCompose(
+							v ->
+							getSessionFactory().withTransaction(
+									(s, t) ->
+										s.persist( newPerson( "critical" ) )
+												.thenCompose( (ignored) -> s.flush() ) // Shouldn't be required!
+												.thenCompose( vo -> s.createQuery( "delete from Person" )
+														.executeUpdate() )
+								  )
+					 )
+					 .thenCompose(
+							 v ->
+									 getSessionFactory().withTransaction(
+											 (s, t) -> s.createQuery( "from Person" ).getResultList().thenAccept( l ->
+																														  context.assertEquals( 0, l.size() )
+											 )
+									 )
+					 )
+		);
+	}
+
+	@Test
+	public void testDeleteThenPersist(TestContext context) {
+		test(context,
+			 getSessionFactory().withTransaction(
+							 (s, t) -> s.persist( newPerson( "foo" ), newPerson( "bar" ), newPerson( "baz" ) )
+					 )
+					 .thenCompose(
+							 v ->
+									 getSessionFactory().withTransaction(
+											 (s, t) -> s.createQuery( "from Person" ).getResultList().thenAccept( l ->
+																														  context.assertEquals( 3, l.size() )
+											 )
+									 )
+					 )
+					 .thenCompose(
+							 v ->
+									 getSessionFactory().withTransaction(
+											 (s, t) ->
+													 s.createQuery( "delete from Person" ).executeUpdate()
+															 .thenCompose( vo -> s.persist( newPerson( "critical" ) ) )
+									 )
+					 )
+					 .thenCompose(
+							 v ->
+									 getSessionFactory().withTransaction(
+											 (s, t) -> s.createQuery( "from Person" ).getResultList().thenAccept( l ->
+																														  context.assertEquals( 1, l.size() )
+											 )
+									 )
+					 )
+		);
+	}
+
+	private static Person newPerson(String name) {
+		final Person person = new Person();
+		person.name = name;
+		return person;
+	}
+
+	@Entity(name="Person")
+	public static class Person {
+
+		@Id
+		@GeneratedValue
+		Integer id;
+
+		String name;
+	}
+
+}


### PR DESCRIPTION
Test for issue #1512 

This introduces a test for the missing auto-flush capababilities in Hibernate Reactive;
the test is currently passing as there's an explicit flush() : this should be unnecessary.

Included an ORM test as well for comparison.