### PR TITLE
 Align with changes in latest ORM (unreleased)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -29,18 +29,18 @@ org.gradle.java.installations.auto-download=false
 #db = MSSQL
 
 # Enable the SonatypeOS maven repository (mainly for Vert.x snapshots) when present (value ignored)
-#enableSonatypeOpenSourceSnapshotsRep = true
+enableSonatypeOpenSourceSnapshotsRep = true
 
 # Enable the maven local repository (for local development when needed) when present (value ignored)
 #enableMavenLocalRepo = true
 
 # Override default Hibernate ORM version
-#hibernateOrmVersion = 6.2.3.Final
+hibernateOrmVersion = 6.2.4-SNAPSHOT
 
 # Override default Hibernate ORM Gradle plugin version
 # Using the stable version because I don't know how to configure the build to download the snapshot version from
 # a remote repository
-#hibernateOrmGradlePluginVersion = 6.2.3.Final
+hibernateOrmGradlePluginVersion = 6.2.3.Final
 
 # If set to true, skip Hibernate ORM version parsing (default is true, if set to null)
 # this is required when using intervals or weird versions or the build will fail

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
@@ -29,6 +29,7 @@ import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.action.spi.Executable;
 import org.hibernate.cache.CacheException;
 import org.hibernate.engine.spi.ActionQueue;
+import org.hibernate.engine.spi.ComparableExecutable;
 import org.hibernate.engine.spi.EntityEntry;
 import org.hibernate.engine.spi.ExecutableList;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -203,7 +204,7 @@ public class ReactiveActionQueue {
 			}
 		};
 
-		public abstract <T extends ReactiveExecutable & Comparable<? super T>> ExecutableList<T> getActions(ReactiveActionQueue instance);
+		public abstract <T extends ReactiveExecutable & ComparableExecutable> ExecutableList<T> getActions(ReactiveActionQueue instance);
 		public abstract void ensureInitialized(ReactiveActionQueue instance);
 	}
 
@@ -1332,17 +1333,4 @@ public class ReactiveActionQueue {
 
 	}
 
