### PR TITLE
reactive examples compatible with 6.2 ORM

### DIFF
--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -1,0 +1,87 @@
+description = 'Hibernate Reactive native SQL Example'
+
+dependencies {
+    implementation project(':hibernate-reactive-core')
+
+    // Hibernate Validator (optional)
+    implementation 'org.hibernate.validator:hibernate-validator:7.0.2.Final'
+    runtimeOnly 'org.glassfish:jakarta.el:3.0.3'
+
+    // JPA metamodel generation for criteria queries (optional)
+    annotationProcessor "org.hibernate.orm:hibernate-jpamodelgen:${hibernateOrmVersion}"
+
+    // database driver for PostgreSQL
+    runtimeOnly "io.vertx:vertx-pg-client:${vertxVersion}"
+
+    // logging (optional)
+    runtimeOnly "org.apache.logging.log4j:log4j-core:2.17.2"
+
+    // Allow authentication to PostgreSQL using SCRAM:
+    runtimeOnly 'com.ongres.scram:client:2.1'
+}
+
+buildscript {
+    repositories {
+        // Example: ./gradlew build -PenableMavenLocalRepo
+        if ( project.hasProperty('enableMavenLocalRepo') ) {
+            // Useful for local development, it should be disabled otherwise
+            mavenLocal()
+        }
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
+
+        mavenCentral()
+
+        // Example: ./gradlew build -PenableJBossSnapshotsRep
+        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+            // Used only for testing with the latest Hibernate ORM snapshots.
+            maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
+        }
+    }
+    dependencies {
+        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmVersion}"
+    }
+}
+
+// Hibernate Gradle plugin to enable bytecode enhancements
+apply plugin: 'org.hibernate.orm'
+
+hibernate {
+    enhancement {
+        lazyInitialization(true)
+        dirtyTracking(true)
+        associationManagement(false)
+    }
+}
+// The following rules define a task to run
+// the different API available.
+//
+// They require the selected db ready
+// to accept connections.
+//
+// Examples:
+// gradle runExampleMySQLMain runExamplePostgreSQLMutinyMain
+def mainClasses = ['Main', 'MutinyMain']
+def dbs = ['PostgreSQL']
+
+dbs.each { db ->
+    tasks.addRule( "Pattern runExampleOn${db}<mainClass>" ) { String taskName ->
+        if ( taskName.startsWith( "runExampleOn${db}" ) ) {
+            task( type: JavaExec, taskName ) {
+                def  mainClass = taskName.substring( "runExampleOn${db}".length() )
+                group = "Execution"
+                description = "Run ${mainClass} on ${db}"
+                classpath = sourceSets.main.runtimeClasspath
+                main = "org.hibernate.reactive.example.nativesql.${mainClass}"
+                // The persistence unit name defined in resources/META-INF/persistence.xml
+                args db.toLowerCase() + '-example'
+            }
+        }
+    }
+}
+
+task runAllExamplesOnPostgreSQL(
+        dependsOn: mainClasses.collect( [] as HashSet ) { mainClass -> "runExampleOnPostgreSQL${mainClass}" } ) {
+    description = "Run ${mainClasses} on PostgreSQL"
+}

--- a/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Author.java
+++ b/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Author.java
@@ -1,0 +1,53 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.nativesql;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLInsert;
+import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.annotations.Subselect;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+@Entity
+@Subselect("select name, id from authors")
+@SQLInsert(sql = "insert into authors (name, id) values ($1, $2)")
+@SQLUpdate(sql = "")
+@SQLDelete(sql = "delete from authors where id = $1")
+@Table(name="authors")
+class Author {
+	@Id @GeneratedValue
+	private Integer id;
+
+	@NotNull @Size(max=100)
+	private String name;
+
+	@OneToMany(mappedBy = "author")
+	private List<Book> books = new ArrayList<>();
+
+	Author(String name) {
+		this.name = name;
+	}
+
+	Author() {}
+
+	Integer getId() {
+		return id;
+	}
+
+	String getName() {
+		return name;
+	}
+
+	List<Book> getBooks() {
+		return books;
+	}
+}

--- a/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Book.java
+++ b/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Book.java
@@ -1,0 +1,74 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.nativesql;
+
+import java.time.LocalDate;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLInsert;
+import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.annotations.Subselect;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Subselect("select author_id, isbn, published, title, id from books")
+@SQLInsert(sql = "insert into books (author_id, isbn, published, title, id) values ($1, $2, $3, $4, $5)")
+@SQLUpdate(sql = "")
+@SQLDelete(sql = "delete from books where id=$1")
+@Table(name="books")
+class Book {
+	@Id @GeneratedValue
+	private Integer id;
+
+	@Size(min=13, max=13)
+	private String isbn;
+
+	@NotNull @Size(max=100)
+	private String title;
+
+	@Basic(fetch = LAZY)
+	@NotNull @Past
+	private LocalDate published;
+
+	@NotNull
+	@ManyToOne(fetch = LAZY)
+	private Author author;
+
+	Book(String isbn, String title, Author author, LocalDate published) {
+		this.title = title;
+		this.isbn = isbn;
+		this.author = author;
+		this.published = published;
+	}
+
+	Book() {}
+
+	Integer getId() {
+		return id;
+	}
+
+	String getIsbn() {
+		return isbn;
+	}
+
+	String getTitle() {
+		return title;
+	}
+
+	Author getAuthor() {
+		return author;
+	}
+
+	LocalDate getPublished() {
+		return published;
+	}
+}

