### PR TITLE
Re-enable tests for MSSQL

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
@@ -86,9 +86,6 @@ public class MultithreadedIdentityGenerationTest {
 	private static Vertx vertx;
 	private static SessionFactory sessionFactory;
 
-	@Rule // Currently failing for unrelated reasons on SQL Server https://github.com/hibernate/hibernate-reactive/issues/1609
-	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( SQLSERVER );
-
 	@BeforeClass
 	public static void setupSessionFactory() {
 		final VertxOptions vertxOptions = new VertxOptions();

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
@@ -67,9 +67,6 @@ import static org.hibernate.reactive.util.impl.CompletionStages.loop;
 @RunWith(VertxUnitRunner.class)
 public class MultithreadedInsertionTest {
 
-	@Rule // Currently failing for unrelated reasons on SQL Server https://github.com/hibernate/hibernate-reactive/issues/1609
-	public DatabaseSelectionRule dbRule = DatabaseSelectionRule.skipTestsFor( SQLSERVER );
-
 	/**
 	 * The number of threads should be higher than the default size of the connection pool so that
 	 * this test is also effective in detecting problems with resource starvation.


### PR DESCRIPTION
Fix #1609 

After the upgrade to Vert.x 4.4.2, these tests work for MSSQL:
* MultithreadedIdentityGenerationTest
* MultithreadedInsertionTest

Because before we couldn't use the correct dialect. See https://github.com/hibernate/hibernate-reactive/issues/1596