-	private abstract static class ListProvider<T extends ReactiveExecutable & Comparable<? super T> & Serializable> {
-		abstract ExecutableList<T> get(ReactiveActionQueue instance);
-
-		abstract ExecutableList<T> init(ReactiveActionQueue instance);
-
-		ExecutableList<T> getOrInit(ReactiveActionQueue instance) {
-			ExecutableList<T> list = get( instance );
-			if ( list == null ) {
-				list = init( instance );
-			}
-			return list;
-		}
-	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveActionQueue.java
@@ -1032,6 +1032,7 @@ public class ReactiveActionQueue {
 		/**
 		 * Sort the insert actions.
 		 */
+		@Override
 		public void sort(List<ReactiveEntityInsertActionHolder> insertions) {
 			// optimize the hash size to eliminate a rehash.
 			this.actionBatches = new HashMap<>();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIdentityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIdentityInsertAction.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive.engine.impl;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
+import org.hibernate.action.internal.AbstractEntityInsertAction;
 import org.hibernate.action.internal.EntityIdentityInsertAction;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -107,6 +108,11 @@ public class ReactiveEntityIdentityInsertAction extends EntityIdentityInsertActi
 	@Override
 	public EntityKey getEntityKey() {
 		return super.getEntityKey();
+	}
+
+	@Override
+	public AbstractEntityInsertAction asAbstractEntityInsertAction() {
+		return this;
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
@@ -12,6 +12,7 @@ import org.hibernate.action.internal.AbstractEntityInsertAction;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.engine.internal.Nullability;
 import org.hibernate.engine.internal.Versioning;
+import org.hibernate.engine.spi.ComparableExecutable;
 import org.hibernate.engine.spi.EntityKey;
 import org.hibernate.engine.spi.SessionImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -28,7 +29,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
  *
  * @see org.hibernate.action.internal.AbstractEntityInsertAction
  */
-public interface ReactiveEntityInsertAction extends ReactiveExecutable {
+public interface ReactiveEntityInsertAction extends ReactiveExecutable, ComparableExecutable {
 	boolean isEarlyInsert();
 	NonNullableTransientDependencies findNonNullableTransientEntities();
 	SharedSessionContractImplementor getSession();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
@@ -9,7 +9,6 @@ import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.action.internal.AbstractEntityInsertAction;
-import org.hibernate.action.internal.ComparableEntityAction;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.engine.internal.Nullability;
 import org.hibernate.engine.internal.Versioning;
@@ -29,7 +28,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
  *
  * @see org.hibernate.action.internal.AbstractEntityInsertAction
  */
-public interface ReactiveEntityInsertAction extends ReactiveExecutable, ComparableEntityAction {
+public interface ReactiveEntityInsertAction extends ReactiveExecutable {
 	boolean isEarlyInsert();
 	NonNullableTransientDependencies findNonNullableTransientEntities();
 	SharedSessionContractImplementor getSession();
@@ -97,5 +96,9 @@ public interface ReactiveEntityInsertAction extends ReactiveExecutable, Comparab
 	}
 
 	AbstractEntityInsertAction asAbstractEntityInsertAction();
+
+	default int compareActionTo(ReactiveEntityInsertAction delegate) {
+		return asAbstractEntityInsertAction().compareTo( delegate.asAbstractEntityInsertAction() );
+	}
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive.engine.impl;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockMode;
+import org.hibernate.action.internal.AbstractEntityInsertAction;
 import org.hibernate.action.internal.ComparableEntityAction;
 import org.hibernate.engine.internal.NonNullableTransientDependencies;
 import org.hibernate.engine.internal.Nullability;
@@ -94,4 +95,7 @@ public interface ReactiveEntityInsertAction extends ReactiveExecutable, Comparab
 	default CompletionStage<NonNullableTransientDependencies> reactiveFindNonNullableTransientEntities() {
 		return ForeignKeys.findNonNullableTransientEntities( getPersister().getEntityName(), getInstance(), getState(), isEarlyInsert(), getSession() );
 	}
+
+	AbstractEntityInsertAction asAbstractEntityInsertAction();
+
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
@@ -1,0 +1,72 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.io.Serializable;
+import java.util.Objects;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.HibernateException;
+import org.hibernate.action.spi.AfterTransactionCompletionProcess;
+import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
+import org.hibernate.action.spi.Executable;
+import org.hibernate.event.spi.EventSource;
+import org.hibernate.reactive.engine.ReactiveExecutable;
+
+public final class ReactiveEntityInsertActionHolder implements Executable, ReactiveExecutable, Comparable<ReactiveEntityInsertActionHolder>,
+		Serializable {
+
+	private final ReactiveEntityInsertAction delegate;
+
+	public ReactiveEntityInsertActionHolder(ReactiveEntityInsertAction delegate) {
+		Objects.requireNonNull( delegate );
+		this.delegate = delegate;
+	}
+
+	@Override
+	public int compareTo(ReactiveEntityInsertActionHolder o) {
+		return delegate.compareActionTo( o.delegate );
+	}
+
+	@Override
+	public Serializable[] getPropertySpaces() {
+		return delegate.getPropertySpaces();
+	}
+
+	@Override
+	public void beforeExecutions() throws HibernateException {
+		delegate.beforeExecutions();
+	}
+
+	@Override
+	public void execute() throws HibernateException {
+		delegate.execute();
+	}
+
+	@Override
+	public AfterTransactionCompletionProcess getAfterTransactionCompletionProcess() {
+		return delegate.getAfterTransactionCompletionProcess();
+	}
+
+	@Override
+	public BeforeTransactionCompletionProcess getBeforeTransactionCompletionProcess() {
+		return delegate.getBeforeTransactionCompletionProcess();
+	}
+
+	@Override
+	public void afterDeserialize(EventSource session) {
+		delegate.afterDeserialize( session );
+	}
+
+	@Override
+	public CompletionStage<Void> reactiveExecute() {
+		return delegate.reactiveExecute();
+	}
+
+	public ReactiveEntityInsertAction getDelegate() {
+		return delegate;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
@@ -13,10 +13,11 @@ import org.hibernate.HibernateException;
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
 import org.hibernate.action.spi.BeforeTransactionCompletionProcess;
 import org.hibernate.action.spi.Executable;
+import org.hibernate.engine.spi.ComparableExecutable;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.reactive.engine.ReactiveExecutable;
 
-public final class ReactiveEntityInsertActionHolder implements Executable, ReactiveExecutable, Comparable<ReactiveEntityInsertActionHolder>,
+public final class ReactiveEntityInsertActionHolder implements Executable, ReactiveExecutable, ComparableExecutable,
 		Serializable {
 
 	private final ReactiveEntityInsertAction delegate;
@@ -24,11 +25,6 @@ public final class ReactiveEntityInsertActionHolder implements Executable, React
 	public ReactiveEntityInsertActionHolder(ReactiveEntityInsertAction delegate) {
 		Objects.requireNonNull( delegate );
 		this.delegate = delegate;
-	}
-
-	@Override
-	public int compareTo(ReactiveEntityInsertActionHolder o) {
-		return delegate.compareActionTo( o.delegate );
 	}
 
 	@Override
@@ -68,5 +64,20 @@ public final class ReactiveEntityInsertActionHolder implements Executable, React
 
 	public ReactiveEntityInsertAction getDelegate() {
 		return delegate;
+	}
+
+	@Override
+	public String getPrimarySortClassifier() {
+		return delegate.getPrimarySortClassifier();
+	}
+
+	@Override
+	public Object getSecondarySortIndex() {
+		return delegate.getSecondarySortIndex();
+	}
+
+	@Override
+	public int compareTo(final ComparableExecutable o) {
+		return delegate.compareTo( o );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
@@ -9,6 +9,7 @@ import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
+import org.hibernate.action.internal.AbstractEntityInsertAction;
 import org.hibernate.action.internal.EntityInsertAction;
 import org.hibernate.cache.spi.access.EntityDataAccess;
 import org.hibernate.cache.spi.entry.CacheEntry;
@@ -148,6 +149,11 @@ public class ReactiveEntityRegularInsertAction extends EntityInsertAction implem
 	@Override
 	public EntityKey getEntityKey() {
 		return super.getEntityKey();
+	}
+
+	@Override
+	public AbstractEntityInsertAction asAbstractEntityInsertAction() {
+		return this;
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -40,6 +40,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.FetchParent;
 import org.hibernate.sql.results.graph.internal.ImmutableFetchList;
@@ -57,15 +58,14 @@ class DatabaseSnapshotExecutor {
 	private final EntityMappingType entityDescriptor;
 
 	private final JdbcOperationQuerySelect jdbcSelect;
-	private final List<JdbcParameter> jdbcParameters;
+	private final JdbcParametersList jdbcParameters;
 
 	DatabaseSnapshotExecutor(
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
-		this.jdbcParameters = new ArrayList<>(
-				entityDescriptor.getIdentifierMapping().getJdbcTypeCount()
-		);
+		JdbcParametersList.Builder jdbcParametersBuilder = JdbcParametersList.newBuilder(
+				entityDescriptor.getIdentifierMapping().getJdbcTypeCount() );
 
 		final QuerySpec rootQuerySpec = new QuerySpec( true );
 
@@ -118,7 +118,7 @@ class DatabaseSnapshotExecutor {
 					);
 
 					final JdbcParameter jdbcParameter = new JdbcParameterImpl( selection.getJdbcMapping() );
-					jdbcParameters.add( jdbcParameter );
+					jdbcParametersBuilder.add( jdbcParameter );
 
 					final ColumnReference columnReference = (ColumnReference) sqlExpressionResolver
 							.resolveSqlExpression( tableReference, selection );
@@ -132,7 +132,7 @@ class DatabaseSnapshotExecutor {
 					);
 				}
 		);
-
+		this.jdbcParameters = jdbcParametersBuilder.build();
 
 		entityDescriptor.forEachAttributeMapping(
 				attributeMapping -> {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderArrayParam.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.reflect.Array;
-import java.util.Collections;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockOptions;
@@ -33,6 +32,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 import org.hibernate.type.BasicType;
 
@@ -145,7 +145,7 @@ public class ReactiveCollectionBatchLoaderArrayParam extends ReactiveAbstractCol
 		final SubselectFetch.RegistrationHandler subSelectFetchableKeysHandler = SubselectFetch.createRegistrationHandler(
 				session.getPersistenceContext().getBatchFetchQueue(),
 				sqlSelect,
-				Collections.singletonList( jdbcParameter ),
+				JdbcParametersList.singleton( jdbcParameter ),
 				jdbcParameterBindings
 		);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderInPredicate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderInPredicate.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockOptions;
@@ -22,10 +21,10 @@ import org.hibernate.internal.util.collections.CollectionHelper;
 import org.hibernate.loader.ast.internal.LoaderSelectBuilder;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
 import org.hibernate.query.spi.QueryOptions;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LOAD_DEBUG_ENABLED;
 import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LOAD_LOGGER;
@@ -37,7 +36,7 @@ public class ReactiveCollectionBatchLoaderInPredicate extends ReactiveAbstractCo
 
 	private final int keyColumnCount;
 	private final int sqlBatchSize;
-	private final List<JdbcParameter> jdbcParameters;
+	private final JdbcParametersList jdbcParameters;
 	private final SelectStatement sqlAst;
 	private final JdbcOperationQuerySelect jdbcSelect;
 
@@ -64,7 +63,7 @@ public class ReactiveCollectionBatchLoaderInPredicate extends ReactiveAbstractCo
 			);
 		}
 
-		this.jdbcParameters = new ArrayList<>();
+		final JdbcParametersList.Builder jdbcParametersBuilder = JdbcParametersList.newBuilder();
 		this.sqlAst = LoaderSelectBuilder.createSelect(
 				attributeMapping,
 				null,
@@ -73,9 +72,10 @@ public class ReactiveCollectionBatchLoaderInPredicate extends ReactiveAbstractCo
 				sqlBatchSize,
 				influencers,
 				LockOptions.NONE,
-				jdbcParameters::add,
+				jdbcParametersBuilder::add,
 				sessionFactory
 		);
+		this.jdbcParameters = jdbcParametersBuilder.build();
 		assert this.jdbcParameters.size() == this.sqlBatchSize * this.keyColumnCount;
 
 		this.jdbcSelect = sessionFactory.getJdbcServices()

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSingleKey.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSingleKey.java
@@ -5,8 +5,6 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockOptions;
@@ -27,12 +25,12 @@ import org.hibernate.reactive.metamodel.mapping.internal.ReactivePluralAttribute
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.BaseExecutionContext;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.graph.entity.LoadingEntityEntry;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 
@@ -46,14 +44,14 @@ public class ReactiveCollectionLoaderSingleKey implements ReactiveCollectionLoad
 	private final int keyJdbcCount;
 
 	private final SelectStatement sqlAst;
-	private final List<JdbcParameter> jdbcParameters;
+	private final JdbcParametersList jdbcParameters;
 
 	public ReactiveCollectionLoaderSingleKey(PluralAttributeMapping attributeMapping, LoadQueryInfluencers influencers, SessionFactoryImplementor sessionFactory) {
 		// PluralAttributeMappingImpl is the only implementation available at the moment in ORM
 		final PluralAttributeMapping reactivePluralAttributeMapping = new ReactivePluralAttributeMapping( (PluralAttributeMappingImpl) attributeMapping );
 		this.attributeMapping = reactivePluralAttributeMapping;
 		this.keyJdbcCount = reactivePluralAttributeMapping.getKeyDescriptor().getJdbcTypeCount();
-		this.jdbcParameters = new ArrayList<>();
+		final JdbcParametersList.Builder jdbcParametersBuilder = JdbcParametersList.newBuilder();
 		this.sqlAst = LoaderSelectBuilder.createSelect(
 				reactivePluralAttributeMapping,
 				null,
@@ -62,9 +60,10 @@ public class ReactiveCollectionLoaderSingleKey implements ReactiveCollectionLoad
 				1,
 				influencers,
 				LockOptions.NONE,
-				jdbcParameters::add,
+				jdbcParametersBuilder::add,
 				sessionFactory
 		);
+		this.jdbcParameters = jdbcParametersBuilder.build();
 	}
 
 	@Override
@@ -80,7 +79,7 @@ public class ReactiveCollectionLoaderSingleKey implements ReactiveCollectionLoad
 		return sqlAst;
 	}
 
-	public List<JdbcParameter> getJdbcParameters() {
+	public JdbcParametersList getJdbcParameters() {
 		return jdbcParameters;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveLoaderHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveLoaderHelper.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.reflect.Array;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
@@ -22,6 +21,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 
 import static java.util.Objects.requireNonNull;
@@ -73,7 +73,7 @@ public class ReactiveLoaderHelper {
 		final SubselectFetch.RegistrationHandler subSelectFetchableKeysHandler = SubselectFetch.createRegistrationHandler(
 				session.getPersistenceContext().getBatchFetchQueue(),
 				sqlAst,
-				Collections.singletonList( jdbcParameter ),
+				JdbcParametersList.singleton( jdbcParameter ),
 				jdbcParameterBindings
 		);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive.loader.ast.internal;
 import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
 
@@ -44,6 +43,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 import org.hibernate.type.BasicType;
 import org.hibernate.type.BasicTypeRegistry;
@@ -189,7 +189,7 @@ public class ReactiveMultiIdEntityLoaderArrayParam<E> extends ReactiveAbstractMu
 					final SubselectFetch.RegistrationHandler subSelectFetchableKeysHandler = SubselectFetch.createRegistrationHandler(
 							batchFetchQueue,
 							sqlAst,
-							Collections.singletonList( jdbcParameter ),
+							JdbcParametersList.singleton( jdbcParameter ),
 							jdbcParameterBindings
 					);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderStandard.java
@@ -43,11 +43,11 @@ import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
@@ -221,8 +221,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 			LOG.tracef( "#loadEntitiesById(`%s`, `%s`, ..)", getEntityDescriptor().getEntityName(), numberOfIdsInBatch );
 		}
 
-		final List<JdbcParameter> jdbcParameters = new ArrayList<>( numberOfIdsInBatch * idJdbcTypeCount );
-
+		final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder( numberOfIdsInBatch * idJdbcTypeCount );
 		final SelectStatement sqlAst = LoaderSelectBuilder.createSelect(
 				getLoadable(),
 				// null here means to select everything
@@ -232,9 +231,10 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 				numberOfIdsInBatch,
 				session.getLoadQueryInfluencers(),
 				lockOptions,
-				jdbcParameters::add,
+				jdbcParametersListBuilder::add,
 				getSessionFactory()
 		);
+		final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
 		final JdbcServices jdbcServices = getSessionFactory().getJdbcServices();
 		final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiKeyLoadChunker.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiKeyLoadChunker.java
@@ -5,19 +5,18 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.Bindable;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
@@ -53,7 +52,7 @@ public class ReactiveMultiKeyLoadChunker<K> {
 	private final int keyColumnCount;
 	private final Bindable bindable;
 
-	private final List<JdbcParameter> jdbcParameters;
+	private final JdbcParametersList jdbcParameters;
 	private final SelectStatement sqlAst;
 	private final JdbcOperationQuerySelect jdbcSelect;
 
@@ -61,7 +60,7 @@ public class ReactiveMultiKeyLoadChunker<K> {
 			int chunkSize,
 			int keyColumnCount,
 			Bindable bindable,
-			List<JdbcParameter> jdbcParameters,
+			JdbcParametersList jdbcParameters,
 			SelectStatement sqlAst,
 			JdbcOperationQuerySelect jdbcSelect) {
 		this.chunkSize = chunkSize;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
@@ -5,8 +5,6 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
@@ -36,7 +34,6 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.SimpleFromClauseAccessImpl;
 import org.hibernate.sql.ast.spi.SqlAliasBaseManager;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
@@ -46,6 +43,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.Callback;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.Fetch;
 import org.hibernate.sql.results.graph.FetchParent;
@@ -148,7 +146,7 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
     public CompletionStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
         final SessionFactoryImplementor sessionFactory = session.getFactory();
 
-        final List<JdbcParameter> jdbcParameters = new ArrayList<>();
+        final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
         final SelectStatement sqlSelect = LoaderSelectBuilder.createSelect(
                 entityDescriptor(),
                 singletonList( naturalIdMapping() ),
@@ -157,9 +155,10 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
                 1,
                 session.getLoadQueryInfluencers(),
                 LockOptions.NONE,
-                jdbcParameters::add,
+                jdbcParametersListBuilder::add,
                 sessionFactory
         );
+        final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
         final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
         final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
@@ -5,14 +5,13 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.ModelPart;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerDatabaseSnapshotImpl;
 import org.hibernate.sql.results.spi.RowTransformer;
 
@@ -24,7 +23,7 @@ public class ReactiveSingleIdArrayLoadPlan extends ReactiveSingleIdLoadPlan<Obje
 	public ReactiveSingleIdArrayLoadPlan(
 			ModelPart restrictivePart,
 			SelectStatement sqlAst,
-			List<JdbcParameter> jdbcParameters,
+			JdbcParametersList jdbcParameters,
 			LockOptions lockOptions,
 			SessionFactoryImplementor sessionFactory) {
 		super( null, restrictivePart, sqlAst, jdbcParameters, lockOptions, sessionFactory );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
@@ -5,9 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.ArrayList;
 import java.util.EnumMap;
-import java.util.List;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -23,8 +21,8 @@ import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.persister.entity.Loadable;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 /**
  * Standard implementation of {@link ReactiveSingleIdEntityLoader}.
@@ -195,8 +193,8 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 			LoadQueryInfluencers queryInfluencers,
 			SessionFactoryImplementor sessionFactory) {
 
-		final List<JdbcParameter> jdbcParameters = new ArrayList<>();
 
+		final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
 		final SelectStatement sqlAst = LoaderSelectBuilder.createSelect(
 				getLoadable(),
 				// null here means to select everything
@@ -206,9 +204,10 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 				1,
 				queryInfluencers,
 				lockOptions,
-				jdbcParameters::add,
+				jdbcParametersListBuilder::add,
 				sessionFactory
 		);
+		final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
 		return new ReactiveSingleIdLoadPlan<>(
 				(Loadable) getLoadable(),

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
@@ -23,13 +23,13 @@ import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.resource.jdbc.spi.LogicalConnectionImplementor;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.CallbackImpl;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.Callback;
 import org.hibernate.sql.exec.spi.ExecutionContext;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.graph.entity.LoadingEntityEntry;
 
 public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<CompletionStage<T>> {
@@ -38,7 +38,7 @@ public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<CompletionStag
 			Loadable persister,
 			ModelPart restrictivePart,
 			SelectStatement sqlAst,
-			List<JdbcParameter> jdbcParameters,
+			JdbcParametersList jdbcParameters,
 			LockOptions lockOptions,
 			SessionFactoryImplementor sessionFactory) {
 		super( persister, restrictivePart, sqlAst, jdbcParameters, lockOptions, sessionFactory );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleUniqueKeyEntityLoaderStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleUniqueKeyEntityLoaderStandard.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -29,7 +28,6 @@ import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.BaseExecutionContext;
 import org.hibernate.sql.exec.internal.CallbackImpl;
@@ -37,6 +35,7 @@ import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.Callback;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 /**
  *
@@ -70,7 +69,7 @@ public class ReactiveSingleUniqueKeyEntityLoaderStandard<T> implements ReactiveS
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 
 		// todo (6.0) : cache the SQL AST and JdbcParameters
-		final List<JdbcParameter> jdbcParameters = new ArrayList<>();
+		final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
 		final SelectStatement sqlAst = LoaderSelectBuilder.createSelectByUniqueKey(
 				entityDescriptor,
 				Collections.emptyList(),
@@ -78,9 +77,10 @@ public class ReactiveSingleUniqueKeyEntityLoaderStandard<T> implements ReactiveS
 				null,
 				LoadQueryInfluencers.NONE,
 				LockOptions.NONE,
-				jdbcParameters::add,
+				jdbcParametersListBuilder::add,
 				sessionFactory
 		);
+		final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 		final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();
@@ -125,7 +125,7 @@ public class ReactiveSingleUniqueKeyEntityLoaderStandard<T> implements ReactiveS
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 
 		// todo (6.0) : cache the SQL AST and JdbcParameters
-		final List<JdbcParameter> jdbcParameters = new ArrayList<>();
+		final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
 		final SelectStatement sqlAst = LoaderSelectBuilder.createSelectByUniqueKey(
 				entityDescriptor,
 				Collections.singletonList( entityDescriptor.getIdentifierMapping() ),
@@ -133,9 +133,10 @@ public class ReactiveSingleUniqueKeyEntityLoaderStandard<T> implements ReactiveS
 				null,
 				LoadQueryInfluencers.NONE,
 				LockOptions.NONE,
-				jdbcParameters::add,
+				jdbcParametersListBuilder::add,
 				sessionFactory
 		);
+		final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 		final JdbcEnvironment jdbcEnvironment = jdbcServices.getJdbcEnvironment();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -51,8 +51,8 @@ import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.sql.SimpleSelect;
 import org.hibernate.sql.Update;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.type.BasicType;
 
 import jakarta.persistence.metamodel.Attribute;
@@ -613,7 +613,7 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 		}
 		else {
 			final SessionFactoryImplementor factory = getFactory();
-			final List<JdbcParameter> jdbcParameters = new ArrayList<>();
+			final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
 			final SelectStatement select = LoaderSelectBuilder.createSelect(
 					this,
 					partsToSelect,
@@ -622,9 +622,10 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 					1,
 					LoadQueryInfluencers.NONE,
 					LockOptions.NONE,
-					jdbcParameters::add,
+					jdbcParametersListBuilder::add,
 					factory
 			);
+			final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 			return new ReactiveSingleIdArrayLoadPlan( getIdentifierMapping(), select, jdbcParameters, LockOptions.NONE, factory );
 		}
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -556,7 +556,9 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 		// in the collected names.  iterate here because it is already alphabetical
 
 		final List<SingularAttributeMapping> collectedAttrMappings = new ArrayList<>();
-		for ( AttributeMapping attributeMapping : getAttributeMappings() ) {
+		final AttributeMappingsList attributeMappings = getAttributeMappings();
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			AttributeMapping attributeMapping = attributeMappings.get( i );
 			if ( attributeNames.contains( attributeMapping.getAttributeName() ) ) {
 				collectedAttrMappings.add( (SingularAttributeMapping) attributeMapping );
 			}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveCoordinatorFactory.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveCoordinatorFactory.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.persister.entity.impl;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.metamodel.mapping.AttributeMapping;
+import org.hibernate.metamodel.mapping.AttributeMappingsList;
 import org.hibernate.metamodel.mapping.SingularAttributeMapping;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveDeleteCoordinator;
@@ -27,7 +28,9 @@ public final class ReactiveCoordinatorFactory {
 			AbstractEntityPersister entityPersister,
 			SessionFactoryImplementor factory) {
 		// we only have updates to issue for entities with one or more singular attributes
-		for ( AttributeMapping attributeMapping : entityPersister.getAttributeMappings() ) {
+		final AttributeMappingsList attributeMappings = entityPersister.getAttributeMappings();
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			AttributeMapping attributeMapping = attributeMappings.get( i );
 			if ( attributeMapping instanceof SingularAttributeMapping ) {
 				return new ReactiveUpdateCoordinatorStandard( entityPersister, factory );
 			}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveGeneratedValuesProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveGeneratedValuesProcessor.java
@@ -18,11 +18,11 @@ import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveSelectExecutor;
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterBindingsImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 /**
  * A reactive version of {@link org.hibernate.metamodel.mapping.internal.GeneratedValuesProcessor}
@@ -31,14 +31,14 @@ class ReactiveGeneratedValuesProcessor {
 
     private final SelectStatement selectStatement;
     private final List<AttributeMapping> generatedValuesToSelect;
-    private final List<JdbcParameter> jdbcParameters;
+    private final JdbcParametersList jdbcParameters;
 
     private final EntityMappingType entityDescriptor;
     private final SessionFactoryImplementor sessionFactory;
 
     ReactiveGeneratedValuesProcessor(SelectStatement selectStatement,
                                      List<AttributeMapping> generatedValuesToSelect,
-                                     List<JdbcParameter> jdbcParameters,
+                                     JdbcParametersList jdbcParameters,
                                      EntityMappingType entityDescriptor,
                                      SessionFactoryImplementor sessionFactory) {
         this.selectStatement = selectStatement;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ConcreteSqmSelectReactiveQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ConcreteSqmSelectReactiveQueryPlan.java
@@ -39,10 +39,10 @@ import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.SqlAstTranslatorFactory;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.TupleMetadata;
 import org.hibernate.sql.results.spi.RowTransformer;
 
@@ -93,7 +93,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 		final JdbcOperationQuerySelect jdbcSelect = sqmInterpretation.getJdbcSelect();
 		// I'm using a supplier so that the whenComplete at the end will catch any errors, like a finally-block
 		Supplier<SubselectFetch.RegistrationHandler> fetchHandlerSupplier = () -> SubselectFetch
-				.createRegistrationHandler( session.getPersistenceContext().getBatchFetchQueue(), sqmInterpretation.selectStatement, emptyList(), jdbcParameterBindings );
+				.createRegistrationHandler( session.getPersistenceContext().getBatchFetchQueue(), sqmInterpretation.selectStatement, JdbcParametersList.empty(), jdbcParameterBindings );
 		return completedFuture( fetchHandlerSupplier )
 				.thenApply( Supplier::get )
 				.thenCompose( subSelectFetchKeyHandler ->  session
@@ -212,7 +212,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 		final SqlAstTranslatorFactory sqlAstTranslatorFactory = jdbcEnvironment.getSqlAstTranslatorFactory();
 		final SqlAstTranslator<JdbcOperationQuerySelect> selectTranslator = sqlAstTranslatorFactory
 				.buildSelectTranslator( sessionFactory, sqmInterpretation.getSqlAst() );
-		final Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref = SqmUtil
+		final Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref = SqmUtil
 				.generateJdbcParamsXref( domainParameterXref, sqmInterpretation::getJdbcParamsBySqmParam );
 		final JdbcParameterBindings jdbcParameterBindings = SqmUtil.createJdbcParameterBindings(
 				executionContext.getQueryParameterBindings(),
@@ -258,7 +258,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 		private final SelectStatement selectStatement;
 		private final JdbcOperationQuerySelect jdbcSelect;
 		private final FromClauseAccess tableGroupAccess;
-		private final Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref;
+		private final Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref;
 		private final Map<SqmParameter<?>, MappingModelExpressible<?>> sqmParameterMappingModelTypes;
 		private transient JdbcParameterBindings firstParameterBindings;
 
@@ -266,7 +266,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 				SelectStatement selectStatement,
 				JdbcOperationQuerySelect jdbcSelect,
 				FromClauseAccess tableGroupAccess,
-				Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref,
+				Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref,
 				Map<SqmParameter<?>, MappingModelExpressible<?>> sqmParameterMappingModelTypes,
 				JdbcParameterBindings firstParameterBindings) {
 			this.selectStatement = selectStatement;
@@ -289,7 +289,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 			return tableGroupAccess;
 		}
 
-		Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> getJdbcParamsXref() {
+		Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> getJdbcParamsXref() {
 			return jdbcParamsXref;
 		}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleDeleteQueryPlan.java
@@ -37,13 +37,13 @@ import org.hibernate.spi.NavigablePath;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.tree.delete.DeleteStatement;
 import org.hibernate.sql.ast.tree.expression.Expression;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.from.MutatingTableReferenceGroupWrapper;
 import org.hibernate.sql.ast.tree.from.NamedTableReference;
 import org.hibernate.sql.ast.tree.predicate.InSubQueryPredicate;
 import org.hibernate.sql.ast.tree.select.QuerySpec;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryDelete;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.SqlSelectionImpl;
 
 import static org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter.usingLockingAndPaging;
@@ -57,7 +57,7 @@ public class ReactiveSimpleDeleteQueryPlan extends SimpleDeleteQueryPlan impleme
 
 	private SqmTranslation<DeleteStatement> sqmInterpretation;
 
-	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref;
+	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref;
 
 	public ReactiveSimpleDeleteQueryPlan(
 			EntityMappingType entityDescriptor,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleInsertQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleInsertQueryPlan.java
@@ -31,10 +31,10 @@ import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.insert.InsertStatement;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryInsert;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 /**
  * @see org.hibernate.query.sqm.internal.SimpleInsertQueryPlan
@@ -49,7 +49,7 @@ public class ReactiveSimpleInsertQueryPlan implements ReactiveNonSelectQueryPlan
 
 	private JdbcOperationQueryInsert jdbcInsert;
 	private FromClauseAccess tableGroupAccess;
-	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref;
+	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref;
 
 	public ReactiveSimpleInsertQueryPlan(
 			SqmInsertStatement<?> sqmInsert,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleUpdateQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/iternal/ReactiveSimpleUpdateQueryPlan.java
@@ -29,10 +29,10 @@ import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
 import org.hibernate.sql.ast.SqlAstTranslator;
 import org.hibernate.sql.ast.spi.FromClauseAccess;
-import org.hibernate.sql.ast.tree.expression.JdbcParameter;
 import org.hibernate.sql.ast.tree.update.UpdateStatement;
 import org.hibernate.sql.exec.spi.JdbcOperationQueryUpdate;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
+import org.hibernate.sql.exec.spi.JdbcParametersList;
 
 
 /**
@@ -45,7 +45,7 @@ public class ReactiveSimpleUpdateQueryPlan implements ReactiveNonSelectQueryPlan
 
 	private JdbcOperationQueryUpdate jdbcUpdate;
 	private FromClauseAccess tableGroupAccess;
-	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<List<JdbcParameter>>>> jdbcParamsXref;
+	private Map<QueryParameterImplementor<?>, Map<SqmParameter<?>, List<JdbcParametersList>>> jdbcParamsXref;
 	private Map<SqmParameter<?>, MappingModelExpressible<?>> sqmParamMappingTypeResolutions;
 
 	public ReactiveSimpleUpdateQueryPlan(SqmUpdateStatement<?> sqmUpdate, DomainParameterXref domainParameterXref) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedUpdateHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedUpdateHandler.java
@@ -80,7 +80,7 @@ public class ReactiveTableBasedUpdateHandler extends TableBasedUpdateHandler imp
 	}
 
 	@Override
-	protected ReactiveUpdateExcutionDelegate buildExecutionDelegate(
+	protected ReactiveUpdateExecutionDelegate buildExecutionDelegate(
 			MultiTableSqmMutationConverter sqmConverter,
 			TemporaryTable idTable,
 			AfterUseAction afterUseAction,
@@ -93,7 +93,7 @@ public class ReactiveTableBasedUpdateHandler extends TableBasedUpdateHandler imp
 			Map<SqmParameter<?>, List<List<JdbcParameter>>> parameterResolutions,
 			Map<SqmParameter<?>, MappingModelExpressible<?>> paramTypeResolutions,
 			DomainQueryExecutionContext executionContext) {
-		return new ReactiveUpdateExcutionDelegate(
+		return new ReactiveUpdateExecutionDelegate(
 				sqmConverter,
 				idTable,
 				afterUseAction,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
@@ -57,11 +57,11 @@ import static org.hibernate.reactive.query.sqm.mutation.internal.temptable.React
 import static org.hibernate.reactive.query.sqm.mutation.internal.temptable.ReactiveExecuteWithTemporaryTableHelper.saveMatchingIdsIntoIdTable;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
-public class ReactiveUpdateExcutionDelegate extends UpdateExecutionDelegate implements ReactiveTableBasedUpdateHandler.ReactiveExecutionDelegate {
+public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate implements ReactiveTableBasedUpdateHandler.ReactiveExecutionDelegate {
 
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	public ReactiveUpdateExcutionDelegate(
+	public ReactiveUpdateExecutionDelegate(
 			MultiTableSqmMutationConverter sqmConverter,
 			TemporaryTable idTable,
 			AfterUseAction afterUseAction,
@@ -214,13 +214,13 @@ public class ReactiveUpdateExcutionDelegate extends UpdateExecutionDelegate impl
 		return StandardReactiveJdbcMutationExecutor.INSTANCE
 				.executeReactive(
 						jdbcUpdate,
-				getJdbcParameterBindings(),
-				executionContext.getSession()
+						getJdbcParameterBindings(),
+						executionContext.getSession()
 						.getJdbcCoordinator()
 						.getStatementPreparer()
 						::prepareStatement,
-						ReactiveUpdateExcutionDelegate::doNothing,
-				executionContext
+						ReactiveUpdateExecutionDelegate::doNothing,
+						executionContext
 		);
 	}
 
@@ -294,7 +294,7 @@ public class ReactiveUpdateExcutionDelegate extends UpdateExecutionDelegate impl
 								.getJdbcCoordinator()
 								.getStatementPreparer()
 								::prepareStatement,
-						ReactiveUpdateExcutionDelegate::doNothing,
+						ReactiveUpdateExecutionDelegate::doNothing,
 						executionContext
 				);
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
@@ -46,6 +46,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import static org.hibernate.cfg.AvailableSettings.SHOW_SQL;
+import static org.hibernate.reactive.BaseReactiveTest.setDefaultProperties;
+import static org.hibernate.reactive.provider.Settings.POOL_CONNECT_TIMEOUT;
 
 /**
  * This is a multi-threaded stress test, intentionally consuming some time.
@@ -95,10 +97,10 @@ public class MultithreadedIdentityGenerationTest {
 		vertxOptions.setBlockedThreadCheckIntervalUnit( TimeUnit.MINUTES );
 		vertx = Vertx.vertx( vertxOptions );
 		Configuration configuration = new Configuration();
+		setDefaultProperties( configuration );
 		configuration.addAnnotatedClass( EntityWithGeneratedId.class );
-		BaseReactiveTest.setDefaultProperties( configuration );
 		configuration.setProperty( SHOW_SQL, String.valueOf( LOG_SQL ) );
-		BaseReactiveTest.setDefaultProperties( configuration );
+		configuration.setProperty( POOL_CONNECT_TIMEOUT, String.valueOf( TIMEOUT_MINUTES * 60 * 1000 ) );
 		StandardServiceRegistryBuilder builder = new ReactiveServiceRegistryBuilder()
 				.applySettings( configuration.getProperties() )
 				//Inject our custom vert.x instance:

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
@@ -36,6 +36,8 @@ import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
 import static org.hibernate.cfg.AvailableSettings.SHOW_SQL;
+import static org.hibernate.reactive.BaseReactiveTest.setDefaultProperties;
+import static org.hibernate.reactive.provider.Settings.POOL_CONNECT_TIMEOUT;
 import static org.hibernate.reactive.util.impl.CompletionStages.loop;
 
 /**
@@ -101,9 +103,10 @@ public class MultithreadedInsertionTest {
 		vertxOptions.setBlockedThreadCheckIntervalUnit( TimeUnit.MINUTES );
 		vertx = Vertx.vertx( vertxOptions );
 		Configuration configuration = new Configuration();
+		setDefaultProperties( configuration );
 		configuration.addAnnotatedClass( EntityWithGeneratedId.class );
-		BaseReactiveTest.setDefaultProperties( configuration );
 		configuration.setProperty( SHOW_SQL, String.valueOf( LOG_SQL ) );
+		configuration.setProperty( POOL_CONNECT_TIMEOUT, String.valueOf( TIMEOUT_MINUTES * 60 * 1000 ) );
 		StandardServiceRegistryBuilder builder = new ReactiveServiceRegistryBuilder()
 				.applySettings( configuration.getProperties() )
 				//Inject our custom vert.x instance:

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
@@ -85,7 +85,7 @@ class OracleDatabase implements TestableDatabase {
 	}
 
 	public static final OracleContainer oracle = new OracleContainer(
-				imageName( "gvenzl/oracle-free", "23-slim-faststart" )
+				imageName( "gvenzl/oracle-free", "latest-faststart" )
 					.asCompatibleSubstituteFor( "gvenzl/oracle-xe" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )


### PR DESCRIPTION
Upgrade to Hibernte ORM 6.4.2-SNAPSHOT
Note that until the final version is released, Hibernate Reactive will use the snapshot available from Sonatype.
It will be released tomorrow, so it should not cause too much trouble.

Remember to update the gradle.properties file accordingly if you want to test local changes with ORM.

Superseeds https://github.com/hibernate/hibernate-reactive/pull/1636
Fix #1645 