--- a/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Main.java
+++ b/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/Main.java
@@ -1,0 +1,156 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.nativesql;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.Persistence.createEntityManagerFactory;
+import static java.lang.System.out;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static org.hibernate.reactive.stage.Stage.SessionFactory;
+
+/**
+ * Demonstrates the use of Hibernate Reactive with the
+ * {@link java.util.concurrent.CompletionStage}-based
+ * API.
+ *
+ * Here we use stateless sessions and handwritten SQL.
+ */
+public class Main {
+
+	// The first argument can be used to select a persistence unit.
+	// Check resources/META-INF/persistence.xml for available names.
+	public static void main(String[] args) {
+		out.println( "== CompletionStage API Example ==" );
+
+		// obtain a factory for reactive sessions based on the
+		// standard JPA configuration properties specified in
+		// resources/META-INF/persistence.xml
+		SessionFactory factory =
+				createEntityManagerFactory( persistenceUnitName( args ) )
+						.unwrap(SessionFactory.class);
+
+		// define some test data
+		Author author1 = new Author("Iain M. Banks");
+		Author author2 = new Author("Neal Stephenson");
+		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+		Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+		Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+		author1.getBooks().add(book1);
+		author2.getBooks().add(book2);
+		author2.getBooks().add(book3);
+
+		try {
+			// obtain a reactive session
+			factory.withStatelessSession(
+							// persist the Authors with their Books in a transaction
+							session -> session.withTransaction(
+									tx -> session.insert( author1, author2, book1, book2, book3 )
+							)
+					)
+					// wait for it to finish
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							// retrieve a Book
+							session -> session.get( Book.class, book1.getId() )
+									// print its title
+									.thenAccept( book -> out.println( book.getTitle() + " is a great book!" ) )
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							// retrieve an Author
+							session -> session.get( Author.class, author2.getId() )
+									// lazily fetch their books
+									.thenCompose( author -> session.fetch( author.getBooks() )
+											// print some info
+											.thenAccept( books -> {
+												out.println( author.getName() + " wrote " + books.size() + " books" );
+												books.forEach( book -> out.println( book.getTitle() ) );
+											} )
+									)
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							// retrieve the Author lazily from a Book
+							session -> session.get( Book.class, book1.getId() )
+									// fetch a lazy field of the Book
+									.thenCompose( book -> session.fetch( book.getAuthor() )
+											// print the lazy field
+											.thenAccept( author -> out.printf( "%s wrote '%s'\n", author.getName(), book1.getTitle() ) )
+									)
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							// query the entire Book entities
+							session -> session.createNativeQuery(
+											"select * from books order by title desc",
+											Book.class
+									)
+									.getResultList()
+									.thenAccept( books -> books.forEach(
+											b -> out.printf(
+													"%s: %s\n",
+													b.getIsbn(),
+													b.getTitle()
+											)
+									) )
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							// query the Book titles
+							session -> session.createNativeQuery(
+											"select book.title, author.name from books book join authors author on book.author_id = author.id order by book.title desc"
+									)
+									.getResultList()
+									.thenAccept( rows -> rows.forEach( row -> {
+											final Object[] theRowArray = (Object[])row;
+											out.printf("%s : (%s)\n", theRowArray[0], theRowArray[1]);
+										} )
+									)
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							session -> session.withTransaction(
+									// delete a detached Book
+									tx -> session.delete( book2 )
+							)
+					)
+					.toCompletableFuture().join();
+
+			factory.withStatelessSession(
+							session -> session.withTransaction(
+									// delete all the Books
+									tx -> session.createNativeQuery( "delete from books" ).executeUpdate()
+											//delete all the Authors
+											.thenCompose( v -> session.createNativeQuery( "delete from authors" ).executeUpdate() )
+							)
+					)
+					.toCompletableFuture().join();
+		}
+		finally {
+			// remember to shut down the factory
+			factory.close();
+		}
+	}
+
+	/**
+	 * Return the persistence unit name to use in the example.
+	 *
+	 * @param args the first element is the persistence unit name if present
+	 * @return the selected persistence unit name or the default one
+	 */
+	public static String persistenceUnitName(String[] args) {
+		return args.length > 0 ? args[0] : "postgresql-example";
+	}
+}

--- a/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/MutinyMain.java
+++ b/examples/native-sql-example/src/main/java/org/hibernate/reactive/example/nativesql/MutinyMain.java
@@ -1,0 +1,155 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.nativesql;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.Persistence.createEntityManagerFactory;
+import static java.lang.System.out;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static org.hibernate.reactive.mutiny.Mutiny.SessionFactory;
+
+/**
+ * Demonstrates the use of Hibernate Reactive with the
+ * {@link io.smallrye.mutiny.Uni Mutiny}-based API.
+ *
+ * Here we use stateless sessions and handwritten SQL.
+ */
+public class MutinyMain {
+
+	// The first argument can be used to select a persistenceUnit.
+	// Check resources/META-INF/persistence.xml for available names.
+	public static void main(String[] args) {
+		out.println( "== Mutiny API Example ==" );
+
+		// obtain a factory for reactive sessions based on the
+		// standard JPA configuration properties specified in
+		// resources/META-INF/persistence.xml
+		SessionFactory factory =
+				createEntityManagerFactory( persistenceUnitName( args ) )
+						.unwrap(SessionFactory.class);
+
+		// define some test data
+		Author author1 = new Author("Iain M. Banks");
+		Author author2 = new Author("Neal Stephenson");
+		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+		Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+		Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+		author1.getBooks().add(book1);
+		author2.getBooks().add(book2);
+		author2.getBooks().add(book3);
+
+		try {
+			// obtain a reactive session
+			factory.withStatelessSession(
+							session -> session.withTransaction(
+									// persist the Authors with their Books in a transaction
+									tx -> session.insertAll( author1, author2, book1, book2, book3 )
+							)
+					)
+					// wait for it to finish
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+							// retrieve a Book
+							session -> session.get( Book.class, book1.getId() )
+									// print its title
+									.invoke( book -> out.println( book.getTitle() + " is a great book!" ) )
+					)
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+							// retrieve an Author
+							session -> session.get( Author.class, author2.getId() )
+									// lazily fetch their books
+									.chain( author -> session.fetch( author.getBooks() )
+											// print some info
+											.invoke( books -> {
+												out.println( author.getName() + " wrote " + books.size() + " books" );
+												books.forEach( book -> out.println( book.getTitle() ) );
+											} )
+									)
+					)
+					.await().indefinitely();
+
+			factory.withSession(
+							// retrieve the Author lazily from a Book
+							session -> session.find( Book.class, book1.getId() )
+									// fetch a lazy field of the Book
+									.chain( book -> session.fetch( book.getAuthor() )
+											// print the lazy field
+											.invoke( author -> out.printf( "%s wrote '%s'\n", author.getName(), book1.getTitle() ) )
+									)
+					)
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+						session -> session.createNativeQuery(
+										"select book.title, author.name from books book join authors author on book.author_id = author.id order by book.title desc"
+								)
+								.getResultList()
+								.invoke( rows -> rows.forEach( row -> {
+										final Object[] theRowArray = (Object[])row;
+										out.printf("%s : (%s)\n", theRowArray[0], theRowArray[1]);
+									} )
+								)
+					)
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+							// query the entire Book entities
+							session -> session.createNativeQuery(
+											"select * from books order by title desc",
+											Book.class
+									)
+									.getResultList()
+									.invoke( books -> books.forEach(
+											b -> out.printf(
+													"%s: %s\n",
+													b.getIsbn(),
+													b.getTitle()
+											)
+									) )
+					)
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+							session -> session.withTransaction(
+									// delete a detached Book
+									tx -> session.delete( book2 )
+							)
+					)
+					.await().indefinitely();
+
+			factory.withStatelessSession(
+							session -> session.withTransaction(
+									// delete all the Books
+									tx -> session.createNativeQuery( "delete from books" ).executeUpdate()
+											//delete all the Authors
+											.chain( () -> session.createNativeQuery( "delete from authors" ).executeUpdate() )
+							)
+					)
+					.await().indefinitely();
+
+		}
+		finally {
+			// remember to shut down the factory
+			factory.close();
+		}
+	}
+
+	/**
+	 * Return the persistence unit name to use in the example.
+	 *
+	 * @param args the first element is the persistence unit name if present
+	 * @return the selected persistence unit name or the default one
+	 */
+	public static String persistenceUnitName(String[] args) {
+		return args.length > 0 ? args[0] : "postgresql-example";
+	}
+}

--- a/examples/native-sql-example/src/main/resources/META-INF/create.sql
+++ b/examples/native-sql-example/src/main/resources/META-INF/create.sql
@@ -1,0 +1,4 @@
+create sequence author_SEQ start 1 increment 50
+create sequence book_SEQ start 1 increment 50
+create table authors (id int4 not null, name varchar(100) not null, primary key (id))
+create table books (id int4 not null, isbn varchar(13), published date not null, title varchar(100) not null, author_id int4 not null, primary key (id), foreign key (author_id) references authors)

