### PR TITLE
various fixes to Session API

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
@@ -128,8 +128,8 @@ public class DefaultReactiveDeleteEventListener
 			final EventSource source = event.getSession();
 			Object object = event.getObject();
 			if ( object instanceof CompletionStage ) {
-				final CompletionStage<Object> objectStage = (CompletionStage<Object>) object;
-				return objectStage.thenCompose( objectEvent -> fetchAndDelete( event, transientEntities, source, objectEvent ) );
+				final CompletionStage<?> stage = (CompletionStage<?>) object;
+				return stage.thenCompose( objectEvent -> fetchAndDelete( event, transientEntities, source, objectEvent ) );
 			}
 			else {
 				return fetchAndDelete( event, transientEntities, source, object);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -347,6 +347,12 @@ public interface Mutiny {
 		 */
 		SelectionQuery<R> setPlan(EntityGraph<R> entityGraph);
 
+		/**
+		 * Enable a {@linkplain org.hibernate.annotations.FetchProfile fetch
+		 * profile} which will be in effect during execution of this query.
+		 */
+		SelectionQuery<R> enableFetchProfile(String profileName);
+
 		@Override
 		SelectionQuery<R> setParameter(int parameter, Object argument);
 
@@ -456,6 +462,9 @@ public interface Mutiny {
 
 		@Override
 		Query<R> setComment(String comment);
+
+		@Override
+		Query<R> enableFetchProfile(String profileName);
 	}
 
 
@@ -863,7 +872,7 @@ public interface Mutiny {
 		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
 		 */
-		<R> SelectionQuery<R> createSelectionQuery(String queryString);
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
 
 		/**
 		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -896,8 +896,12 @@ public interface Mutiny {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1461,8 +1465,12 @@ public interface Mutiny {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see Session#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1477,6 +1485,30 @@ public interface Mutiny {
 		 * @see Session#createQuery(String, Class)
 		 */
 		<R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
+		 * query string.
+		 *
+		 * @param queryString The HQL/JPQL query
+		 *
+		 * @return The {@link SelectionQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
+		 */
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL
+		 * update or delete statement.
+		 *
+		 * @param queryString The HQL/JPQL query, update or delete statement
+		 *
+		 * @return The {@link MutationQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String)
+		 */
+		MutationQuery createMutationQuery(String queryString);
 
 		/**
 		 * Create an instance of {@link Query} for the named query.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.mutiny.impl;
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.Parameter;
 import org.hibernate.reactive.mutiny.Mutiny.MutationQuery;
-import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.query.ReactiveMutationQuery;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -16,9 +16,9 @@ import java.util.function.Supplier;
 public class MutinyMutationQueryImpl<R> implements MutationQuery {
 
 	private final MutinySessionFactoryImpl factory;
-	private final ReactiveQuery<R> delegate;
+	private final ReactiveMutationQuery<R> delegate;
 
-	public MutinyMutationQueryImpl(ReactiveQuery<R> delegate, MutinySessionFactoryImpl factory) {
+	public MutinyMutationQueryImpl(ReactiveMutationQuery<R> delegate, MutinySessionFactoryImpl factory) {
 		this.delegate = delegate;
 		this.factory = factory;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -72,6 +72,12 @@ public class MutinyQueryImpl<R> implements Query<R> {
 	}
 
 	@Override
+	public Query<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
 	public Uni<R> getSingleResult() {
 		return uni( delegate::getReactiveSingleResult );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.LockMode;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
-import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.query.ReactiveSelectionQuery;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -26,9 +26,9 @@ import java.util.function.Supplier;
 
 public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	private final MutinySessionFactoryImpl factory;
-	private final ReactiveQuery<R> delegate;
+	private final ReactiveSelectionQuery<R> delegate;
 
-	public MutinySelectionQueryImpl(ReactiveQuery<R> delegate, MutinySessionFactoryImpl factory) {
+	public MutinySelectionQueryImpl(ReactiveSelectionQuery<R> delegate, MutinySessionFactoryImpl factory) {
 		this.delegate = delegate;
 		this.factory = factory;
 	}
@@ -207,6 +207,12 @@ public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	@Override
 	public SelectionQuery<R> setComment(String comment) {
 		delegate.setComment( comment );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
 		return this;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -33,7 +33,6 @@ import org.hibernate.reactive.mutiny.Mutiny.MutationQuery;
 import org.hibernate.reactive.mutiny.Mutiny.Query;
 import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
 import org.hibernate.reactive.pool.ReactiveConnection;
-import org.hibernate.reactive.query.sqm.internal.ReactiveQuerySqmImpl;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.reactive.session.ReactiveQueryProducer;
 import org.hibernate.reactive.session.ReactiveSession;
@@ -125,7 +124,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 		return new MutinyMutationQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new MutinyQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
@@ -143,7 +142,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 	@Override
 	public <R> MutationQuery createQuery(CriteriaUpdate<R> criteriaUpdate) {
 		return new MutinyMutationQueryImpl<>(
-				(ReactiveQuerySqmImpl<R>) delegate.createReactiveMutationQuery( criteriaUpdate ),
+				delegate.createReactiveMutationQuery( criteriaUpdate ),
 				factory
 		);
 	}
@@ -151,7 +150,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 	@Override
 	public <R> MutationQuery createQuery(CriteriaDelete<R> criteriaDelete) {
 		return new MutinyMutationQueryImpl<>(
-				(ReactiveQuerySqmImpl<R>) delegate.createReactiveMutationQuery( criteriaDelete ),
+				delegate.createReactiveMutationQuery( criteriaDelete ),
 				factory
 		);
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -116,8 +116,8 @@ public class MutinySessionImpl implements Mutiny.Session {
 	}
 
 	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(String queryString) {
-		return new MutinySelectionQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new MutinySelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ), factory );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -68,9 +68,19 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 		return new MutinyQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType) {
 		return new MutinySelectionQueryImpl<>( delegate.createReactiveQuery( queryString, resultType ), factory );
+	}
+
+	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new MutinySelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType), factory );
+	}
+
+	@Override
+	public Mutiny.MutationQuery createMutationQuery(String queryString) {
+		return new MutinyMutationQueryImpl<>( delegate.createReactiveMutationQuery( queryString), factory );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
@@ -115,11 +115,14 @@ public interface ReactiveSelectionQuery<R> extends CommonQueryContract {
 
 	ReactiveSelectionQuery<R> setLockMode(String alias, LockMode lockMode);
 
+	@Deprecated
 	ReactiveSelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode);
 
 	ReactiveSelectionQuery<R> setFollowOnLocking(boolean enable);
 
 	void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic);
+
+	void enableFetchProfile(String profileName);
 
 	@Override
 	ReactiveSelectionQuery<R> setParameter(String name, Object value);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
@@ -64,6 +64,7 @@ public interface ReactiveSelectionQuery<R> extends CommonQueryContract {
 
 	@Override
 	ReactiveSelectionQuery<R> setTimeout(int timeout);
+
 	Integer getFetchSize();
 
 	ReactiveSelectionQuery<R> setFetchSize(int fetchSize);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
@@ -741,4 +741,9 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		super.applyGraph( graph, semantic );
 	}
+
+	@Override
+	public void enableFetchProfile(String profileName) {
+		throw new UnsupportedOperationException("A native SQL query cannot use fetch profiles");
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
@@ -7,12 +7,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
@@ -830,5 +825,10 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 	@Override
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		super.applyGraph( graph, semantic );
+	}
+
+	@Override
+	public void enableFetchProfile(String profileName) {
+		selectionQueryDelegate.enableFetchProfile( profileName );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
@@ -588,4 +588,9 @@ public class ReactiveSqmSelectionQueryImpl<R> extends SqmSelectionQueryImpl<R> i
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		getQueryOptions().applyGraph( graph, semantic );
 	}
+
+	@Override
+	public void enableFetchProfile(String profileName) {
+		selectionQueryDelegate.enableFetchProfile( profileName );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
@@ -69,8 +69,6 @@ public interface ReactiveQueryProducer extends ReactiveConnectionSupplier {
 
 	<R> ReactiveNativeQuery<R> createReactiveNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass);
 
-	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString);
-
 	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType);
 
 	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(CriteriaQuery<R> criteria);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -500,11 +500,6 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	}
 
 	@Override
-	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString) {
-		return interpretAndCreateSelectionQuery( hqlString, null );
-	}
-
-	@Override
 	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType) {
 		return interpretAndCreateSelectionQuery( hqlString, resultType );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -832,11 +832,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 	}
 
 	@Override
-	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString) {
-		return interpretAndCreateSelectionQuery( hqlString, null );
-	}
-
-	@Override
 	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType) {
 		return interpretAndCreateSelectionQuery( hqlString, resultType );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -349,6 +349,12 @@ public interface Stage {
 		 */
 		SelectionQuery<R> setPlan(EntityGraph<R> entityGraph);
 
+		/**
+		 * Enable a {@linkplain org.hibernate.annotations.FetchProfile fetch
+		 * profile} which will be in effect during execution of this query.
+		 */
+		SelectionQuery<R> enableFetchProfile(String profileName);
+
 		@Override
 		SelectionQuery<R> setParameter(int parameter, Object argument);
 
@@ -903,7 +909,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
 		 */
-		<R> SelectionQuery<R> createSelectionQuery(String queryString);
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
 
 		/**
 		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -933,8 +933,12 @@ public interface Stage {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1496,8 +1500,12 @@ public interface Stage {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see org.hibernate.Session#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1512,6 +1520,30 @@ public interface Stage {
 		 * @see org.hibernate.Session#createQuery(String, Class)
 		 */
 		<R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
+		 * query string.
+		 *
+		 * @param queryString The HQL/JPQL query
+		 *
+		 * @return The {@link SelectionQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
+		 */
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL
+		 * update or delete statement.
+		 *
+		 * @param queryString The HQL/JPQL query, update or delete statement
+		 *
+		 * @return The {@link MutationQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String)
+		 */
+		MutationQuery createMutationQuery(String queryString);
 
 		/**
 		 * Create an instance of {@link Query} for the given SQL query string,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.LockMode;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.Stage.Query;
 
 import java.util.List;
@@ -59,6 +60,12 @@ public class StageQueryImpl<R> implements Query<R> {
 	@Override
 	public Query<R> setPlan(EntityGraph<R> entityGraph) {
 		delegate.applyGraph( (RootGraphImplementor<?>) entityGraph, GraphSemantic.FETCH );
+		return this;
+	}
+
+	@Override
+	public Stage.SelectionQuery<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
@@ -63,6 +63,12 @@ public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	}
 
 	@Override
+	public SelectionQuery<T> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
 	public CompletionStage<T> getSingleResult() {
 		return delegate.getReactiveSingleResult();
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -485,7 +485,7 @@ public class StageSessionImpl implements Stage.Session {
 		return delegate.createEntityGraph( rootType, graphName );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new StageQueryImpl<>( delegate.createReactiveQuery( queryString ) );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -108,8 +108,8 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(String queryString) {
-		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString ) );
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ) );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -225,9 +225,19 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 		return delegate.reactiveGet( entityClass, id, null, entityGraph );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new StageQueryImpl<>( delegate.createReactiveQuery( queryString ) );
+	}
+
+	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ) );
+	}
+
+	@Override
+	public MutationQuery createMutationQuery(String queryString) {
+		return new StageMutationQueryImpl<>( delegate.createReactiveMutationQuery( queryString ) );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -886,7 +886,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session
-								.createSelectionQuery( "from GuineaPig" )
+								.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 								.getResultList()
 								.thenAccept( resultList -> assertThat( resultList ).containsExactlyInAnyOrder( aloiPig, bloiPig ) ) ) )
 		);
@@ -903,7 +903,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 								.getSingleResult()
 								.thenAccept( actualPig -> assertThatPigsAreEqual( expectedPig, actualPig ) ) )
 						.thenCompose( v -> openSession() )
-						.thenCompose( session -> session.createSelectionQuery( "from GuineaPig" )
+						.thenCompose( session -> session.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 								.getSingleResult()
 								.thenAccept( actualPig -> assertThatPigsAreEqual( expectedPig, (GuineaPig) actualPig ) ) )
 				)
@@ -917,7 +917,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						.getSingleResultOrNull()
 						.thenAccept( Assertions::assertNull ) )
 				.thenCompose( v -> openSession() )
-				.thenCompose( session -> session.createSelectionQuery( "from GuineaPig" )
+				.thenCompose( session -> session.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 						.getSingleResultOrNull()
 						.thenAccept( Assertions::assertNull ) )
 		);


### PR DESCRIPTION
1. add `Session.getFactory()` and `StatelessSession.getFactory()`
2. fix the signature of `mergeAll()`
3. fix the broken signature of `createSelectionQuery()` oops!
4. #1703 add `enableFetchProfile()` to Query
5. deprecate `Session.createQuery()` to align with deprecation in H 6.3
6. add `createSelectionQuery()`/`createMutationQuery()` to `StatelessSession`