### PR TITLE
Wire in SqlExceptionHelper which is now useful in Vert.x 4.4.0

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
@@ -6,6 +6,7 @@
 package org.hibernate.reactive.pool;
 
 import org.hibernate.Incubating;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder;
 import org.hibernate.service.Service;
 
@@ -42,10 +43,25 @@ public interface ReactiveConnectionPool extends Service {
 	CompletionStage<ReactiveConnection> getConnection();
 
 	/**
+	 * Obtain a reactive connection, returning the connection
+	 * via a {@link CompletionStage} and overriding the default
+	 * {@link SqlExceptionHelper} for the pool.
+	 */
+	CompletionStage<ReactiveConnection> getConnection(SqlExceptionHelper sqlExceptionHelper);
+
+	/**
 	 * Obtain a reactive connection for the given tenant id,
 	 * returning the connection via a {@link CompletionStage}.
 	 */
 	CompletionStage<ReactiveConnection> getConnection(String tenantId);
+
+	/**
+	 * Obtain a reactive connection for the given tenant id,
+	 * returning the connection via a {@link CompletionStage}
+	 * and overriding the default {@link SqlExceptionHelper}
+	 * for the pool.
+	 */
+	CompletionStage<ReactiveConnection> getConnection(String tenantId, SqlExceptionHelper sqlExceptionHelper);
 
 	/**
 	 * Obtain a lazily-initializing reactive connection. The

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -14,6 +14,8 @@ import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.engine.jdbc.spi.JdbcServices;
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.internal.util.config.ConfigurationException;
 import org.hibernate.internal.util.config.ConfigurationHelper;
@@ -109,6 +111,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 
 	private Pool pools;
 	private SqlStatementLogger sqlStatementLogger;
+	private SqlExceptionHelper sqlExceptionHelper;
 	private URI uri;
 	private ServiceRegistryImplementor serviceRegistry;
 
@@ -149,6 +152,15 @@ public class DefaultSqlClientPool extends SqlClientPool
 	@Override
 	protected SqlStatementLogger getSqlStatementLogger() {
 		return sqlStatementLogger;
+	}
+
+	@Override
+	public SqlExceptionHelper getSqlExceptionHelper() {
+		if ( sqlExceptionHelper == null ) {
+			sqlExceptionHelper = serviceRegistry
+					.getService( JdbcServices.class ).getSqlExceptionHelper();
+		}
+		return sqlExceptionHelper;
 	}
 
 	/**

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.pool.impl;
 
 import java.util.concurrent.CompletionStage;
 
+import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
@@ -47,10 +48,12 @@ public final class ExternalSqlClientPool extends SqlClientPool {
 
 	private final Pool pool;
 	private final SqlStatementLogger sqlStatementLogger;
+	private SqlExceptionHelper sqlExceptionHelper;
 
-	public ExternalSqlClientPool(Pool pool, SqlStatementLogger sqlStatementLogger) {
+	public ExternalSqlClientPool(Pool pool, SqlStatementLogger sqlStatementLogger, SqlExceptionHelper sqlExceptionHelper) {
 		this.pool = pool;
 		this.sqlStatementLogger = sqlStatementLogger;
+		this.sqlExceptionHelper = sqlExceptionHelper;
 	}
 
 	@Override
@@ -63,13 +66,17 @@ public final class ExternalSqlClientPool extends SqlClientPool {
 		return sqlStatementLogger;
 	}
 
+	@Override
+	public SqlExceptionHelper getSqlExceptionHelper() {
+		return sqlExceptionHelper;
+	}
+
 	/**
 	 * Since this Service implementation does not implement @{@link org.hibernate.service.spi.Stoppable}
 	 * and we're only adapting an externally provided pool, we will not actually close such provided pool
 	 * when Hibernate ORM is shutdown (it doesn't own the lifecycle of this external component).
-	 * Therefore there is no need to wait for its shutdown and this method returns an already
+	 * Therefore, there is no need to wait for its shutdown and this method returns an already
 	 * successfully completed CompletionStage.
-	 * @return
 	 */
 	@Override
 	public CompletionStage<Void> getCloseFuture() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/impl/CompletionStages.java
@@ -243,6 +243,14 @@ public class  CompletionStages {
 			this.throwable = throwable;
 		}
 
+		public boolean hasFailed() {
+			return throwable != null;
+		}
+
+		public T getThrowable() {
+			return throwable;
+		}
+
 		public R getResult() throws T {
 			if ( throwable == null ) {
 				return result;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinyExceptionsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MutinyExceptionsTest.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive;
 import java.util.Collection;
 import java.util.List;
 
-import org.hibernate.HibernateException;
+import org.hibernate.exception.ConstraintViolationException;
 import org.hibernate.reactive.mutiny.Mutiny;
 
 import org.junit.Test;
@@ -27,7 +27,7 @@ public class MutinyExceptionsTest extends BaseReactiveTest {
 	}
 
 	Class<?> getExpectedException() {
-		return HibernateException.class;
+		return ConstraintViolationException.class;
 	}
 
 	@Test

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveConstraintViolationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveConstraintViolationTest.java
@@ -1,0 +1,103 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.exception.ConstraintViolationException;
+
+import org.junit.Test;
+
+import io.vertx.ext.unit.TestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import static org.hibernate.reactive.testing.ReactiveAssertions.assertThrown;
+
+public class ReactiveConstraintViolationTest extends BaseReactiveTest {
+
+	@Override
+	protected Set<Class<?>> annotatedEntities() {
+		return Set.of( GuineaPig.class );
+	}
+
+	private CompletionStage<Void> populateDB() {
+		return getSessionFactory()
+				.withTransaction( s -> s.persist( new GuineaPig( 5, "Aloi" ) ) );
+	}
+
+	@Test
+	public void reactiveConstraintViolation(TestContext context) {
+		test( context, assertThrown(
+					  ConstraintViolationException.class,
+					  populateDB()
+							  .thenCompose( v -> openSession() )
+							  .thenCompose( s -> s.persist( new GuineaPig( 5, "Aloi" ) )
+									  .thenCompose( i -> s.flush() ) )
+			  )
+		);
+	}
+
+	@Entity(name = "GuineaPig")
+	@Table(name = "bad_pig")
+	public static class GuineaPig {
+		@Id
+		private Integer id;
+		private String name;
+		@Version
+		private int version;
+
+		public GuineaPig() {
+		}
+
+		public GuineaPig(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public void setId(Integer id) {
+			this.id = id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		@Override
+		public String toString() {
+			return id + ": " + name;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			GuineaPig guineaPig = (GuineaPig) o;
+			return Objects.equals( name, guineaPig.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+	}
+}


### PR DESCRIPTION
There were some conflicts with the changes I made for the autodetection of the version of the dialect.
I had to add a couple of methods to `ReactiveConnectionPool` because the default `SqlExceptionHelper` needs a dialect and we don't have the dialect during yet when we create the connection to check the version on the database.

Because it uses the latest ORM, we don't need to skip the test for SqlServer anymore.

Fix #1602 