--- a/examples/native-sql-example/src/main/resources/META-INF/drop.sql
+++ b/examples/native-sql-example/src/main/resources/META-INF/drop.sql
@@ -1,0 +1,4 @@
+drop table if exists authors cascade
+drop table if exists books cascade
+drop sequence if exists author_SEQ
+drop sequence if exists book_SEQ

--- a/examples/native-sql-example/src/main/resources/META-INF/persistence.xml
+++ b/examples/native-sql-example/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,45 @@
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+
+<persistence-unit name="postgresql-example">
+        <provider>org.hibernate.reactive.provider.ReactivePersistenceProvider</provider>
+
+        <class>org.hibernate.reactive.example.nativesql.Author</class>
+        <class>org.hibernate.reactive.example.nativesql.Book</class>
+
+        <properties>
+
+            <!-- PostgreSQL -->
+            <property name="jakarta.persistence.jdbc.url"
+                      value="jdbc:postgresql://localhost/hreact"/>
+
+            <!-- Credentials -->
+            <property name="jakarta.persistence.jdbc.user"
+                      value="hreact"/>
+            <property name="jakarta.persistence.jdbc.password"
+                      value="hreact"/>
+
+            <!-- The Vert.x SQL Client connection pool size -->
+            <property name="hibernate.connection.pool_size"
+                      value="10"/>
+
+            <!-- Automatic schema export -->
+            <property name="jakarta.persistence.schema-generation.database.action"
+                      value="drop-and-create"/>
+            <property name="jakarta.persistence.schema-generation.create-source" value="script"/>
+            <property name="jakarta.persistence.schema-generation.drop-source" value="script"/>
+            <property name="jakarta.persistence.schema-generation.create-script-source" value="META-INF/create.sql"/>
+            <property name="jakarta.persistence.schema-generation.drop-script-source" value="META-INF/drop.sql"/>
+
+            <!-- SQL statement logging -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.highlight_sql" value="true"/>
+
+        </properties>
+
+    </persistence-unit>
+
+</persistence>

--- a/examples/native-sql-example/src/main/resources/log4j2.properties
+++ b/examples/native-sql-example/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+rootLogger.level = info
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = console
+
+logger.hibernate.name = org.hibernate.SQL
+logger.hibernate.level = info
+
+appender.console.name = console
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %highlight{[%p]} %m%n

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -1,0 +1,102 @@
+description = 'Hibernate Reactive Session Example'
+
+dependencies {
+    implementation project(':hibernate-reactive-core')
+
+    // Hibernate Validator (optional)
+    implementation 'org.hibernate.validator:hibernate-validator:7.0.2.Final'
+    runtimeOnly 'org.glassfish:jakarta.el:3.0.3'
+
+    // JPA metamodel generation for criteria queries (optional)
+    annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernateOrmVersion}"
+
+    // database drivers for PostgreSQL and MySQL
+    runtimeOnly "io.vertx:vertx-pg-client:${vertxVersion}"
+    runtimeOnly "io.vertx:vertx-mysql-client:${vertxVersion}"
+
+    // logging (optional)
+    runtimeOnly "org.apache.logging.log4j:log4j-core:2.17.2"
+
+    // Allow authentication to PostgreSQL using SCRAM:
+    runtimeOnly 'com.ongres.scram:client:2.1'
+}
+
+// All of the remaining configuration is only necessary to enable
+// the Hibernate bytecode enhancer and field-level lazy fetching.
+// (This is very optional!)
+
+buildscript {
+    repositories {
+        // Example: ./gradlew build -PenableMavenLocalRepo
+        if ( project.hasProperty('enableMavenLocalRepo') ) {
+            // Useful for local development, it should be disabled otherwise
+            mavenLocal()
+        }
+        maven {
+            url = uri("https://plugins.gradle.org/m2/")
+        }
+
+        mavenCentral()
+
+        // Example: ./gradlew build -PenableJBossSnapshotsRep
+        if ( project.hasProperty('enableJBossSnapshotsRep') ) {
+            // Used only for testing with the latest Hibernate ORM snapshots.
+            maven { url 'https://repository.jboss.org/nexus/content/repositories/snapshots' }
+        }
+    }
+    dependencies {
+        classpath "org.hibernate.orm:hibernate-gradle-plugin:${hibernateOrmVersion}"
+    }
+}
+
+// Hibernate Gradle plugin to enable bytecode enhancements
+apply plugin: 'org.hibernate.orm'
+
+hibernate {
+    enhancement {
+        lazyInitialization(true)
+        dirtyTracking(true)
+        associationManagement(false)
+    }
+}
+
+// The following rules define a task to run
+// the different API available.
+//
+// They require the selected db ready
+// to accept connections.
+//
+// Examples:
+// gradle runExampleMySQLMain runExamplePostgreSQLMutinyMain
+def mainClasses = ['Main', 'MutinyMain']
+def dbs = ['PostgreSQL', 'MySQL']
+
+dbs.each { db ->
+    tasks.addRule( "Pattern runExampleOn${db}<mainClass>" ) { String taskName ->
+        if ( taskName.startsWith( "runExampleOn${db}" ) ) {
+            task( type: JavaExec, taskName ) {
+                def  mainClass = taskName.substring( "runExampleOn${db}".length() )
+                group = "Execution"
+                description = "Run ${mainClass} on ${db}"
+                classpath = sourceSets.main.runtimeClasspath
+                main = "org.hibernate.reactive.example.session.${mainClass}"
+                // The persistence unit name defined in resources/META-INF/persistence.xml
+                args db.toLowerCase() + '-example'
+            }
+        }
+    }
+}
+
+task runAllExamplesOnPostgreSQL(
+        dependsOn: mainClasses.collect( [] as HashSet ) { mainClass -> "runExampleOnPostgreSQL${mainClass}" } ) {
+    description = "Run ${mainClasses} on PostgreSQL"
+}
+
+task runAllExamplesOnMySQL(
+        dependsOn: mainClasses.collect( [] as HashSet ) { mainClass -> "runExampleOnMySQL${mainClass}" } ) {
+    description = "Run ${mainClasses} on MySQL"
+}
+
+task runAllExamples( dependsOn: ["runAllExamplesOnPostgreSQL", "runAllExamplesOnMySQL"] ) {
+    description = "Run  examples on ${mainClasses}"
+}

--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Author.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Author.java
@@ -1,0 +1,49 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.session;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.ArrayList;
+import java.util.List;
+
+import static jakarta.persistence.CascadeType.PERSIST;
+
+@Entity
+@Table(name="authors")
+public class Author {
+	@Id @GeneratedValue
+	private Integer id;
+
+	@NotNull @Size(max=100)
+	private String name;
+
+	@OneToMany(mappedBy = "author", cascade = PERSIST)
+	private List<Book> books = new ArrayList<>();
+
+	Author(String name) {
+		this.name = name;
+	}
+
+	Author() {}
+
+	Integer getId() {
+		return id;
+	}
+
+	String getName() {
+		return name;
+	}
+
+	List<Book> getBooks() {
+		return books;
+	}
+}

