### PR TITLE
Add check mark in front of the selected driver

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -47,7 +47,7 @@ public interface Log extends BasicLogger {
 	void sqlClientUrl(String url);
 
 	@LogMessage(level = INFO)
-	@Message(id = 13, value = "Detected driver [%1$s] %2$s")
+	@Message(id = 13, value = "Detected driver %2$s[%1$s]")
 	void detectedDriver(String driverName, String checkmark);
 
 	@LogMessage(level = INFO)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -47,8 +47,8 @@ public interface Log extends BasicLogger {
 	void sqlClientUrl(String url);
 
 	@LogMessage(level = INFO)
-	@Message(id = 13, value = "Detected driver [%1$s]")
-	void detectedDriver(String driverName);
+	@Message(id = 13, value = "Detected driver [%1$s] %2$s")
+	void detectedDriver(String driverName, String checkmark);
 
 	@LogMessage(level = INFO)
 	@Message(id = 14, value = "Prepared statement cache disabled")

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -238,7 +238,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 				selected.add( d );
 			}
 			else {
-				LOG.detectedDriver( driverName, "" );
+				LOG.detectedDriver( driverName, " " );
 			}
 		}
 		if ( selected.isEmpty() ) {


### PR DESCRIPTION
Fix #1565

Log example:
```
INFO DefaultSqlClientPoolConfiguration [vert.x-worker-thread-0] HR000025: Connection pool size: 5
INFO DefaultSqlClientPool [vert.x-worker-thread-0] HR000013: Detected driver [io.vertx.pgclient.spi.PgDriver] 
INFO DefaultSqlClientPool [vert.x-worker-thread-0] HR000013: Detected driver [io.vertx.mysqlclient.spi.MySQLDriver] ✓
```