--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Book.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Book.java
@@ -1,0 +1,78 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.session;
+
+import jakarta.persistence.Basic;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Past;
+import jakarta.validation.constraints.Size;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.FetchType.LAZY;
+
+@Entity
+@Table(name="books")
+class Book {
+	@Id @GeneratedValue
+	private Integer id;
+
+	@Size(min=13, max=13)
+	private String isbn;
+
+	@NotNull @Size(max=100)
+	private String title;
+
+	@Basic(fetch = LAZY)
+	@NotNull @Past
+	private LocalDate published;
+
+	@Basic(fetch = LAZY)
+	public byte[] coverImage;
+
+	@NotNull
+	@ManyToOne(fetch = LAZY)
+	private Author author;
+
+	Book(String isbn, String title, Author author, LocalDate published) {
+		this.title = title;
+		this.isbn = isbn;
+		this.author = author;
+		this.published = published;
+		this.coverImage = ("Cover image for '" + title + "'").getBytes();
+	}
+
+	Book() {}
+
+	Integer getId() {
+		return id;
+	}
+
+	String getIsbn() {
+		return isbn;
+	}
+
+	String getTitle() {
+		return title;
+	}
+
+	Author getAuthor() {
+		return author;
+	}
+
+	LocalDate getPublished() {
+		return published;
+	}
+
+	byte[] getCoverImage() {
+		return coverImage;
+	}
+}

--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Main.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/Main.java
@@ -1,0 +1,192 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.session;
+
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.Persistence.createEntityManagerFactory;
+import static java.lang.System.out;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static org.hibernate.reactive.stage.Stage.SessionFactory;
+import static org.hibernate.reactive.stage.Stage.fetch;
+
+/**
+ * Demonstrates the use of Hibernate Reactive with the
+ * {@link java.util.concurrent.CompletionStage}-based
+ * API.
+ */
+public class Main {
+
+	// The first argument can be used to select a persistence unit.
+	// Check resources/META-INF/persistence.xml for available names.
+	public static void main(String[] args) {
+		out.println( "== CompletionStage API Example ==" );
+
+		// obtain a factory for reactive sessions based on the
+		// standard JPA configuration properties specified in
+		// resources/META-INF/persistence.xml
+		SessionFactory factory =
+				createEntityManagerFactory( persistenceUnitName( args ) )
+						.unwrap(SessionFactory.class);
+
+		// define some test data
+		Author author1 = new Author("Iain M. Banks");
+		Author author2 = new Author("Neal Stephenson");
+		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+		Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+		Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+		author1.getBooks().add(book1);
+		author2.getBooks().add(book2);
+		author2.getBooks().add(book3);
+
+		try {
+			// obtain a reactive session
+			factory.withTransaction(
+					// persist the Authors with their Books in a transaction
+					(session, tx) -> session.persist( author1, author2 )
+			)
+					// wait for it to finish
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// retrieve a Book
+					session -> session.find( Book.class, book1.getId() )
+							// print its title
+							.thenAccept( book -> out.println( book.getTitle() + " is a great book!" ) )
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// retrieve both Authors at once
+					session -> session.find( Author.class, author1.getId(), author2.getId() )
+							.thenAccept( authors -> authors.forEach( author -> out.println( author.getName() ) ) )
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// retrieve an Author
+					session -> session.find( Author.class, author2.getId() )
+							// lazily fetch their books
+							.thenCompose( author -> fetch( author.getBooks() )
+									// print some info
+									.thenAccept( books -> {
+										out.println( author.getName() + " wrote " + books.size() + " books" );
+										books.forEach( book -> out.println( book.getTitle() ) );
+									} )
+							)
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// retrieve the Author lazily from a Book
+					session -> session.find( Book.class, book1.getId() )
+							// fetch a lazy field of the Book
+							.thenCompose( book -> fetch( book.getAuthor() )
+									// print the lazy field
+									.thenAccept( author -> out.printf( "%s wrote '%s'\n", author.getName(), book1.getTitle() ) )
+							)
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// query the Book titles
+					session -> session.createQuery(
+							"select title, author.name from Book order by title desc",
+							Object[].class
+					)
+							.getResultList()
+							.thenAccept( rows -> rows.forEach(
+									row -> out.printf( "%s (%s)\n", row[0], row[1] )
+							) )
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// query the entire Book entities
+					session -> session.createQuery(
+							"from Book book join fetch book.author order by book.title desc",
+							Book.class
+					)
+							.getResultList()
+							.thenAccept( books -> books.forEach(
+									b -> out.printf(
+											"%s: %s (%s)\n",
+											b.getIsbn(),
+											b.getTitle(),
+											b.getAuthor().getName()
+									)
+							) )
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// use a criteria query
+					session -> {
+						CriteriaQuery<Book> query = factory.getCriteriaBuilder().createQuery( Book.class );
+						Root<Author> a = query.from( Author.class );
+						Join<Author, Book> b = a.join( Author_.books );
+						query.where( a.get( Author_.name ).in( "Neal Stephenson", "William Gibson" ) );
+						query.select( b );
+						return session.createQuery( query ).getResultList().thenAccept(
+								books -> books.forEach( book -> out.println( book.getTitle() ) )
+						);
+					}
+			)
+					.toCompletableFuture().join();
+
+			factory.withSession(
+					// retrieve a Book
+					session -> session.find( Book.class, book1.getId() )
+							// fetch a lazy field of the Book
+							.thenCompose( book -> session.fetch( book, Book_.published )
+									// print the lazy field
+									.thenAccept( published -> out.printf(
+											"'%s' was published in %d\n",
+											book.getTitle(),
+											published.getYear()
+									) )
+							)
+			)
+					.toCompletableFuture().join();
+
+			factory.withTransaction(
+					// retrieve a Book
+					(session, tx) -> session.find( Book.class, book2.getId() )
+							// delete the Book
+							.thenCompose( session::remove )
+			)
+					.toCompletableFuture().join();
+
+			factory.withTransaction(
+					// delete all the Books in a transaction
+					(session, tx) -> session.createQuery( "delete Book" ).executeUpdate()
+							// delete all the Authors
+							.thenCompose( $ -> session.createQuery( "delete Author" ).executeUpdate() )
+			)
+					.toCompletableFuture().join();
+		}
+		finally {
+			// remember to shut down the factory
+			factory.close();
+		}
+	}
+
+	/**
+	 * Return the persistence unit name to use in the example.
+	 *
+	 * @param args the first element is the persistence unit name if present
+	 * @return the selected persistence unit name or the default one
+	 */
+	public static String persistenceUnitName(String[] args) {
+		return args.length > 0 ? args[0] : "postgresql-example";
+	}
+}

--- a/examples/session-example/src/main/java/org/hibernate/reactive/example/session/MutinyMain.java
+++ b/examples/session-example/src/main/java/org/hibernate/reactive/example/session/MutinyMain.java
@@ -1,0 +1,196 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example.session;
+
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Join;
+import jakarta.persistence.criteria.Root;
+
+import java.time.LocalDate;
+
+import static jakarta.persistence.Persistence.createEntityManagerFactory;
+import static java.lang.System.out;
+import static java.time.Month.JANUARY;
+import static java.time.Month.JUNE;
+import static java.time.Month.MAY;
+import static org.hibernate.reactive.mutiny.Mutiny.SessionFactory;
+import static org.hibernate.reactive.mutiny.Mutiny.fetch;
+
+/**
+ * Demonstrates the use of Hibernate Reactive with the
+ * {@link io.smallrye.mutiny.Uni Mutiny}-based API.
+ */
+public class MutinyMain {
+
+	// The first argument can be used to select a persistenceUnit.
+	// Check resources/META-INF/persistence.xml for available names.
+	public static void main(String[] args) {
+		out.println( "== Mutiny API Example ==" );
+
+		// obtain a factory for reactive sessions based on the
+		// standard JPA configuration properties specified in
+		// resources/META-INF/persistence.xml
+		SessionFactory factory =
+				createEntityManagerFactory( persistenceUnitName( args ) )
+						.unwrap(SessionFactory.class);
+
+		// define some test data
+		Author author1 = new Author("Iain M. Banks");
+		Author author2 = new Author("Neal Stephenson");
+		Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+		Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+		Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+		author1.getBooks().add(book1);
+		author2.getBooks().add(book2);
+		author2.getBooks().add(book3);
+
+		try {
+			// obtain a reactive session
+			factory.withTransaction(
+					// persist the Authors with their Books in a transaction
+					(session, tx) -> session.persistAll( author1, author2)
+			)
+					// wait for it to finish
+					.await().indefinitely();
+
+			factory.withSession(
+					// retrieve a Book
+					session -> session.find( Book.class, book1.getId() )
+							// print its title
+							.invoke( book -> out.println( book.getTitle() + " is a great book!" ) )
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// retrieve both Authors at once
+					session -> session.find( Author.class, author1.getId(), author2.getId() )
+							.invoke( authors -> authors.forEach( author -> out.println( author.getName() ) ) )
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// retrieve an Author
+					session -> session.find( Author.class, author2.getId() )
+							// lazily fetch their books
+							.chain( author -> fetch( author.getBooks() )
+									// print some info
+									.invoke( books -> {
+										out.println( author.getName() + " wrote " + books.size() + " books" );
+										books.forEach( book -> out.println( book.getTitle() ) );
+									} )
+							)
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// retrieve the Author lazily from a Book
+					session -> session.find( Book.class, book1.getId() )
+							// fetch a lazy field of the Book
+							.chain( book -> fetch( book.getAuthor() )
+									// print the lazy field
+									.invoke( author -> out.printf( "%s wrote '%s'\n", author.getName(), book1.getTitle() ) )
+							)
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// query the Book titles
+					session -> session.createQuery(
+							"select title, author.name from Book order by title desc",
+							Object[].class
+					)
+							.getResultList()
+							.invoke( rows -> rows.forEach(
+									row -> out.printf( "%s (%s)\n", row[0], row[1] )
+							) )
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// query the entire Book entities
+					session -> session.createQuery(
+							"from Book book join fetch book.author order by book.title desc",
+							Book.class
+					)
+							.getResultList()
+							.invoke( books -> books.forEach(
+									b -> out.printf(
+											"%s: %s (%s)\n",
+											b.getIsbn(),
+											b.getTitle(),
+											b.getAuthor().getName()
+									)
+							) )
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// use a criteria query
+					session -> {
+						CriteriaQuery<Book> query = factory.getCriteriaBuilder().createQuery( Book.class );
+						Root<Author> a = query.from( Author.class );
+						Join<Author, Book> b = a.join( Author_.books );
+						query.where( a.get( Author_.name ).in( "Neal Stephenson", "William Gibson" ) );
+						query.select( b );
+						return session.createQuery( query ).getResultList().invoke(
+								books -> books.forEach( book -> out.println( book.getTitle() ) )
+						);
+					}
+			)
+					.await().indefinitely();
+
+			factory.withSession(
+					// retrieve a Book
+					session -> session.find( Book.class, book1.getId() )
+							// fetch a lazy field of the Book
+							.call( book -> session.fetch( book, Book_.published )
+									// print one lazy field
+									.invoke( published -> out.printf(
+											"'%s' was published in %d\n",
+											book.getTitle(),
+											published.getYear()
+									) )
+							)
+							.call( book -> session.fetch( book, Book_.coverImage )
+									// print the other lazy field
+									.invoke( coverImage -> out.println( new String( coverImage ) ) )
+							)
+					)
+					.await().indefinitely();
+
+			factory.withTransaction(
+					// retrieve a Book
+					(session, tx) -> session.find( Book.class, book2.getId() )
+							// delete the Book
+							.chain( session::remove )
+			)
+					.await().indefinitely();
+
+			factory.withTransaction(
+					// delete all the Books in a transaction
+					(session, tx) -> session.createQuery( "delete Book" ).executeUpdate()
+							//delete all the Authors
+							.call( () -> session.createQuery( "delete Author" ).executeUpdate() )
+			)
+					.await().indefinitely();
+
+		}
+		finally {
+			// remember to shut down the factory
+			factory.close();
+		}
+	}
+
+	/**
+	 * Return the persistence unit name to use in the example.
+	 *
+	 * @param args the first element is the persistence unit name if present
+	 * @return the selected persistence unit name or the default one
+	 */
+	public static String persistenceUnitName(String[] args) {
+		return args.length > 0 ? args[0] : "postgresql-example";
+	}
+}

--- a/examples/session-example/src/main/resources/META-INF/persistence.xml
+++ b/examples/session-example/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,75 @@
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+             version="3.0">
+
+<persistence-unit name="postgresql-example">
+        <provider>org.hibernate.reactive.provider.ReactivePersistenceProvider</provider>
+
+        <class>org.hibernate.reactive.example.session.Author</class>
+        <class>org.hibernate.reactive.example.session.Book</class>
+
+        <properties>
+
+            <!-- PostgreSQL -->
+            <property name="jakarta.persistence.jdbc.url"
+                      value="jdbc:postgresql://localhost/hreact"/>
+
+            <!-- Credentials -->
+            <property name="jakarta.persistence.jdbc.user"
+                      value="hreact"/>
+            <property name="jakarta.persistence.jdbc.password"
+                      value="hreact"/>
+
+            <!-- The Vert.x SQL Client connection pool size -->
+            <property name="hibernate.connection.pool_size"
+                      value="10"/>
+
+            <!-- Automatic schema export -->
+            <property name="jakarta.persistence.schema-generation.database.action"
+                      value="drop-and-create"/>
+
+            <!-- SQL statement logging -->
+            <property name="hibernate.show_sql" value="true"/>
+            <property name="hibernate.format_sql" value="true"/>
+            <property name="hibernate.highlight_sql" value="true"/>
+
+        </properties>
+
+    </persistence-unit>
+
+    <persistence-unit name="mysql-example">
+        <provider>org.hibernate.reactive.provider.ReactivePersistenceProvider</provider>
+
+        <class>org.hibernate.reactive.example.session.Author</class>
+        <class>org.hibernate.reactive.example.session.Book</class>
+
+        <properties>
+
+            <!-- MySQL -->
+            <property name="jakarta.persistence.jdbc.url"
+                      value="jdbc:mysql://localhost/hreact"/>
+
+            <!-- Credentials -->
+            <property name="jakarta.persistence.jdbc.user"
+                      value="hreact"/>
+            <property name="jakarta.persistence.jdbc.password"
+                      value="hreact"/>
+
+            <!-- The Vert.x SQL Client connection pool size -->
+            <property name="hibernate.connection.pool_size"
+                      value="10"/>
+
+            <!-- Automatic schema export -->
+            <property name="jakarta.persistence.schema-generation.database.action"
+                      value="drop-and-create"/>
+
+            <!-- SQL statement logging -->
+            <property name="hibernate.format_sql" value="true"/>
+            <!--property name="hibernate.show_sql" value="true"/-->
+
+        </properties>
+
+    </persistence-unit>
+
+</persistence>

--- a/examples/session-example/src/main/resources/log4j2.properties
+++ b/examples/session-example/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+rootLogger.level = info
+rootLogger.appenderRefs = console
+rootLogger.appenderRef.console.ref = console
+
+logger.hibernate.name = org.hibernate.SQL
+logger.hibernate.level = info
+
+appender.console.name = console
+appender.console.type = Console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %highlight{[%p]} %m%n

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
@@ -13,6 +13,7 @@ import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.results.internal.RowTransformerDatabaseSnapshotImpl;
 import org.hibernate.sql.results.spi.RowTransformer;
 
 /**
@@ -32,7 +33,7 @@ public class ReactiveSingleIdArrayLoadPlan extends ReactiveSingleIdLoadPlan<Obje
 	//FIXME: This doesn't make much sense... I will change it when I have a test
 	@Override
 	protected RowTransformer<CompletionStage<Object[]>> getRowTransformer() {
-		return super.getRowTransformer();
+		return RowTransformerDatabaseSnapshotImpl.instance();
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1520,6 +1520,17 @@ public interface Mutiny {
 		<R> Query<R> createQuery(String queryString, Class<R> resultType);
 
 		/**
+		 * Create an instance of {@link Mutiny.Query} for the given criteria query.
+		 *
+		 * @param criteriaQuery The {@link CriteriaQuery}
+		 *
+		 * @return The {@link Mutiny.Query} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String)
+		 */
+		<R> Mutiny.Query<R> createQuery(CriteriaQuery<R> criteriaQuery);
+
+		/**
 		 * Create an instance of {@link Mutiny.Query} for the given criteria update.
 		 *
 		 * @param criteriaUpdate The {@link CriteriaUpdate}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -34,6 +34,7 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
 import jakarta.persistence.criteria.CriteriaUpdate;
 import jakarta.persistence.metamodel.Attribute;
 
@@ -116,6 +117,14 @@ public class MutinySessionImpl implements Mutiny.Session {
 	@Override
 	public <R> Mutiny.Query<R> createQuery(String queryString, Class<R> resultType) {
 		return new MutinyQueryImpl<>( delegate.createReactiveQuery( queryString, resultType ), factory );
+	}
+
+	@Override
+	public <R> Mutiny.Query<R> createQuery(CriteriaQuery<R> criteriaQuery) {
+		return new MutinyQueryImpl<>(
+				(ReactiveQuerySqmImpl<R>) delegate.createReactiveQuery( criteriaQuery ),
+				factory
+		);
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
@@ -15,7 +15,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.jdbc.Expectation;
-import org.hibernate.loader.ast.internal.SingleIdArrayLoadPlan;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
@@ -28,6 +27,7 @@ import org.hibernate.persister.entity.JoinedSubclassEntityPersister;
 import org.hibernate.persister.entity.mutation.DeleteCoordinator;
 import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
+import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveDeleteCoordinator;
@@ -114,11 +114,6 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 		else {
 			return reactiveDelegate.createDomainResult( this, navigablePath, tableGroup, resultVariable, creationState );
 		}
-	}
-
-	@Override
-	public SingleIdArrayLoadPlan getSQLLazySelectLoadPlan(String fetchGroup) {
-		return null;
 	}
 
 	@Override
@@ -295,6 +290,11 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 
 	protected ReactiveSingleUniqueKeyEntityLoader<Object> getReactiveUniqueKeyLoader(String attributeName) {
 		return reactiveDelegate.getReactiveUniqueKeyLoader( this, (SingularAttributeMapping) findByPath( attributeName ) );
+	}
+
+	@Override
+	public ReactiveSingleIdArrayLoadPlan reactiveGetSQLLazySelectLoadPlan(String fetchGroup) {
+		return this.getLazyLoadPlanByFetchGroup( getSubclassPropertyNameClosure() ).get(fetchGroup );
 	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
@@ -19,17 +19,13 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.jdbc.Expectation;
-import org.hibernate.loader.ast.internal.SingleIdArrayLoadPlan;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
-import org.hibernate.metamodel.mapping.NaturalIdMapping;
-import org.hibernate.metamodel.mapping.SingularAttributeMapping;
+import org.hibernate.metamodel.mapping.*;
 import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.mapping.Property;
-import org.hibernate.metamodel.mapping.AttributeMapping;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
-import org.hibernate.metamodel.mapping.internal.MappingModelCreationProcess;
 import org.hibernate.metamodel.mapping.internal.ToOneAttributeMapping;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.entity.AbstractEntityPersister;
@@ -37,6 +33,7 @@ import org.hibernate.persister.entity.SingleTableEntityPersister;
 import org.hibernate.persister.entity.mutation.DeleteCoordinator;
 import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
+import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.metamodel.mapping.internal.ReactiveToOneAttributeMapping;
@@ -49,6 +46,7 @@ import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultCreationState;
 import org.hibernate.tuple.NonIdentifierAttribute;
+
 
 /**
  * A {@link ReactiveEntityPersister} backed by {@link SingleTableEntityPersister}
@@ -312,8 +310,8 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	}
 
 	@Override
-	public SingleIdArrayLoadPlan getSQLLazySelectLoadPlan(String fetchGroup) {
-		throw new UnsupportedOperationException();
+	public ReactiveSingleIdArrayLoadPlan reactiveGetSQLLazySelectLoadPlan(String fetchGroup) {
+		return this.getLazyLoadPlanByFetchGroup( getSubclassPropertyNameClosure() ).get(fetchGroup );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
@@ -17,7 +17,6 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.id.IdentityGenerator;
 import org.hibernate.jdbc.Expectation;
-import org.hibernate.loader.ast.internal.SingleIdArrayLoadPlan;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
@@ -30,6 +29,7 @@ import org.hibernate.persister.entity.UnionSubclassEntityPersister;
 import org.hibernate.persister.entity.mutation.DeleteCoordinator;
 import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
+import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.logging.impl.Log;
@@ -313,7 +313,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public SingleIdArrayLoadPlan getSQLLazySelectLoadPlan(String fetchGroup) {
-		throw new UnsupportedOperationException();
+	public ReactiveSingleIdArrayLoadPlan reactiveGetSQLLazySelectLoadPlan(String fetchGroup) {
+		return this.getLazyLoadPlanByFetchGroup( getSubclassPropertyNameClosure() ).get(fetchGroup );
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/example/MutinyMain.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/example/MutinyMain.java
@@ -1,0 +1,410 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.example;
+
+import io.vertx.ext.unit.TestContext;
+import jakarta.persistence.*;
+import jakarta.persistence.criteria.*;
+import org.hibernate.reactive.BaseReactiveTest;
+import org.jetbrains.annotations.NotNull;
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static java.lang.System.out;
+import static java.time.Month.*;
+
+public class MutinyMain extends BaseReactiveTest {
+
+    @Override
+    protected Collection<Class<?>> annotatedEntities() {
+        return List.of( Book.class, Author.class );
+    }
+
+    @Test
+    public void testWithInsert(TestContext context) {
+        out.println( "== Mutiny API Example ==" );
+
+        // obtain a factory for reactive sessions based on the
+        // standard JPA configuration properties specified in
+        // resources/META-INF/persistence.xml
+
+        // define some test data
+        Author author1 = new Author("Iain M. Banks");
+        Author author2 = new Author("Neal Stephenson");
+        Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+        Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+        Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+        author1.getBooks().add(book1);
+        author2.getBooks().add(book2);
+        author2.getBooks().add(book3);
+
+        CriteriaBuilder builder = getSessionFactory().getCriteriaBuilder();
+        CriteriaQuery<Book> query = builder.createQuery( Book.class );
+        Root<Book> b = query.from( Book.class );
+        b.fetch( "author" );
+        ParameterExpression<String> t = builder.parameter( String.class );
+        query.where( builder.equal( b.get( "title" ), t ) );
+        query.orderBy( builder.asc( b.get( "isbn" ) ) );
+
+        CriteriaUpdate<Book> update = builder.createCriteriaUpdate( Book.class );
+        b = update.from( Book.class );
+        update.where( builder.equal( b.get( "title" ), t ) );
+        update.set( b.get( "title" ), "XXX" );
+
+        test(
+                context,
+                getMutinySessionFactory().withStatelessSession(session ->
+                                session.withTransaction(tx -> session.insertAll(author1, author2, book1, book2, book3)
+                                ))
+                        .chain(() ->
+                                getMutinySessionFactory().withStatelessSession(
+                                        session -> session.get(Author.class, author1.getId())
+                                                .invoke(author -> out.println("Author.name: " + author.getName())))
+                        )
+                        .chain(() ->
+                                getMutinySessionFactory().withStatelessSession(
+                                        session -> session.get(Book.class, book3.getId())
+                                                .invoke(book -> out.println("Book.title: " + book.getTitle())))
+                        ).chain(() ->
+                                getMutinySessionFactory().withStatelessSession(
+                                        session -> session.createNativeQuery(
+                                                        "select book.title, author.name from books book join authors author on book.author_id = author.id order by book.title desc"
+//                                                        ,Object.class
+                                                )
+                                                .getResultList()
+                                                .invoke( rows -> {
+                                                    List topArray = rows;
+
+                                                    for( Object row : topArray ) {
+                                                        final Object[] theRowArray = (Object[])row;
+                                                        out.printf("%s : (%s)\n", theRowArray[0], theRowArray[1]);
+                                                    }
+
+//                                                    rows.forEach(
+//                                                            row -> out.printf("%s (%s)\n", row)
+//                                                    )
+                                                } )
+                                )
+                        )
+        );
+    }
+
+    @Test
+    public void test(TestContext context) {
+        out.println( "== Mutiny API Example ==" );
+
+        // obtain a factory for reactive sessions based on the
+        // standard JPA configuration properties specified in
+        // resources/META-INF/persistence.xml
+
+        // define some test data
+        Author author1 = new Author("Iain M. Banks");
+        Author author2 = new Author("Neal Stephenson");
+        Book book1 = new Book("1-85723-235-6", "Feersum Endjinn", author1, LocalDate.of(1994, JANUARY, 1));
+        Book book2 = new Book("0-380-97346-4", "Cryptonomicon", author2, LocalDate.of(1999, MAY, 1));
+        Book book3 = new Book("0-553-08853-X", "Snow Crash", author2, LocalDate.of(1992, JUNE, 1));
+        author1.getBooks().add(book1);
+        author2.getBooks().add(book2);
+        author2.getBooks().add(book3);
+
+        CriteriaBuilder builder = getSessionFactory().getCriteriaBuilder();
+        CriteriaQuery<Book> query = builder.createQuery( Book.class );
+        Root<Book> b = query.from( Book.class );
+        b.fetch( "author" );
+        ParameterExpression<String> t = builder.parameter( String.class );
+        query.where( builder.equal( b.get( "title" ), t ) );
+        query.orderBy( builder.asc( b.get( "isbn" ) ) );
+
+        CriteriaUpdate<Book> update = builder.createCriteriaUpdate( Book.class );
+        b = update.from( Book.class );
+        update.where( builder.equal( b.get( "title" ), t ) );
+        update.set( b.get( "title" ), "XXX" );
+
+        test(
+                context,
+                getMutinySessionFactory().withTransaction( (session, tx) -> session
+                        .persistAll( author1, author2 )
+                        .call( session::flush )
+                        .chain( () -> session.find( Book.class, book1.getId() )
+                        .invoke( singleBook -> out.println( book1.getTitle() + " is a great book!" ) ) )
+                ).chain( () ->
+                      getMutinySessionFactory().withSession(
+                              session -> session.find( Author.class, author1.getId(), author2.getId() )
+                                      .invoke( authors -> authors.forEach( author -> out.println("Author.name: " + author.getName() ) ) )
+                      )
+                )
+
+                /*
+                		test(
+				context,
+				openSession()
+						.thenCompose( session -> session.persist( author1, author2 )
+								.thenCompose( v -> session.flush() )
+						)
+						.thenCompose( v -> openSession() )
+						.thenCompose( session -> session.createQuery( query )
+								.setParameter( t, "Snow Crash" )
+								.getResultList() )
+						.thenAccept( books -> {
+							context.assertEquals( 1, books.size() );
+							books.forEach( book -> {
+								context.assertNotNull( book.id );
+								context.assertNotNull( book.title );
+								context.assertNotNull( book.isbn );
+								context.assertEquals( "Snow Crash", book.title );
+							} );
+						} )
+
+						.thenCompose( v -> openSession() )
+						.thenCompose( session -> session.createQuery( update )
+								.setParameter( t, "Snow Crash" )
+								.executeUpdate() )
+						.thenCompose( v -> openSession() )
+						.thenCompose( session -> session.createQuery( delete )
+								.setParameter( t, "Snow Crash" )
+								.executeUpdate() )
+		);
+                 */
+        );
+    }
+
+    /*
+        try {
+            // obtain a reactive session
+            factory.withTransaction(
+                            // persist the Authors with their Books in a transaction
+                            (session, tx) -> session.persistAll( author1, author2 )
+                    )
+                    // wait for it to finish
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // retrieve a Book
+                            session -> session.find( Book.class, book1.getId() )
+                                    // print its title
+                                    .invoke( book -> out.println( book.getTitle() + " is a great book!" ) )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // retrieve both Authors at once
+                            session -> session.find( Author.class, author1.getId(), author2.getId() )
+                                    .invoke( authors -> authors.forEach( author -> out.println( author.getName() ) ) )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // retrieve an Author
+                            session -> session.find( Author.class, author2.getId() )
+                                    // lazily fetch their books
+                                    .chain( author -> fetch( author.getBooks() )
+                                            // print some info
+                                            .invoke( books -> {
+                                                out.println( author.getName() + " wrote " + books.size() + " books" );
+                                                books.forEach( book -> out.println( book.getTitle() ) );
+                                            } )
+                                    )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // retrieve the Author lazily from a Book
+                            session -> session.find( Book.class, book1.getId() )
+                                    // fetch a lazy field of the Book
+                                    .chain( book -> fetch( book.getAuthor() )
+                                            // print the lazy field
+                                            .invoke( author -> out.printf( "%s wrote '%s'\n", author.getName(), book1.getTitle() ) )
+                                    )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // query the Book titles
+                            session -> session.createQuery(
+                                            "select title, author.name from Book order by title desc",
+                                            Object[].class
+                                    )
+                                    .getResultList()
+                                    .invoke( rows -> rows.forEach(
+                                            row -> out.printf( "%s (%s)\n", row[0], row[1] )
+                                    ) )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // query the entire Book entities
+                            session -> session.createQuery(
+                                            "from Book book join fetch book.author order by book.title desc",
+                                            Book.class
+                                    )
+                                    .getResultList()
+                                    .invoke( books -> books.forEach(
+                                            b -> out.printf(
+                                                    "%s: %s (%s)\n",
+                                                    b.getIsbn(),
+                                                    b.getTitle(),
+                                                    b.getAuthor().getName()
+                                            )
+                                    ) )
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // use a criteria query
+                            session -> {
+                                CriteriaQuery<Book> query = factory.getCriteriaBuilder().createQuery( Book.class );
+                                Root<Author> a = query.from( Author.class );
+                                Join<Author, Book> b = a.join( author1.getBooks() );
+                                query.where( a.get( author1.getName() ).in( "Neal Stephenson", "William Gibson" ) );
+                                query.select( b );
+                                return session.createQuery( query ).getResultList().invoke(
+                                        books -> books.forEach( book -> out.println( book.getTitle() ) )
+                                );
+                            }
+                    )
+                    .await().indefinitely();
+
+            factory.withSession(
+                            // retrieve a Book
+                            session -> session.find( Book.class, book1.getId() )
+                                    // fetch a lazy field of the Book
+                                    .call( book -> session.fetch( book, book1.getPublished() )
+                                            // print one lazy field
+                                            .invoke( published -> out.printf(
+                                                    "'%s' was published in %d\n",
+                                                    book.getTitle(),
+                                                    published.getYear()
+                                            ) )
+                                    )
+                                    .call( book -> session.fetch( book, book1.coverImage )
+                                            // print the other lazy field
+                                            .invoke( coverImage -> out.println( new String( coverImage ) ) )
+                                    )
+                    )
+                    .await().indefinitely();
+
+            factory.withTransaction(
+                            // retrieve a Book
+                            (session, tx) -> session.find( Book.class, book2.getId() )
+                                    // delete the Book
+                                    .chain( session::remove )
+                    )
+                    .await().indefinitely();
+
+            factory.withTransaction(
+                            // delete all the Books in a transaction
+                            (session, tx) -> session.createQuery( "delete Book" ).executeUpdate()
+                                    //delete all the Authors
+                                    .call( () -> session.createQuery( "delete Author" ).executeUpdate() )
+                    )
+                    .await().indefinitely();
+
+        }
+        finally {
+            // remember to shut down the factory
+            factory.close();
+        }
+    }}
+    */
+
+    @Entity
+    @Table(name="authors")
+    public static class Author {
+        @Id
+        @GeneratedValue
+        private Integer id;
+
+        @NotNull
+        private String name;
+
+        @OneToMany(mappedBy = "author", cascade = CascadeType.PERSIST)
+        private List<Book> books = new ArrayList<>();
+
+        public Author(String name) {
+            super();
+            this.name = name;
+        }
+
+        public Author() {}
+
+        Integer getId() {
+            return id;
+        }
+
+        String getName() {
+            return name;
+        }
+
+        List<Book> getBooks() {
+            return books;
+        }
+    }
+
+
+    @Entity
+    @Table(name="books")
+    public static class Book {
+        @Id
+        @GeneratedValue
+        private Integer id;
+
+        private String isbn;
+
+        @NotNull
+        private String title;
+
+        @Basic(fetch = LAZY)
+        @NotNull
+        private LocalDate published;
+
+        @Basic(fetch = LAZY)
+        public byte[] coverImage;
+
+        @NotNull
+        @ManyToOne(fetch = LAZY)
+        private Author author;
+
+        public Book(String isbn, String title, Author author, LocalDate published) {
+            super();
+            this.title = title;
+            this.isbn = isbn;
+            this.author = author;
+            this.published = published;
+            this.coverImage = ("Cover image for '" + title + "'").getBytes();
+        }
+
+        public Book() {}
+
+        Integer getId() {
+            return id;
+        }
+
+        String getIsbn() {
+            return isbn;
+        }
+
+        String getTitle() {
+            return title;
+        }
+
+        Author getAuthor() {
+            return author;
+        }
+
+        LocalDate getPublished() {
+            return published;
+        }
+
+        byte[] getCoverImage() {
+            return coverImage;
+        }
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -82,6 +82,8 @@ logger.lifecycle "Java versions for main code: " + gradle.ext.javaVersions.main
 logger.lifecycle "Java versions for tests: " + gradle.ext.javaVersions.test
 
 include 'hibernate-reactive-core'
+include 'session-example'
+include 'native-sql-example'
 include 'documentation'
 include 'release'
 include 'bytecode-enhancements-it'


### PR DESCRIPTION
These `session-example` commands will execute and mostly work except for a couple of Criteria related blocks in each of Main & MutinyMain versions.  I've commented out the failing parts in the code

- ./gradlew :session-example:runExampleOnPostgreSQLMain
- ./gradlew :session-example:runExampleOnPostgreSQLMutinyMain
- ./gradlew :session-example:runAllExamplesOnPostgreSQL

- ./gradlew :session-example:runExampleOnMySQLMain
- ./gradlew :session-example:runExampleOnMySQLMutinyMain
- ./gradlew :session-example:runAllExamplesOnMySQL

- ./gradlew :session-example:runAllExamples


The `native-sql-example` commands will execute also, but both Main and MutinyMain versions have issues with performing the initial `insert(...)` of the entities where the `insert` hangs.  I've commented out the code for now.

- ./gradlew :native-sql-example:runExampleOnPostgreSQLMain - FAILS
- ./gradlew :native-sql-example:runExampleOnPostgreSQLMutinyMain  - FAILS
- ./gradlew :native-sql-example:runAllExamplesOnPostgreSQL  - FAILS
- ./gradlew :native-sql-example:runAllExamples  - FAILS