### PR TITLE
Exploring the idea of potentially move away from internal use of JDK's CompletionStage and CompletableFuture

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -32,15 +32,15 @@ org.gradle.java.installations.auto-download=false
 #enableSonatypeOpenSourceSnapshotsRep = true
 
 # Enable the maven local repository (for local development when needed) when present (value ignored)
-#enableMavenLocalRepo = true
+enableMavenLocalRepo = true
 
 # Override default Hibernate ORM version
-#hibernateOrmVersion = 6.2.3.Final
+hibernateOrmVersion = 6.2.8-SNAPSHOT
 
 # Override default Hibernate ORM Gradle plugin version
 # Using the stable version because I don't know how to configure the build to download the snapshot version from
 # a remote repository
-#hibernateOrmGradlePluginVersion = 6.2.3.Final
+hibernateOrmGradlePluginVersion = 6.2.7.Final
 
 # If set to true, skip Hibernate ORM version parsing (default is true, if set to null)
 # this is required when using intervals or weird versions or the build will fail

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveAfterTransactionCompletionProcess.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.engine;
 
 import org.hibernate.reactive.session.ReactiveSession;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Contract representing some process that needs to occur during after transaction completion.
@@ -22,5 +22,5 @@ public interface ReactiveAfterTransactionCompletionProcess {
 	 * @param success Did the transaction complete successfully?  True means it did.
 	 * @param session The session on which the transaction is completing.
 	 */
-	CompletionStage<Void> doAfterTransactionCompletion(boolean success, ReactiveSession session);
+	InternalStage<Void> doAfterTransactionCompletion(boolean success, ReactiveSession session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveBeforeTransactionCompletionProcess.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.engine;
 
 import org.hibernate.reactive.session.ReactiveSession;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Contract representing some process that needs to occur during before transaction completion.
@@ -21,5 +21,5 @@ public interface ReactiveBeforeTransactionCompletionProcess {
 	 *
 	 * @param session The session on which the transaction is preparing to complete.
 	 */
-	CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session);
+	InternalStage<Void> doBeforeTransactionCompletion(ReactiveSession session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveExecutable.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/ReactiveExecutable.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.engine;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.spi.Executable;
 
@@ -16,5 +16,5 @@ import org.hibernate.action.spi.Executable;
  * to {@link Executable}.
  */
 public interface ReactiveExecutable extends Executable, Serializable {
-	CompletionStage<Void> reactiveExecute();
+	InternalStage<Void> reactiveExecute();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
@@ -11,7 +11,6 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Hibernate;
@@ -64,7 +63,7 @@ public final class Cascade<C> {
 	private final C context;
 	private CascadePoint cascadePoint;
 
-	private CompletionStage<Void> stage = voidFuture();
+	private InternalStage<Void> stage = voidFuture();
 
 	/**
 	 * 	@param persister The parent's entity persister
@@ -84,13 +83,13 @@ public final class Cascade<C> {
 		this.context = context;
 	}
 
-	public static CompletionStage<?> fetchLazyAssociationsBeforeCascade(
+	public static InternalStage<?> fetchLazyAssociationsBeforeCascade(
 			CascadingAction<?> action,
 			EntityPersister persister,
 			Object entity,
 			EventSource session) {
 
-		CompletionStage<?> beforeDelete = voidFuture();
+		InternalStage<?> beforeDelete = voidFuture();
 		if ( persister.hasCascades() ) {
 			CascadeStyle[] cascadeStyles = persister.getPropertyCascadeStyles();
 			Object[] state = persister.getValues( entity );
@@ -109,7 +108,7 @@ public final class Cascade<C> {
 	/**
 	 * Cascade an action from the parent entity instance to all its children.
 	 */
-	public CompletionStage<Void> cascade() throws HibernateException {
+	public InternalStage<Void> cascade() throws HibernateException {
 		return voidFuture().thenCompose(v -> {
 			CacheMode cacheMode = eventSource.getCacheMode();
 			if ( action==CascadingActions.DELETE ) {
@@ -123,7 +122,7 @@ public final class Cascade<C> {
 		} );
 	}
 
-	private CompletionStage<Void> cascadeInternal() throws HibernateException {
+	private InternalStage<Void> cascadeInternal() throws HibernateException {
 
 		if ( persister.hasCascades() || action.requiresNoCascadeChecking() ) { // performance opt
 			final boolean traceEnabled = LOG.isTraceEnabled();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingAction.java
@@ -13,7 +13,6 @@ import org.hibernate.type.CollectionType;
 import org.hibernate.type.Type;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
 
 /**
  * A {@link Stage.Session reactive session} operation that may
@@ -35,7 +34,7 @@ public interface CascadingAction<C> {
 	 * which is specific to each CascadingAction type
 	 * @param isCascadeDeleteEnabled Are cascading deletes enabled.
 	 */
-	CompletionStage<Void> cascade(
+	InternalStage<Void> cascade(
 			EventSource session,
 			Object child,
 			String entityName,
@@ -81,7 +80,7 @@ public interface CascadingAction<C> {
 	 * @param propertyType The property type
 	 * @param propertyIndex The index of the property within the owner.
 	 */
-	CompletionStage<Void> noCascade(EventSource session, Object parent, EntityPersister persister, Type propertyType, int propertyIndex);
+	InternalStage<Void> noCascade(EventSource session, Object parent, EntityPersister persister, Type propertyType, int propertyIndex);
 
 	/**
 	 * Should this action be performed (or noCascade consulted) in the case of lazy properties.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingActions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingActions.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.engine.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
@@ -50,7 +49,7 @@ public class CascadingActions {
 	 */
 	public static final CascadingAction<DeleteContext> DELETE = new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.DELETE ) {
 		@Override
-		public CompletionStage<Void> cascade(
+		public InternalStage<Void> cascade(
 				EventSource session,
 				Object child,
 				String entityName,
@@ -70,7 +69,7 @@ public class CascadingActions {
 	 */
 	public static final CascadingAction<PersistContext> PERSIST = new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.PERSIST ) {
 		@Override
-		public CompletionStage<Void> cascade(
+		public InternalStage<Void> cascade(
 				EventSource session,
 				Object child,
 				String entityName,
@@ -89,7 +88,7 @@ public class CascadingActions {
 	 */
 	public static final CascadingAction<PersistContext> PERSIST_ON_FLUSH = new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.PERSIST_ON_FLUSH ) {
 		@Override
-		public CompletionStage<Void> cascade(
+		public InternalStage<Void> cascade(
 				EventSource session,
 				Object child,
 				String entityName,
@@ -118,7 +117,7 @@ public class CascadingActions {
 		}
 
 		@Override
-		public CompletionStage<Void> noCascade(
+		public InternalStage<Void> noCascade(
 				EventSource session,
 				Object parent,
 				EntityPersister persister,
@@ -156,7 +155,7 @@ public class CascadingActions {
 	public static final CascadingAction<MergeContext> MERGE =
 			new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.MERGE ) {
 				@Override
-				public CompletionStage<Void> cascade(
+				public InternalStage<Void> cascade(
 						EventSource session,
 						Object child,
 						String entityName,
@@ -174,7 +173,7 @@ public class CascadingActions {
 	 */
 	public static final CascadingAction<RefreshContext> REFRESH = new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.REFRESH ) {
 				@Override
-				public CompletionStage<Void> cascade(
+				public InternalStage<Void> cascade(
 						EventSource session,
 						Object child,
 						String entityName,
@@ -191,7 +190,7 @@ public class CascadingActions {
 	 */
 	public static final CascadingAction<LockOptions> LOCK = new BaseCascadingAction<>( org.hibernate.engine.spi.CascadingActions.LOCK ) {
 				@Override
-				public CompletionStage<Void> cascade(
+				public InternalStage<Void> cascade(
 						EventSource session,
 						Object child,
 						String entityName,
@@ -234,7 +233,7 @@ public class CascadingActions {
 		 * @see BaseCascadingAction#noCascade(EventSource, Object, EntityPersister, Type, int)
 		 */
 		@Override
-		public CompletionStage<Void> noCascade(EventSource session, Object parent, EntityPersister persister, Type propertyType, int propertyIndex) {
+		public InternalStage<Void> noCascade(EventSource session, Object parent, EntityPersister persister, Type propertyType, int propertyIndex) {
 			return voidFuture();
 		}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.engine.impl;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
@@ -51,7 +50,7 @@ public class EntityTypes {
 	/*
 	 * Replacement for {@link EntityType#resolve(Object, SharedSessionContractImplementor, Object)}
 	 */
-	public static CompletionStage<Object> resolve(EntityType entityType, Object idOrUniqueKey, Object owner, SharedSessionContractImplementor session) {
+	public static InternalStage<Object> resolve(EntityType entityType, Object idOrUniqueKey, Object owner, SharedSessionContractImplementor session) {
 		if ( idOrUniqueKey != null && !isNull( entityType, owner, session ) ) {
 			if ( entityType.isReferenceToPrimaryKey() ) {
 				return ReactiveQueryExecutorLookup.extract( session ).reactiveInternalLoad(
@@ -105,7 +104,7 @@ public class EntityTypes {
 	 * @return The loaded entity
 	 * @throws HibernateException generally indicates problems performing the load.
 	 */
-	static CompletionStage<Object> loadByUniqueKey(
+	static InternalStage<Object> loadByUniqueKey(
 			EntityType entityType,
 			Object key,
 			SharedSessionContractImplementor session) throws HibernateException {
@@ -149,7 +148,7 @@ public class EntityTypes {
 	/**
 	 * @see org.hibernate.type.TypeHelper#replace(Object[], Object[], Type[], SharedSessionContractImplementor, Object, Map)
 	 */
-	public static CompletionStage<Object[]> replace(
+	public static InternalStage<Object[]> replace(
 			final Object[] original,
 			final Object[] target,
 			final Type[] types,
@@ -185,7 +184,7 @@ public class EntityTypes {
 							 copyCache
 					 ).thenCompose( copy -> {
 						 if ( copy instanceof CompletionStage ) {
-							 return ( (CompletionStage<?>) copy )
+							 return ( (InternalStage<?>) copy )
 									 .thenAccept( nonStageCopy -> copied[i] = nonStageCopy );
 						 }
 						 else {
@@ -199,7 +198,7 @@ public class EntityTypes {
 	/**
 	 * @see org.hibernate.type.TypeHelper#replace(Object[], Object[], Type[], SharedSessionContractImplementor, Object, Map, ForeignKeyDirection)
 	 */
-	public static CompletionStage<Object[]> replace(
+	public static InternalStage<Object[]> replace(
 			final Object[] original,
 			final Object[] target,
 			final Type[] types,
@@ -238,7 +237,7 @@ public class EntityTypes {
 							 foreignKeyDirection
 					 ).thenCompose( copy -> {
 						 if ( copy instanceof CompletionStage ) {
-							 return ( (CompletionStage<?>) copy ).thenAccept( nonStageCopy -> copied[i] = nonStageCopy );
+							 return ( (InternalStage<?>) copy ).thenAccept( nonStageCopy -> copied[i] = nonStageCopy );
 						 }
 						 else {
 							 copied[i] = copy;
@@ -251,7 +250,7 @@ public class EntityTypes {
 	/**
 	 * @see org.hibernate.type.AbstractType#replace(Object, Object, SharedSessionContractImplementor, Object, Map, ForeignKeyDirection)
 	 */
-	private static CompletionStage<Object> replace(
+	private static InternalStage<Object> replace(
 			EntityType entityType,
 			Object original,
 			Object target,
@@ -271,7 +270,7 @@ public class EntityTypes {
 	/**
 	 * @see EntityType#replace(Object, Object, SharedSessionContractImplementor, Object, Map)
 	 */
-	private static CompletionStage<Object> replace(
+	private static InternalStage<Object> replace(
 			EntityType entityType,
 			Object original,
 			Object target,
@@ -318,7 +317,7 @@ public class EntityTypes {
 		}
 	}
 
-	private static CompletionStage<Object> resolveIdOrUniqueKey(
+	private static InternalStage<Object> resolveIdOrUniqueKey(
 			EntityType entityType,
 			Object original,
 			SessionImplementor session,
@@ -340,7 +339,7 @@ public class EntityTypes {
 								Object idOrUniqueKey = entityType.getIdentifierOrUniqueKeyType( session.getFactory() )
 										.replace( fetched, null, session, owner, copyCache );
 								if ( idOrUniqueKey instanceof CompletionStage ) {
-									return ( (CompletionStage<?>) idOrUniqueKey )
+									return ( (InternalStage<?>) idOrUniqueKey )
 											.thenCompose( key -> resolve( entityType, key, owner, session ) );
 								}
 
@@ -352,7 +351,7 @@ public class EntityTypes {
 	/**
 	 * see EntityType#getIdentifier(Object, SharedSessionContractImplementor)
 	 */
-	private static CompletionStage<Object> getIdentifier(
+	private static InternalStage<Object> getIdentifier(
 			EntityType entityType,
 			Object value,
 			SessionImplementor session) {
@@ -402,7 +401,7 @@ public class EntityTypes {
 
 	}
 
-	private static CompletionStage<Object> getIdentifierFromHibernateProxy(
+	private static InternalStage<Object> getIdentifierFromHibernateProxy(
 			EntityType entityType,
 			HibernateProxy proxy,
 			SharedSessionContractImplementor session) {
@@ -431,7 +430,7 @@ public class EntityTypes {
 				} );
 	}
 
-	private static CompletionStage<Object> loadHibernateProxyEntity(
+	private static InternalStage<Object> loadHibernateProxyEntity(
 			Object entity,
 			SharedSessionContractImplementor session) {
 		if ( entity instanceof HibernateProxy ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/InternalStage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/InternalStage.java
@@ -1,0 +1,56 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public interface InternalStage<T> {
+
+	static <T> InternalStage<T> completedFuture(T value) {
+		return new POCInternalStage<>( CompletableFuture.completedFuture( value ) );
+	}
+
+	static <T> InternalStage<T> failedStage(Throwable t) {
+		CompletableFuture<T> ret = new CompletableFuture<>();
+		ret.completeExceptionally( t );
+		return new POCInternalStage<>( ret );
+	}
+
+	static <T> InternalStage<T> newStage() {
+		return new POCInternalStage<>();
+	}
+
+	<U> InternalStage<U> thenCompose(Function<? super T, ? extends InternalStage<U>> fn);
+
+	InternalStage<T> whenComplete(BiConsumer<? super T, ? super Throwable> action);
+
+	<U> InternalStage<U> thenApply(Function<? super T,? extends U> fn);
+
+	boolean completeExceptionally(Throwable ex);
+
+	boolean complete(T value);
+
+	<U> InternalStage<U> handle(BiFunction<? super T, Throwable, ? extends U> fn);
+
+	InternalStage<Void> thenRun(Runnable action);
+
+	InternalStage<Void> thenAccept(Consumer<? super T> action);
+
+	boolean isDone();
+
+	T getNow(T valueIfAbsent);
+
+	InternalStage<T> exceptionally(Function<Throwable, ? extends T> fn);
+
+	@Deprecated //exists only to simplify migration
+	InternalStage<T> toCompletableFuture();
+
+	T join();
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/POCInternalStage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/POCInternalStage.java
@@ -1,0 +1,98 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.engine.impl;
+
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.function.Function;
+
+public class POCInternalStage<T> implements InternalStage<T> {
+
+	private final CompletableFuture<T> delegate;
+
+	protected POCInternalStage() {
+		this( new CompletableFuture<>() );
+	}
+
+	POCInternalStage(CompletableFuture<T> delegation) {
+		Objects.requireNonNull( delegation );
+		this.delegate = delegation;
+	}
+
+	@Override
+	public <U> InternalStage<U> thenCompose(Function<? super T, ? extends InternalStage<U>> fn) {
+		return new POCInternalStage<U>( delegate.thenCompose( convertFunction( fn ) ) );
+	}
+
+	private static <U,T> Function<? super T, ? extends CompletionStage<U>> convertFunction( Function<? super T, ? extends InternalStage<U>> fn ) {
+		return t -> ( (POCInternalStage) fn.apply( t ) ).delegate;
+	}
+
+	@Override
+	public InternalStage<T> whenComplete(BiConsumer<? super T, ? super Throwable> action) {
+		return new POCInternalStage( delegate.whenComplete( action ) );
+	}
+
+	@Override
+	public <U> InternalStage<U> thenApply(Function<? super T, ? extends U> fn) {
+		return new POCInternalStage( delegate.thenApply( fn ) );
+	}
+
+	@Override
+	public boolean completeExceptionally(Throwable ex) {
+		return delegate.completeExceptionally( ex );
+	}
+
+	@Override
+	public boolean complete(T value) {
+		return delegate.complete( value );
+	}
+
+	@Override
+	public <U> InternalStage<U> handle(BiFunction<? super T, Throwable, ? extends U> fn) {
+		return new POCInternalStage<>( delegate.handle( fn ) );
+	}
+
+	@Override
+	public InternalStage<Void> thenRun(Runnable action) {
+		return new POCInternalStage<>( delegate.thenRun( action ) );
+	}
+
+	@Override
+	public InternalStage<Void> thenAccept(Consumer<? super T> action) {
+		return new POCInternalStage<>( delegate.thenAccept( action ) );
+	}
+
+	@Override
+	public boolean isDone() {
+		return delegate.isDone();
+	}
+
+	@Override
+	public T getNow(T valueIfAbsent) {
+		return delegate.getNow( valueIfAbsent );
+	}
+
+	@Override
+	public InternalStage<T> exceptionally(Function<Throwable, ? extends T> fn) {
+		return new POCInternalStage<>( delegate.exceptionally( fn ) );
+	}
+
+	@Override
+	public InternalStage<T> toCompletableFuture() {
+		return this;
+	}
+
+	@Override
+	public T join() {
+		return delegate.join();
+	}
+
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/QueuedOperationCollectionAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/QueuedOperationCollectionAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.action.internal.CollectionAction;
@@ -38,7 +37,7 @@ public final class QueuedOperationCollectionAction extends CollectionAction impl
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() {
+	public InternalStage<Void> reactiveExecute() {
 		// this QueuedOperationCollectionAction has to be executed before any other
 		// CollectionAction involving the same collection.
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRecreateAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.action.internal.CollectionAction;
@@ -28,7 +27,7 @@ public class ReactiveCollectionRecreateAction extends CollectionAction implement
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() {
+	public InternalStage<Void> reactiveExecute() {
 		// this method is called when a new non-null collection is persisted
 		// or when an existing (non-null) collection is moved to a new owner
 		final PersistentCollection<?> collection = getCollection();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionRemoveAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
@@ -63,11 +62,11 @@ public class ReactiveCollectionRemoveAction extends CollectionAction implements 
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() {
+	public InternalStage<Void> reactiveExecute() {
 		preRemove();
 
 		final SharedSessionContractImplementor session = getSession();
-		CompletionStage<Void> removeStage;
+		InternalStage<Void> removeStage;
 		if ( emptySnapshot ) {
 			removeStage = voidFuture();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveCollectionUpdateAction.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.engine.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
@@ -50,7 +49,7 @@ public class ReactiveCollectionUpdateAction extends CollectionAction implements 
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() {
+	public InternalStage<Void> reactiveExecute() {
 		final Object key = getKey();
 		final SharedSessionContractImplementor session = getSession();
 		final ReactiveCollectionPersister reactivePersister = (ReactiveCollectionPersister) getPersister();
@@ -60,7 +59,7 @@ public class ReactiveCollectionUpdateAction extends CollectionAction implements 
 
 		preUpdate();
 
-		final CompletionStage<Void> updateStage;
+		final InternalStage<Void> updateStage;
 		if ( !collection.wasInitialized() ) {
 			// If there were queued operations, they would have been processed
 			// and cleared by now.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityDeleteAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityDeleteAction.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive.engine.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.action.internal.EntityDeleteAction;
@@ -54,7 +53,7 @@ public class ReactiveEntityDeleteAction extends EntityDeleteAction implements Re
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() throws HibernateException {
+	public InternalStage<Void> reactiveExecute() throws HibernateException {
 		final Object id = getId();
 		final Object version = getCurrentVersion();
 		final EntityPersister persister = getPersister();
@@ -65,7 +64,7 @@ public class ReactiveEntityDeleteAction extends EntityDeleteAction implements Re
 
 		final Object ck = lockCacheItem();
 
-		final CompletionStage<Void> deleteStep = !isCascadeDeleteEnabled() && !veto
+		final InternalStage<Void> deleteStep = !isCascadeDeleteEnabled() && !veto
 				? ( (ReactiveEntityPersister) persister ).deleteReactive( id, version, instance, session )
 				: voidFuture();
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIdentityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIdentityInsertAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.action.internal.AbstractEntityInsertAction;
@@ -47,8 +46,8 @@ public class ReactiveEntityIdentityInsertAction extends EntityIdentityInsertActi
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() throws HibernateException {
-		final CompletionStage<Void> stage = reactiveNullifyTransientReferencesIfNotAlready();
+	public InternalStage<Void> reactiveExecute() throws HibernateException {
+		final InternalStage<Void> stage = reactiveNullifyTransientReferencesIfNotAlready();
 
 		final EntityPersister persister = getPersister();
 		final SharedSessionContractImplementor session = getSession();
@@ -95,7 +94,7 @@ public class ReactiveEntityIdentityInsertAction extends EntityIdentityInsertActi
 		}
 	}
 
-	private CompletionStage<Void> processInsertGeneratedProperties(
+	private InternalStage<Void> processInsertGeneratedProperties(
 			ReactiveEntityPersister persister,
 			Object generatedId,
 			Object instance,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityIncrementVersionProcess.java
@@ -12,7 +12,6 @@ import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
 import org.hibernate.reactive.session.ReactiveSession;
 
-import java.util.concurrent.CompletionStage;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
@@ -41,7 +40,7 @@ public class ReactiveEntityIncrementVersionProcess implements ReactiveBeforeTran
 	 * @param session The session on which the transaction is preparing to complete.
 	 */
 	@Override
-	public CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
+	public InternalStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
 		// Don't increment version for an entity that is not in the PersistenceContext;
 		if ( entry == null ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.action.internal.AbstractEntityInsertAction;
@@ -58,7 +57,7 @@ public interface ReactiveEntityInsertAction extends ReactiveExecutable, Comparab
 	 * @see #reactiveMakeEntityManaged()
 	 */
 	// @see org.hibernate.action.internal.AbstractEntityInsertAction#nullifyTransientReferencesIfNotAlready()
-	default CompletionStage<Void> reactiveNullifyTransientReferencesIfNotAlready() {
+	default InternalStage<Void> reactiveNullifyTransientReferencesIfNotAlready() {
 		if ( !areTransientReferencesNullified() ) {
 			return new ForeignKeys.Nullifier( getInstance(), false, isEarlyInsert(), (SessionImplementor) getSession(), getPersister() )
 					.nullifyTransientReferences( getState() )
@@ -77,7 +76,7 @@ public interface ReactiveEntityInsertAction extends ReactiveExecutable, Comparab
 	 *
 	 * @see org.hibernate.action.internal.AbstractEntityInsertAction#makeEntityManaged()
 	 */
-	default CompletionStage<Void> reactiveMakeEntityManaged() {
+	default InternalStage<Void> reactiveMakeEntityManaged() {
 		return reactiveNullifyTransientReferencesIfNotAlready()
 				.thenAccept( v -> getSession().getPersistenceContextInternal().addEntity(
 						getInstance(),
@@ -92,7 +91,7 @@ public interface ReactiveEntityInsertAction extends ReactiveExecutable, Comparab
 				));
 	}
 
-	default CompletionStage<NonNullableTransientDependencies> reactiveFindNonNullableTransientEntities() {
+	default InternalStage<NonNullableTransientDependencies> reactiveFindNonNullableTransientEntities() {
 		return ForeignKeys.findNonNullableTransientEntities( getPersister().getEntityName(), getInstance(), getState(), isEarlyInsert(), getSession() );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.engine.impl;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.action.spi.AfterTransactionCompletionProcess;
@@ -58,7 +57,7 @@ public final class ReactiveEntityInsertActionHolder implements Executable, React
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() {
+	public InternalStage<Void> reactiveExecute() {
 		return delegate.reactiveExecute();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.HibernateException;
@@ -53,8 +52,8 @@ public class ReactiveEntityRegularInsertAction extends EntityInsertAction implem
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() throws HibernateException {
-		final CompletionStage<Void> stage = reactiveNullifyTransientReferencesIfNotAlready();
+	public InternalStage<Void> reactiveExecute() throws HibernateException {
+		final InternalStage<Void> stage = reactiveNullifyTransientReferencesIfNotAlready();
 
 		final EntityPersister persister = getPersister();
 		final SharedSessionContractImplementor session = getSession();
@@ -126,7 +125,7 @@ public class ReactiveEntityRegularInsertAction extends EntityInsertAction implem
 		}
 	}
 
-	private CompletionStage<Void> processInsertGeneratedProperties(
+	private InternalStage<Void> processInsertGeneratedProperties(
 			ReactiveEntityPersister persister,
 			SharedSessionContractImplementor session,
 			Object instance,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityUpdateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityUpdateAction.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.engine.impl;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.AssertionFailure;
 import org.hibernate.CacheMode;
@@ -67,7 +66,7 @@ public class ReactiveEntityUpdateAction extends EntityUpdateAction implements Re
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveExecute() throws HibernateException {
+	public InternalStage<Void> reactiveExecute() throws HibernateException {
 		if ( preUpdate() ) {
 			return voidFuture();
 		}
@@ -113,7 +112,7 @@ public class ReactiveEntityUpdateAction extends EntityUpdateAction implements Re
 				} );
 	}
 
-	private CompletionStage<EntityEntry> handleGeneratedProperties(EntityEntry entry) {
+	private InternalStage<EntityEntry> handleGeneratedProperties(EntityEntry entry) {
 		final EntityPersister persister = getPersister();
 		if ( entry.getStatus() == Status.MANAGED || persister.isVersionPropertyGenerated() ) {
 			final SharedSessionContractImplementor session = getSession();
@@ -224,7 +223,7 @@ public class ReactiveEntityUpdateAction extends EntityUpdateAction implements Re
 		}
 	}
 
-	private CompletionStage<Void> processGeneratedProperties(
+	private InternalStage<Void> processGeneratedProperties(
 			Object id,
 			ReactiveEntityPersister persister,
 			SharedSessionContractImplementor session,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityVerifyVersionProcess.java
@@ -11,7 +11,6 @@ import org.hibernate.reactive.engine.ReactiveBeforeTransactionCompletionProcess;
 import org.hibernate.reactive.persister.entity.impl.ReactiveEntityPersister;
 import org.hibernate.reactive.session.ReactiveSession;
 
-import java.util.concurrent.CompletionStage;
 
 import static org.hibernate.pretty.MessageHelper.infoString;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
@@ -36,7 +35,7 @@ public class ReactiveEntityVerifyVersionProcess implements ReactiveBeforeTransac
 	}
 
 	@Override
-	public CompletionStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
+	public InternalStage<Void> doBeforeTransactionCompletion(ReactiveSession session) {
 		final EntityEntry entry = session.getPersistenceContext().getEntry( object );
 		// Don't check version for an entity that is not in the PersistenceContext;
 		if ( entry == null ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactivePersistenceContextAdapter.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactivePersistenceContextAdapter.java
@@ -18,7 +18,6 @@ import org.hibernate.reactive.session.ReactiveSession;
 
 import java.io.Serializable;
 import java.util.HashMap;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import static org.hibernate.pretty.MessageHelper.infoString;
@@ -41,14 +40,14 @@ public class ReactivePersistenceContextAdapter extends StatefulPersistenceContex
 		super( session );
 	}
 
-	public CompletionStage<Void> reactiveInitializeNonLazyCollections() throws HibernateException {
+	public InternalStage<Void> reactiveInitializeNonLazyCollections() throws HibernateException {
 		final NonLazyCollectionInitializer initializer = new NonLazyCollectionInitializer();
 		initializeNonLazyCollections( initializer );
 		return initializer.stage;
 	}
 
 	private class NonLazyCollectionInitializer implements Consumer<PersistentCollection<?>> {
-		CompletionStage<Void> stage = voidFuture();
+		InternalStage<Void> stage = voidFuture();
 
 		@Override
 		public void accept(PersistentCollection<?> nonLazyCollection) {
@@ -76,7 +75,7 @@ public class ReactivePersistenceContextAdapter extends StatefulPersistenceContex
 
 	private static final Object[] NO_ROW = new Object[]{ StatefulPersistenceContext.NO_ROW };
 
-	public CompletionStage<Object[]> reactiveGetDatabaseSnapshot(Object id, EntityPersister persister)
+	public InternalStage<Object[]> reactiveGetDatabaseSnapshot(Object id, EntityPersister persister)
 			throws HibernateException {
 
 		SessionImplementor session = (SessionImplementor) getSession();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/env/internal/ReactiveMutationExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/env/internal/ReactiveMutationExecutor.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.engine.jdbc.env.internal;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.MutationExecutor;
@@ -46,7 +46,7 @@ public interface ReactiveMutationExecutor extends MutationExecutor {
 		throw LOG.nonReactiveMethodCall( "executeReactive" );
 	}
 
-	default CompletionStage<Object> executeReactive(
+	default InternalStage<Object> executeReactive(
 			Object modelReference,
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
@@ -58,7 +58,7 @@ public interface ReactiveMutationExecutor extends MutationExecutor {
 				.thenApply( CompletionStages::nullFuture );
 	}
 
-	default CompletionStage<Void> performReactiveNonBatchedOperations(
+	default InternalStage<Void> performReactiveNonBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			OperationResultChecker resultChecker,
@@ -66,14 +66,14 @@ public interface ReactiveMutationExecutor extends MutationExecutor {
 		return voidFuture();
 	}
 
-	default CompletionStage<Void> performReactiveSelfExecutingOperations(
+	default InternalStage<Void> performReactiveSelfExecutingOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			SharedSessionContractImplementor session) {
 		return voidFuture();
 	}
 
-	default CompletionStage<Void> performReactiveBatchedOperations(
+	default InternalStage<Void> performReactiveBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker, OperationResultChecker resultChecker,
 			SharedSessionContractImplementor session) {
@@ -83,7 +83,7 @@ public interface ReactiveMutationExecutor extends MutationExecutor {
 	/**
 	 * Perform a non-batched mutation
 	 */
-	default CompletionStage<Void> performReactiveNonBatchedMutation(
+	default InternalStage<Void> performReactiveNonBatchedMutation(
 			PreparedStatementDetails statementDetails,
 			JdbcValueBindings valueBindings,
 			TableInclusionChecker inclusionChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsert.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsert.java
@@ -9,7 +9,7 @@ import static org.hibernate.reactive.engine.jdbc.ResultsCheckerUtil.checkResults
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER_TRACE_ENABLED;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.atomic.AtomicReference;
 import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
 import org.hibernate.engine.jdbc.mutation.ParameterUsage;
@@ -36,7 +36,7 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 	}
 
 	@Override
-	public CompletionStage<Object> executeReactive(Object modelReference, ValuesAnalysis valuesAnalysis,
+	public InternalStage<Object> executeReactive(Object modelReference, ValuesAnalysis valuesAnalysis,
 												   TableInclusionChecker inclusionChecker,
 												   OperationResultChecker resultChecker,
 												   SharedSessionContractImplementor session) {
@@ -52,7 +52,7 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 					if (secondaryTablesStatementGroup == null) {
 						return completedFuture(id);
 					}
-					AtomicReference<CompletionStage<Object>>  res = new AtomicReference<>(completedFuture(id));
+					AtomicReference<InternalStage<Object>>  res = new AtomicReference<>(completedFuture(id));
 					secondaryTablesStatementGroup.forEachStatement((tableName, statementDetails) -> {
 						res.set(res.get().thenCompose(i -> reactiveExecuteWithId(i, tableName, statementDetails, inclusionChecker, resultChecker, session)));
 					});
@@ -68,7 +68,7 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 		return identifier;
 	}
 
-	private CompletionStage<Object> reactiveExecuteWithId(
+	private InternalStage<Object> reactiveExecuteWithId(
 			Object id,
 			String tableName,
 			PreparedStatementDetails statementDetails,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsertSingleTable.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsertSingleTable.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.engine.jdbc.mutation.internal;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
 import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
@@ -57,7 +57,7 @@ public class ReactiveMutationExecutorPostInsertSingleTable extends MutationExecu
 	}
 
 	@Override
-	public CompletionStage<Object> executeReactive(
+	public InternalStage<Object> executeReactive(
 			Object modelReference,
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleBatched.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleBatched.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.engine.jdbc.mutation.internal;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER_TRACE_ENABLED;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.engine.jdbc.batch.spi.BatchKey;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
@@ -38,7 +38,7 @@ public class ReactiveMutationExecutorSingleBatched extends MutationExecutorSingl
 	}
 
 	@Override
-	public CompletionStage<Void> performReactiveBatchedOperations(
+	public InternalStage<Void> performReactiveBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			OperationResultChecker resultChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleNonBatched.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorSingleNonBatched.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.engine.jdbc.mutation.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
 import org.hibernate.engine.jdbc.mutation.TableInclusionChecker;
@@ -28,7 +28,7 @@ public class ReactiveMutationExecutorSingleNonBatched extends MutationExecutorSi
 	}
 
 	@Override
-	public CompletionStage<Void> performReactiveNonBatchedOperations(
+	public InternalStage<Void> performReactiveNonBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			OperationResultChecker resultChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorStandard.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.engine.jdbc.mutation.internal;
 
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.OperationResultChecker;
@@ -49,7 +49,7 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 	}
 
 	@Override
-	public CompletionStage<Void> performReactiveBatchedOperations(
+	public InternalStage<Void> performReactiveBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker, OperationResultChecker resultChecker,
 			SharedSessionContractImplementor session) {
@@ -82,7 +82,7 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 	}
 
 	@Override
-	public CompletionStage<Void> performReactiveNonBatchedOperations(
+	public InternalStage<Void> performReactiveNonBatchedOperations(
 			ValuesAnalysis valuesAnalysis,
 			TableInclusionChecker inclusionChecker,
 			OperationResultChecker resultChecker,
@@ -105,7 +105,7 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 		private final SharedSessionContractImplementor session;
 		private final JdbcValueBindings jdbcValueBindings;
 
-		private CompletionStage<Void> loop = voidFuture();
+		private InternalStage<Void> loop = voidFuture();
 
 		public OperationsForEach(
 				TableInclusionChecker inclusionChecker,
@@ -128,12 +128,12 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 			) );
 		}
 
-		public CompletionStage<Void> buildLoop() {
+		public InternalStage<Void> buildLoop() {
 			return loop;
 		}
 	}
 	@Override
-	public CompletionStage<Void> performReactiveNonBatchedMutation(
+	public InternalStage<Void> performReactiveNonBatchedMutation(
 			PreparedStatementDetails statementDetails,
 			JdbcValueBindings valueBindings,
 			TableInclusionChecker inclusionChecker,
@@ -168,7 +168,7 @@ public class ReactiveMutationExecutorStandard extends MutationExecutorStandard i
 				} );
 	}
 
-	private static CompletionStage<Void> checkResult(
+	private static InternalStage<Void> checkResult(
 			SharedSessionContractImplementor session,
 			PreparedStatementDetails statementDetails,
 			OperationResultChecker resultChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/spi/ReactiveSharedSessionContractImplementor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/spi/ReactiveSharedSessionContractImplementor.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.engine.spi;
 
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 
 import org.hibernate.engine.spi.PersistenceContext;
@@ -18,7 +18,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.falseFuture;
  */
 public interface ReactiveSharedSessionContractImplementor {
 
-	default CompletionStage<Boolean> reactiveAutoFlushIfRequired(Set<String> querySpaces) {
+	default InternalStage<Boolean> reactiveAutoFlushIfRequired(Set<String> querySpaces) {
 		return falseFuture();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveAutoFlushEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveAutoFlushEventListener.java
@@ -6,13 +6,13 @@
 package org.hibernate.reactive.event;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.AutoFlushEvent;
 
 public interface ReactiveAutoFlushEventListener extends Serializable {
 
-	CompletionStage<Void> reactiveOnAutoFlush(AutoFlushEvent event) throws HibernateException;
+	InternalStage<Void> reactiveOnAutoFlush(AutoFlushEvent event) throws HibernateException;
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveDeleteEventListener.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.event;
 
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.DeleteContext;
@@ -25,7 +25,7 @@ public interface ReactiveDeleteEventListener extends Serializable {
 	 *
 	 * @param event The delete event to be handled.
 	 */
-	CompletionStage<Void> reactiveOnDelete(DeleteEvent event) throws HibernateException;
+	InternalStage<Void> reactiveOnDelete(DeleteEvent event) throws HibernateException;
 
-	CompletionStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities) throws HibernateException;
+	InternalStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities) throws HibernateException;
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
@@ -1,0 +1,4 @@
+package org.hibernate.reactive.event;
+
+public interface ReactiveEventListenerGroup {
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
@@ -1,4 +1,68 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
 package org.hibernate.reactive.event;
 
-public interface ReactiveEventListenerGroup {
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiConsumer;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.hibernate.Incubating;
+import org.hibernate.event.service.spi.EventListenerGroup;
+
+public interface ReactiveEventListenerGroup<T> {
+
+	/**
+	 * Similar to {@link #fireEventOnEachListener(Object, Function)}, but Reactive friendly: it chains
+	 * processing of the same event on each Reactive Listener, and returns a {@link CompletionStage} of type R.
+	 * The various generic types allow using this for each concrete event type and flexible return types.
+	 * <p>Used by Hibernate Reactive</p>
+	 * @param event The event being fired
+	 * @param fun The function combining each event listener with the event
+	 * @param <R> the return type of the returned CompletionStage
+	 * @param <U> the type of the event being fired on each listener
+	 * @param <RL> the type of ReactiveListener: each listener of type T will be casted to it.
+	 * @return the composite completion stage of invoking fun(event) on each listener.
+	 */
+	@Incubating
+	<R, U, RL> CompletionStage<R> fireEventOnEachListener(final U event, final Function<RL, Function<U, CompletionStage<R>>> fun);
+
+	/**
+	 * Similar to {@link #fireEventOnEachListener(Object, Object, Function)}, but Reactive friendly: it chains
+	 * processing of the same event on each Reactive Listener, and returns a {@link CompletionStage} of type R.
+	 * The various generic types allow using this for each concrete event type and flexible return types.
+	 * <p>Used by Hibernate Reactive</p>
+	 * @param event The event being fired
+	 * @param fun The function combining each event listener with the event
+	 * @param <R> the return type of the returned CompletionStage
+	 * @param <U> the type of the event being fired on each listener
+	 * @param <RL> the type of ReactiveListener: each listener of type T will be casted to it.
+	 * @param <X> an additional parameter to be passed to the function fun
+	 * @return the composite completion stage of invoking fun(event) on each listener.
+	 */
+	@Incubating
+	<R, U, RL, X> CompletionStage<R> fireEventOnEachListener(U event, X param, Function<RL, BiFunction<U, X, CompletionStage<R>>> fun);
+
+	/**
+	 * Similar to {@link EventListenerGroup#fireLazyEventOnEachListener(Supplier, BiConsumer)}, but Reactive friendly: it chains
+	 * processing of the same event on each Reactive Listener, and returns a {@link CompletionStage} of type R.
+	 * The various generic types allow using this for each concrete event type and flexible return types.
+	 * <p>This variant expects a Supplier of the event, rather than the event directly; this is useful for the
+	 * event types which are commonly configured with no listeners at all, so to allow skipping creating the
+	 * event; use only for event types which are known to be expensive while the listeners are commonly empty.</p>
+	 * <p>Used by Hibernate Reactive</p>
+	 * @param eventSupplier A supplier able to produce the actual event
+	 * @param fun The function combining each event listener with the event
+	 * @param <R> the return type of the returned CompletionStage
+	 * @param <U> the type of the event being fired on each listener
+	 * @param <RL> the type of ReactiveListener: each listener of type T will be casted to it.
+	 * @return the composite completion stage of invoking fun(event) on each listener.
+	 */
+	@Incubating
+	<R, U, RL> CompletionStage<R> fireLazyEventOnEachListener(final Supplier<U> eventSupplier, final Function<RL, Function<U, CompletionStage<R>>> fun);
+
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveEventListenerGroup.java
@@ -13,6 +13,7 @@ import java.util.function.Supplier;
 
 import org.hibernate.Incubating;
 import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 public interface ReactiveEventListenerGroup<T> {
 
@@ -29,7 +30,7 @@ public interface ReactiveEventListenerGroup<T> {
 	 * @return the composite completion stage of invoking fun(event) on each listener.
 	 */
 	@Incubating
-	<R, U, RL> CompletionStage<R> fireEventOnEachListener(final U event, final Function<RL, Function<U, CompletionStage<R>>> fun);
+	<R, U, RL> InternalStage<R> fireEventOnEachListener(final U event, final Function<RL, Function<U, InternalStage<R>>> fun);
 
 	/**
 	 * Similar to {@link #fireEventOnEachListener(Object, Object, Function)}, but Reactive friendly: it chains
@@ -45,7 +46,7 @@ public interface ReactiveEventListenerGroup<T> {
 	 * @return the composite completion stage of invoking fun(event) on each listener.
 	 */
 	@Incubating
-	<R, U, RL, X> CompletionStage<R> fireEventOnEachListener(U event, X param, Function<RL, BiFunction<U, X, CompletionStage<R>>> fun);
+	<R, U, RL, X> InternalStage<R> fireEventOnEachListener(U event, X param, Function<RL, BiFunction<U, X, InternalStage<R>>> fun);
 
 	/**
 	 * Similar to {@link EventListenerGroup#fireLazyEventOnEachListener(Supplier, BiConsumer)}, but Reactive friendly: it chains
@@ -63,6 +64,6 @@ public interface ReactiveEventListenerGroup<T> {
 	 * @return the composite completion stage of invoking fun(event) on each listener.
 	 */
 	@Incubating
-	<R, U, RL> CompletionStage<R> fireLazyEventOnEachListener(final Supplier<U> eventSupplier, final Function<RL, Function<U, CompletionStage<R>>> fun);
+	<R, U, RL> InternalStage<R> fireLazyEventOnEachListener(final Supplier<U> eventSupplier, final Function<RL, Function<U, InternalStage<R>>> fun);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveFlushEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveFlushEventListener.java
@@ -9,7 +9,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.event.spi.FlushEvent;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Defines the contract for handling of reactive session flush events.
@@ -20,5 +20,5 @@ public interface ReactiveFlushEventListener extends Serializable {
 	 *
 	 * @param event The flush event to be handled.
 	 */
-	CompletionStage<Void> reactiveOnFlush(FlushEvent event) throws HibernateException;
+	InternalStage<Void> reactiveOnFlush(FlushEvent event) throws HibernateException;
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveLoadEventListener.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.event;
 
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.LoadEvent;
@@ -27,6 +27,6 @@ public interface ReactiveLoadEventListener extends Serializable {
 	 *
 	 * @throws HibernateException
 	 */
-	CompletionStage<Void> reactiveOnLoad(LoadEvent event, LoadType loadType) throws HibernateException;
+	InternalStage<Void> reactiveOnLoad(LoadEvent event, LoadType loadType) throws HibernateException;
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveLockEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveLockEventListener.java
@@ -9,7 +9,7 @@ import org.hibernate.HibernateException;
 import org.hibernate.event.spi.LockEvent;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Defines the contract for handling of lock events generated from a session.
@@ -23,5 +23,5 @@ public interface ReactiveLockEventListener extends Serializable {
      *
      * @param event The lock event to be handled.
      */
-	CompletionStage<Void> reactiveOnLock(LockEvent event) throws HibernateException;
+	InternalStage<Void> reactiveOnLock(LockEvent event) throws HibernateException;
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveMergeEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveMergeEventListener.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.event;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.event.spi.MergeContext;
@@ -24,13 +24,13 @@ public interface ReactiveMergeEventListener extends Serializable {
      *
      * @param event The merge event to be handled.
      */
-	CompletionStage<Void> reactiveOnMerge(MergeEvent event) throws HibernateException;
+	InternalStage<Void> reactiveOnMerge(MergeEvent event) throws HibernateException;
 
     /**
      * Handle the given merge event.
      *
      * @param event The merge event to be handled.
      */
-	CompletionStage<Void> reactiveOnMerge(MergeEvent event, MergeContext copiedAlready) throws HibernateException;
+	InternalStage<Void> reactiveOnMerge(MergeEvent event, MergeContext copiedAlready) throws HibernateException;
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactivePersistEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactivePersistEventListener.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.event;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.event.spi.PersistContext;
 import org.hibernate.event.spi.PersistEvent;
@@ -22,13 +22,13 @@ public interface ReactivePersistEventListener {
 	 *
 	 * @param event The create event to be handled.
 	 */
-	CompletionStage<Void> reactiveOnPersist(PersistEvent event);
+	InternalStage<Void> reactiveOnPersist(PersistEvent event);
 
 	/**
 	 * Handle the given create event.
 	 *
 	 * @param event The create event to be handled.
 	 */
-	CompletionStage<Void> reactiveOnPersist(PersistEvent event, PersistContext createdAlready);
+	InternalStage<Void> reactiveOnPersist(PersistEvent event, PersistContext createdAlready);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveRefreshEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveRefreshEventListener.java
@@ -9,7 +9,7 @@ import org.hibernate.event.spi.RefreshContext;
 import org.hibernate.event.spi.RefreshEvent;
 
 import java.io.Serializable;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Defines the contract for handling of refresh events generated from a session.
@@ -23,8 +23,8 @@ public interface ReactiveRefreshEventListener extends Serializable {
      *
      * @param event The refresh event to be handled.
      */
-	CompletionStage<Void> reactiveOnRefresh(RefreshEvent event);
+	InternalStage<Void> reactiveOnRefresh(RefreshEvent event);
 
-	CompletionStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready);
+	InternalStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveResolveNaturalIdEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/ReactiveResolveNaturalIdEventListener.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.event;
 
 import org.hibernate.event.spi.ResolveNaturalIdEvent;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Defines the contract for handling of resolve natural id events generated from a session.
@@ -24,6 +24,6 @@ public interface ReactiveResolveNaturalIdEventListener {
 	 *
 	 * @param event The resolve natural id event to be handled.
 	 */
-	CompletionStage<Void> onReactiveResolveNaturalId(ResolveNaturalIdEvent event);
+	InternalStage<Void> onReactiveResolveNaturalId(ResolveNaturalIdEvent event);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveFlushingEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveFlushingEventListener.java
@@ -9,7 +9,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.loop;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.Interceptor;
@@ -47,7 +47,7 @@ public abstract class AbstractReactiveFlushingEventListener {
 
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	protected CompletionStage<Void> performExecutions(EventSource session) {
+	protected InternalStage<Void> performExecutions(EventSource session) {
 		LOG.trace( "Executing flush" );
 
 		// IMPL NOTE : here we alter the flushing flag of the persistence context to allow
@@ -79,7 +79,7 @@ public abstract class AbstractReactiveFlushingEventListener {
 	 * @param event The flush event.
 	 * @throws HibernateException Error flushing caches to execution queues.
 	 */
-	protected CompletionStage<Void> flushEverythingToExecutions(FlushEvent event) throws HibernateException {
+	protected InternalStage<Void> flushEverythingToExecutions(FlushEvent event) throws HibernateException {
 
 		LOG.trace( "Flushing session" );
 
@@ -144,7 +144,7 @@ public abstract class AbstractReactiveFlushingEventListener {
 	 * any newly referenced entity that must be passed to saveOrUpdate(),
 	 * and also apply orphan delete
 	 */
-	private CompletionStage<Void> prepareEntityFlushes(EventSource session, PersistenceContext persistenceContext) throws HibernateException {
+	private InternalStage<Void> prepareEntityFlushes(EventSource session, PersistenceContext persistenceContext) throws HibernateException {
 
 		LOG.debug( "Processing flush-time cascades" );
 
@@ -299,7 +299,7 @@ public abstract class AbstractReactiveFlushingEventListener {
 		return count;
 	}
 
-	private CompletionStage<Void> cascadeOnFlush(
+	private InternalStage<Void> cascadeOnFlush(
 			EventSource session,
 			EntityPersister persister,
 			Object object,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveSaveEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/AbstractReactiveSaveEventListener.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.event.impl;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.NonUniqueObjectException;
@@ -82,7 +82,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 *
 	 * @return The id used to save the entity.
 	 */
-	protected CompletionStage<Void> reactiveSaveWithRequestedId(
+	protected InternalStage<Void> reactiveSaveWithRequestedId(
 			Object entity,
 			Object requestedId,
 			String entityName,
@@ -116,7 +116,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 * @return The id used to save the entity; may be null depending on the
 	 * type of id generator used and the requiresImmediateIdAccess value
 	 */
-	protected CompletionStage<Void> reactiveSaveWithGeneratedId(
+	protected InternalStage<Void> reactiveSaveWithGeneratedId(
 			Object entity,
 			String entityName,
 			C context,
@@ -145,7 +145,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 		}
 	}
 
-	private CompletionStage<Void> performSaveWithId(
+	private InternalStage<Void> performSaveWithId(
 			Object entity,
 			C context,
 			EventSource source,
@@ -187,7 +187,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 * @return The id used to save the entity; may be null depending on the
 	 * type of id generator used and the requiresImmediateIdAccess value
 	 */
-	protected CompletionStage<Void> reactivePerformSave(
+	protected InternalStage<Void> reactivePerformSave(
 			Object entity,
 			Object id,
 			EntityPersister persister,
@@ -212,7 +212,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 				) );
 	}
 
-	private CompletionStage<EntityKey> entityKey(Object entity, Object id, EntityPersister persister, boolean useIdentityColumn, EventSource source) {
+	private InternalStage<EntityKey> entityKey(Object entity, Object id, EntityPersister persister, boolean useIdentityColumn, EventSource source) {
 		return useIdentityColumn
 				? nullFuture()
 				: generateEntityKey( id, persister, source )
@@ -222,7 +222,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 						} );
 	}
 
-	private CompletionStage<EntityKey> generateEntityKey(Object id, EntityPersister persister, EventSource source) {
+	private InternalStage<EntityKey> generateEntityKey(Object id, EntityPersister persister, EventSource source) {
 		final EntityKey key = source.generateEntityKey( id, persister );
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 		final Object old = persistenceContext.getEntity( key );
@@ -257,7 +257,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 * @return The id used to save the entity; may be null depending on the
 	 * type of id generator used and the requiresImmediateIdAccess value
 	 */
-	protected CompletionStage<Void> reactivePerformSaveOrReplicate(
+	protected InternalStage<Void> reactivePerformSaveOrReplicate(
 			Object entity,
 			EntityKey key,
 			EntityPersister persister,
@@ -358,7 +358,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 		return null;
 	}
 
-	private CompletionStage<AbstractEntityInsertAction> addInsertAction(
+	private InternalStage<AbstractEntityInsertAction> addInsertAction(
 			Object[] values,
 			Object id,
 			Object entity,
@@ -389,7 +389,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 * @param entity The entity to be saved.
 	 * @param context Generally cascade-specific data
 	 */
-	protected CompletionStage<Void> cascadeBeforeSave(
+	protected InternalStage<Void> cascadeBeforeSave(
 			EventSource source,
 			EntityPersister persister,
 			Object entity,
@@ -410,7 +410,7 @@ abstract class AbstractReactiveSaveEventListener<C> implements CallbackRegistryC
 	 * @param entity The entity beng saved.
 	 * @param context Generally cascade-specific data
 	 */
-	protected CompletionStage<Void> cascadeAfterSave(
+	protected InternalStage<Void> cascadeAfterSave(
 			EventSource source,
 			EntityPersister persister,
 			Object entity,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveAutoFlushEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveAutoFlushEventListener.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.event.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FlushMode;
 import org.hibernate.HibernateException;
@@ -30,12 +30,12 @@ public class DefaultReactiveAutoFlushEventListener extends AbstractReactiveFlush
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	@Override
-	public CompletionStage<Void> reactiveOnAutoFlush(AutoFlushEvent event) throws HibernateException {
+	public InternalStage<Void> reactiveOnAutoFlush(AutoFlushEvent event) throws HibernateException {
 		final EventSource source = event.getSession();
 		final SessionEventListenerManager eventListenerManager = source.getEventListenerManager();
 
 		eventListenerManager.partialFlushStart();
-		CompletionStage<Void> autoFlushStage = voidFuture();
+		InternalStage<Void> autoFlushStage = voidFuture();
 		if ( flushMightBeNeeded( source ) ) {
 			// Need to get the number of collection removals before flushing to executions
 			// (because flushing to executions can add collection removal actions to the action queue).

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
@@ -10,7 +10,7 @@ import static org.hibernate.reactive.engine.impl.Cascade.fetchLazyAssociationsBe
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -108,7 +108,7 @@ public class DefaultReactiveDeleteEventListener
 	 *
 	 */
 	@Override
-	public CompletionStage<Void> reactiveOnDelete(DeleteEvent event) throws HibernateException {
+	public InternalStage<Void> reactiveOnDelete(DeleteEvent event) throws HibernateException {
 		return reactiveOnDelete( event, DeleteContext.create() );
 	}
 
@@ -120,15 +120,15 @@ public class DefaultReactiveDeleteEventListener
 	 *
 	 */
 	@Override
-	public CompletionStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities) throws HibernateException {
+	public InternalStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities) throws HibernateException {
 		if ( optimizeUnloadedDelete( event ) ) {
 			return voidFuture();
 		}
 		else {
 			final EventSource source = event.getSession();
 			Object object = event.getObject();
-			if ( object instanceof CompletionStage ) {
-				final CompletionStage<Object> objectStage = (CompletionStage<Object>) object;
+			if ( object instanceof InternalStage ) {
+				final InternalStage<Object> objectStage = (InternalStage<Object>) object;
 				return objectStage.thenCompose( objectEvent -> fetchAndDelete( event, transientEntities, source, objectEvent ) );
 			}
 			else {
@@ -190,7 +190,7 @@ public class DefaultReactiveDeleteEventListener
 		}
 	}
 
-	private CompletionStage<Void> fetchAndDelete(
+	private InternalStage<Void> fetchAndDelete(
 			DeleteEvent event,
 			DeleteContext transientEntities,
 			EventSource source,
@@ -209,7 +209,7 @@ public class DefaultReactiveDeleteEventListener
 				.thenCompose( entity -> reactiveOnDelete( event, transientEntities, entity ) );
 	}
 
-	private CompletionStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities, Object entity) {
+	private InternalStage<Void> reactiveOnDelete(DeleteEvent event, DeleteContext transientEntities, Object entity) {
 		final PersistenceContext persistenceContext = event.getSession().getPersistenceContextInternal();
 		final EntityEntry entityEntry = persistenceContext.getEntry( entity );
 		if ( entityEntry == null ) {
@@ -220,7 +220,7 @@ public class DefaultReactiveDeleteEventListener
 		}
 	}
 
-	private CompletionStage<Void> deleteTransientInstance(DeleteEvent event, DeleteContext transientEntities, Object entity) {
+	private InternalStage<Void> deleteTransientInstance(DeleteEvent event, DeleteContext transientEntities, Object entity) {
 		LOG.trace( "Entity was not persistent in delete processing" );
 
 		final EventSource source = event.getSession();
@@ -268,7 +268,7 @@ public class DefaultReactiveDeleteEventListener
 				} );
 	}
 
-	private CompletionStage<Void> deletePersistentInstance(
+	private InternalStage<Void> deletePersistentInstance(
 			DeleteEvent event,
 			DeleteContext transientEntities,
 			Object entity,
@@ -295,7 +295,7 @@ public class DefaultReactiveDeleteEventListener
 		}
 	}
 
-	private CompletionStage<Void> delete(
+	private InternalStage<Void> delete(
 			DeleteEvent event,
 			DeleteContext transientEntities,
 			EventSource source,
@@ -391,7 +391,7 @@ public class DefaultReactiveDeleteEventListener
 	 * @param transientEntities A cache of already visited transient entities
 	 * (to avoid infinite recursion).
 	 */
-	protected CompletionStage<Void> deleteTransientEntity(
+	protected InternalStage<Void> deleteTransientEntity(
 			EventSource session,
 			Object entity,
 			EntityPersister persister,
@@ -419,7 +419,7 @@ public class DefaultReactiveDeleteEventListener
 	 * @param persister The entity persister.
 	 * @param transientEntities A cache of already deleted entities.
 	 */
-	protected CompletionStage<Void> deleteEntity(
+	protected InternalStage<Void> deleteEntity(
 			final EventSource session,
 			final Object entity,
 			final EntityEntry entityEntry,
@@ -550,7 +550,7 @@ public class DefaultReactiveDeleteEventListener
 		return deletedState;
 	}
 
-	protected CompletionStage<Void> cascadeBeforeDelete(
+	protected InternalStage<Void> cascadeBeforeDelete(
 			EventSource session,
 			EntityPersister persister,
 			Object entity,
@@ -566,7 +566,7 @@ public class DefaultReactiveDeleteEventListener
 				);
 	}
 
-	protected CompletionStage<Void> cascadeAfterDelete(
+	protected InternalStage<Void> cascadeAfterDelete(
 			EventSource session,
 			EntityPersister persister,
 			Object entity,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveFlushEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveFlushEventListener.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.event.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -30,7 +30,7 @@ public class DefaultReactiveFlushEventListener extends AbstractReactiveFlushingE
 	private static final Log LOG = make( Log.class, lookup() );
 
 	@Override
-	public CompletionStage<Void> reactiveOnFlush(FlushEvent event) throws HibernateException {
+	public InternalStage<Void> reactiveOnFlush(FlushEvent event) throws HibernateException {
 		final EventSource source = event.getSession();
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveInitializeCollectionEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveInitializeCollectionEventListener.java
@@ -9,7 +9,7 @@ import static org.hibernate.pretty.MessageHelper.collectionInfoString;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.cache.spi.access.CollectionDataAccess;
@@ -41,7 +41,7 @@ public class DefaultReactiveInitializeCollectionEventListener implements Initial
 	/**
 	 * called by a collection that wants to initialize itself
 	 */
-	public CompletionStage<Void> onReactiveInitializeCollection(InitializeCollectionEvent event) throws HibernateException {
+	public InternalStage<Void> onReactiveInitializeCollection(InitializeCollectionEvent event) throws HibernateException {
 		final PersistentCollection<?> collection = event.getCollection();
 		final SessionImplementor source = event.getSession();
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.event.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -47,7 +47,7 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	@Override
-	public CompletionStage<Void> reactiveOnLock(LockEvent event) throws HibernateException {
+	public InternalStage<Void> reactiveOnLock(LockEvent event) throws HibernateException {
 		if ( event.getObject() == null ) {
 			throw new NullPointerException( "attempted to lock null" );
 		}
@@ -79,13 +79,13 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 				.thenCompose( entity -> reactiveOnLock( event, entity ) );
 	}
 
-	private CompletionStage<Void> reactiveOnLock(LockEvent event, Object entity) {
+	private InternalStage<Void> reactiveOnLock(LockEvent event, Object entity) {
 
 		final SessionImplementor source = event.getSession();
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 
 		final EntityEntry entry = persistenceContext.getEntry(entity);
-		final CompletionStage<EntityEntry> stage;
+		final InternalStage<EntityEntry> stage;
 		if ( entry==null ) {
 			final EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );
 			final Object id = persister.getIdentifier( entity, source );
@@ -139,7 +139,7 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 	 * @param lockOptions contains the requested lock mode.
 	 * @param source The session which is the source of the event being processed.
 	 */
-	protected CompletionStage<Void> upgradeLock(
+	protected InternalStage<Void> upgradeLock(
 			Object object,
 			EntityEntry entry,
 			LockOptions lockOptions,
@@ -184,7 +184,7 @@ public class DefaultReactiveLockEventListener extends AbstractReassociateEventLi
 		}
 	}
 
-	private CompletionStage<Void> doUpgradeLock(Object object, EntityEntry entry,
+	private InternalStage<Void> doUpgradeLock(Object object, EntityEntry entry,
 												LockOptions lockOptions,
 												EventSource source) {
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePersistEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactivePersistEventListener.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.event.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.ObjectDeletedException;
@@ -60,7 +60,7 @@ public class DefaultReactivePersistEventListener
 	 * @param event The create event to be handled.
 	 */
 	@Override
-	public CompletionStage<Void> reactiveOnPersist(PersistEvent event) {
+	public InternalStage<Void> reactiveOnPersist(PersistEvent event) {
 		return reactiveOnPersist( event, PersistContext.create() );
 	}
 
@@ -75,7 +75,7 @@ public class DefaultReactivePersistEventListener
 	 * @param event The create event to be handled.
 	 */
 	@Override
-	public CompletionStage<Void> reactiveOnPersist(PersistEvent event, PersistContext createCache) {
+	public InternalStage<Void> reactiveOnPersist(PersistEvent event, PersistContext createCache) {
 		final Object object = event.getObject();
 		final LazyInitializer lazyInitializer = HibernateProxy.extractLazyInitializer( object );
 		if ( lazyInitializer != null ) {
@@ -93,7 +93,7 @@ public class DefaultReactivePersistEventListener
 		}
 	}
 
-	private CompletionStage<Void> persist(PersistEvent event, PersistContext createCache, Object entity) {
+	private InternalStage<Void> persist(PersistEvent event, PersistContext createCache, Object entity) {
 		final SessionImplementor source = event.getSession();
 		final EntityEntry entityEntry = source.getPersistenceContextInternal().getEntry(entity);
 		final String entityName = entityName( event, entity, entityEntry );
@@ -159,7 +159,7 @@ public class DefaultReactivePersistEventListener
 		}
 	}
 
-	protected CompletionStage<Void> entityIsPersistent(PersistEvent event, PersistContext createCache) {
+	protected InternalStage<Void> entityIsPersistent(PersistEvent event, PersistContext createCache) {
 		LOG.trace( "Ignoring persistent instance" );
 		final EventSource source = event.getSession();
 		//TODO: check that entry.getIdentifier().equals(requestedId)
@@ -169,7 +169,7 @@ public class DefaultReactivePersistEventListener
 				: voidFuture();
 	}
 
-	private CompletionStage<Void> justCascade(PersistContext createCache, EventSource source, Object entity, EntityPersister persister) {
+	private InternalStage<Void> justCascade(PersistContext createCache, EventSource source, Object entity, EntityPersister persister) {
 		//TODO: merge into one method!
 		return cascadeBeforeSave( source, persister, entity, createCache )
 				.thenCompose( v -> cascadeAfterSave( source, persister, entity, createCache ) );
@@ -181,7 +181,7 @@ public class DefaultReactivePersistEventListener
 	 * @param event The save event to be handled.
 	 * @param createCache The copy cache of entity instance to merge/copy instance.
 	 */
-	protected CompletionStage<Void> entityIsTransient(PersistEvent event, PersistContext createCache) {
+	protected InternalStage<Void> entityIsTransient(PersistEvent event, PersistContext createCache) {
 		LOG.trace( "Saving transient instance" );
 		final EventSource source = event.getSession();
 		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );
@@ -190,7 +190,7 @@ public class DefaultReactivePersistEventListener
 				: voidFuture();
 	}
 
-	private CompletionStage<Void> entityIsDeleted(PersistEvent event, PersistContext createCache) {
+	private InternalStage<Void> entityIsDeleted(PersistEvent event, PersistContext createCache) {
 		final EventSource source = event.getSession();
 		final Object entity = source.getPersistenceContextInternal().unproxy( event.getObject() );
 		final EntityPersister persister = source.getEntityPersister( event.getEntityName(), entity );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveRefreshEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveRefreshEventListener.java
@@ -9,8 +9,7 @@ import static org.hibernate.pretty.MessageHelper.infoString;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -54,7 +53,7 @@ public class DefaultReactiveRefreshEventListener
 
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	public CompletionStage<Void> reactiveOnRefresh(RefreshEvent event) throws HibernateException {
+	public InternalStage<Void> reactiveOnRefresh(RefreshEvent event) throws HibernateException {
 		return reactiveOnRefresh( event, RefreshContext.create() );
 	}
 
@@ -74,7 +73,7 @@ public class DefaultReactiveRefreshEventListener
 	 * @param event The refresh event to be handled.
 	 */
 	@Override
-	public CompletionStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready) {
+	public InternalStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready) {
 		final EventSource source = event.getSession();
 
 		boolean detached = event.getEntityName() != null
@@ -89,7 +88,7 @@ public class DefaultReactiveRefreshEventListener
 				.thenCompose( entity -> reactiveOnRefresh( event, refreshedAlready, entity ) );
 	}
 
-	private CompletionStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready, Object entity) {
+	private InternalStage<Void> reactiveOnRefresh(RefreshEvent event, RefreshContext refreshedAlready, Object entity) {
 		final EventSource source = event.getSession();
 		final PersistenceContext persistenceContext = source.getPersistenceContextInternal();
 
@@ -151,7 +150,7 @@ public class DefaultReactiveRefreshEventListener
 					evictEntity( entity, persister, id, source );
 					evictCachedCollections( persister, id, source );
 
-					final CompletableFuture<Void> refresh = new CompletableFuture<>();
+					final InternalStage<Void> refresh = InternalStage.newStage();
 					source.getLoadQueryInfluencers()
 							.fromInternalFetchProfile(
 									CascadingFetchProfile.REFRESH,
@@ -191,7 +190,7 @@ public class DefaultReactiveRefreshEventListener
 		}
 	}
 
-	private static CompletionStage<Void> doRefresh(
+	private static InternalStage<Void> doRefresh(
 			RefreshEvent event,
 			EventSource source,
 			Object entity,
@@ -263,7 +262,7 @@ public class DefaultReactiveRefreshEventListener
 				} );
 	}
 
-	private CompletionStage<Void> cascadeRefresh(
+	private InternalStage<Void> cascadeRefresh(
 			EventSource source,
 			EntityPersister persister,
 			Object object,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveResolveNaturalIdEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveResolveNaturalIdEventListener.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.event.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.engine.spi.NaturalIdResolutions;
@@ -40,7 +40,7 @@ public class DefaultReactiveResolveNaturalIdEventListener extends AbstractLockUp
 	}
 
 	@Override
-	public CompletionStage<Void> onReactiveResolveNaturalId(ResolveNaturalIdEvent event) throws HibernateException {
+	public InternalStage<Void> onReactiveResolveNaturalId(ResolveNaturalIdEvent event) throws HibernateException {
 		return resolveNaturalId( event ).thenAccept( event::setEntityId );
 	}
 
@@ -54,7 +54,7 @@ public class DefaultReactiveResolveNaturalIdEventListener extends AbstractLockUp
 	 *
 	 * @return The loaded entity, or null.
 	 */
-	protected CompletionStage<Object> resolveNaturalId(ResolveNaturalIdEvent event) {
+	protected InternalStage<Object> resolveNaturalId(ResolveNaturalIdEvent event) {
 		final EntityPersister persister = event.getEntityPersister();
 
 		if ( LOG.isTraceEnabled() ) {
@@ -106,7 +106,7 @@ public class DefaultReactiveResolveNaturalIdEventListener extends AbstractLockUp
 	 *
 	 * @return The object loaded from the datasource, or null if not found.
 	 */
-	protected CompletionStage<Object> loadFromDatasource(ResolveNaturalIdEvent event) {
+	protected InternalStage<Object> loadFromDatasource(ResolveNaturalIdEvent event) {
 		final EventSource session = event.getSession();
 		final EntityPersister entityPersister = event.getEntityPersister();
 		final StatisticsImplementor statistics = session.getFactory().getStatistics();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
@@ -1,2 +1,81 @@
-package org.hibernate.reactive.event.impl;public class ReactiveEventListenerGroupAdaptor {
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.event.impl;
+
+import java.lang.reflect.Array;
+import java.util.Iterator;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.reactive.event.ReactiveEventListenerGroup;
+
+public final class ReactiveEventListenerGroupAdaptor<T> implements ReactiveEventListenerGroup<T> {
+
+	private static final CompletableFuture COMPLETED = CompletableFuture.completedFuture( null );
+	private final T[] listeners;
+
+	public ReactiveEventListenerGroupAdaptor(EventListenerGroup<T> eventListenerGroup) {
+		int size = eventListenerGroup.count();
+		final Class type = eventListenerGroup.getEventType().baseListenerInterface();
+		this.listeners = (T[]) Array.newInstance( type, size );
+		final Iterator<T> listenersIterator = eventListenerGroup.listeners().iterator();//TBD: don't use the deprecated method
+		for ( int i = 0; i < size; i++ ) {
+			this.listeners[i] = listenersIterator.next();
+		}
+	}
+
+	@Override
+	public <R, U, RL> CompletionStage<R> fireEventOnEachListener(
+			final U event,
+			final Function<RL, Function<U, CompletionStage<R>>> fun) {
+		CompletionStage<R> ret = COMPLETED;
+		final T[] ls = listeners;
+		if ( ls != null && ls.length != 0 ) {
+			for ( T listener : ls ) {
+				//to preserve atomicity of the Session methods
+				//call apply() from within the arg of thenCompose()
+				ret = ret.thenCompose( v -> fun.apply( (RL) listener ).apply( event ) );
+			}
+		}
+		return ret;
+	}
+
+	@Override
+	public <R, U, RL, X> CompletionStage<R> fireEventOnEachListener(
+			U event, X param, Function<RL, BiFunction<U, X, CompletionStage<R>>> fun) {
+		CompletionStage<R> ret = COMPLETED;
+		final T[] ls = listeners;
+		if ( ls != null && ls.length != 0 ) {
+			for ( T listener : ls ) {
+				//to preserve atomicity of the Session methods
+				//call apply() from within the arg of thenCompose()
+				ret = ret.thenCompose( v -> fun.apply( (RL) listener ).apply( event, param ) );
+			}
+		}
+		return ret;
+	}
+
+	@Override
+	public <R, U, RL> CompletionStage<R> fireLazyEventOnEachListener(
+			final Supplier<U> eventSupplier,
+			final Function<RL, Function<U, CompletionStage<R>>> fun) {
+		CompletionStage<R> ret = COMPLETED;
+		final T[] ls = listeners;
+		if ( ls != null && ls.length != 0 ) {
+			final U event = eventSupplier.get();
+			for ( T listener : ls ) {
+				//to preserve atomicity of the Session methods
+				//call apply() from within the arg of thenCompose()
+				ret = ret.thenCompose( v -> fun.apply( (RL) listener ).apply( event ) );
+			}
+		}
+		return ret;
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
@@ -7,18 +7,17 @@ package org.hibernate.reactive.event.impl;
 
 import java.lang.reflect.Array;
 import java.util.Iterator;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
 import org.hibernate.event.service.spi.EventListenerGroup;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.reactive.event.ReactiveEventListenerGroup;
 
 public final class ReactiveEventListenerGroupAdaptor<T> implements ReactiveEventListenerGroup<T> {
 
-	private static final CompletableFuture COMPLETED = CompletableFuture.completedFuture( null );
+	private static final InternalStage COMPLETED = InternalStage.completedFuture( null );
 	private final T[] listeners;
 
 	public ReactiveEventListenerGroupAdaptor(EventListenerGroup<T> eventListenerGroup) {
@@ -32,10 +31,10 @@ public final class ReactiveEventListenerGroupAdaptor<T> implements ReactiveEvent
 	}
 
 	@Override
-	public <R, U, RL> CompletionStage<R> fireEventOnEachListener(
+	public <R, U, RL> InternalStage<R> fireEventOnEachListener(
 			final U event,
-			final Function<RL, Function<U, CompletionStage<R>>> fun) {
-		CompletionStage<R> ret = COMPLETED;
+			final Function<RL, Function<U, InternalStage<R>>> fun) {
+		InternalStage<R> ret = COMPLETED;
 		final T[] ls = listeners;
 		if ( ls != null && ls.length != 0 ) {
 			for ( T listener : ls ) {
@@ -48,9 +47,9 @@ public final class ReactiveEventListenerGroupAdaptor<T> implements ReactiveEvent
 	}
 
 	@Override
-	public <R, U, RL, X> CompletionStage<R> fireEventOnEachListener(
-			U event, X param, Function<RL, BiFunction<U, X, CompletionStage<R>>> fun) {
-		CompletionStage<R> ret = COMPLETED;
+	public <R, U, RL, X> InternalStage<R> fireEventOnEachListener(
+			U event, X param, Function<RL, BiFunction<U, X, InternalStage<R>>> fun) {
+		InternalStage<R> ret = COMPLETED;
 		final T[] ls = listeners;
 		if ( ls != null && ls.length != 0 ) {
 			for ( T listener : ls ) {
@@ -63,10 +62,10 @@ public final class ReactiveEventListenerGroupAdaptor<T> implements ReactiveEvent
 	}
 
 	@Override
-	public <R, U, RL> CompletionStage<R> fireLazyEventOnEachListener(
+	public <R, U, RL> InternalStage<R> fireLazyEventOnEachListener(
 			final Supplier<U> eventSupplier,
-			final Function<RL, Function<U, CompletionStage<R>>> fun) {
-		CompletionStage<R> ret = COMPLETED;
+			final Function<RL, Function<U, InternalStage<R>>> fun) {
+		InternalStage<R> ret = COMPLETED;
 		final T[] ls = listeners;
 		if ( ls != null && ls.length != 0 ) {
 			final U event = eventSupplier.get();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/ReactiveEventListenerGroupAdaptor.java
@@ -1,0 +1,2 @@
+package org.hibernate.reactive.event.impl;public class ReactiveEventListenerGroupAdaptor {
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/ReactiveIdentifierGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/ReactiveIdentifierGenerator.java
@@ -9,7 +9,7 @@ import org.hibernate.Incubating;
 import org.hibernate.id.IdentifierGenerator;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * A replacement for {@link org.hibernate.id.IdentifierGenerator},
@@ -31,5 +31,5 @@ public interface ReactiveIdentifierGenerator<Id> {
 	 *
 	 * @param session the reactive session
 	 */
-	CompletionStage<Id> generate(ReactiveConnectionSupplier session, Object entity);
+	InternalStage<Id> generate(ReactiveConnectionSupplier session, Object entity);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/enhanced/ReactiveAccessCallback.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/enhanced/ReactiveAccessCallback.java
@@ -5,11 +5,11 @@
  */
 package org.hibernate.reactive.id.enhanced;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.id.IntegralDataTypeHolder;
 import org.hibernate.id.enhanced.AccessCallback;
 
 public interface ReactiveAccessCallback extends AccessCallback {
-	CompletionStage<IntegralDataTypeHolder> getNextReactiveValue();
+	InternalStage<IntegralDataTypeHolder> getNextReactiveValue();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/ReactiveGeneratorWrapper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/ReactiveGeneratorWrapper.java
@@ -14,7 +14,7 @@ import org.hibernate.reactive.id.ReactiveIdentifierGenerator;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * @author Gavin King
@@ -45,7 +45,7 @@ public class ReactiveGeneratorWrapper
 	}
 
 	@Override
-	public CompletionStage<Object> generate(ReactiveConnectionSupplier session, Object entity) {
+	public InternalStage<Object> generate(ReactiveConnectionSupplier session, Object entity) {
 		return reactiveGenerator.generate( session, entity ).thenApply( id -> id );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/ReactiveSequenceIdentifierGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/ReactiveSequenceIdentifierGenerator.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.id.impl;
 
 import java.util.Properties;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.boot.model.naming.Identifier;
@@ -57,7 +57,7 @@ public class ReactiveSequenceIdentifierGenerator extends BlockingIdentifierGener
 	}
 
 	@Override
-	protected CompletionStage<Long> nextHiValue(ReactiveConnectionSupplier session) {
+	protected InternalStage<Long> nextHiValue(ReactiveConnectionSupplier session) {
 		return session.getReactiveConnection()
 				.selectIdentifier( sql, NO_PARAMS, Long.class );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/TableReactiveIdentifierGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/impl/TableReactiveIdentifierGenerator.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.id.impl;
 
 import java.util.Collections;
 import java.util.Properties;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;
@@ -71,7 +71,7 @@ public class TableReactiveIdentifierGenerator extends BlockingIdentifierGenerato
 	}
 
 	@Override
-	protected CompletionStage<Long> nextHiValue(ReactiveConnectionSupplier session) {
+	protected InternalStage<Long> nextHiValue(ReactiveConnectionSupplier session) {
 
 		// We need to read the current hi value from the table
 		// and update it by the specified increment, but we

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveAbstractReturningDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveAbstractReturningDelegate.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.id.insert;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.CockroachDialect;
 import org.hibernate.dialect.DB2Dialect;
@@ -35,7 +35,7 @@ public interface ReactiveAbstractReturningDelegate extends ReactiveInsertGenerat
 	PostInsertIdentityPersister getPersister();
 
 	@Override
-	default CompletionStage<Object> reactivePerformInsert(PreparedStatementDetails insertStatementDetails, JdbcValueBindings jdbcValueBindings, Object entity, SharedSessionContractImplementor session) {
+	default InternalStage<Object> reactivePerformInsert(PreparedStatementDetails insertStatementDetails, JdbcValueBindings jdbcValueBindings, Object entity, SharedSessionContractImplementor session) {
 		final Class<?> idType = getPersister().getIdentifierType().getReturnedClass();
 		final JdbcServices jdbcServices = session.getJdbcServices();
 		final String identifierColumnName = getPersister().getIdentifierColumnNames()[0];
@@ -121,7 +121,7 @@ public interface ReactiveAbstractReturningDelegate extends ReactiveInsertGenerat
 	}
 
 	@Override
-	default CompletionStage<Object> reactivePerformInsert(String insertSQL, SharedSessionContractImplementor session, Binder binder) {
+	default InternalStage<Object> reactivePerformInsert(String insertSQL, SharedSessionContractImplementor session, Binder binder) {
 		throw LOG.notYetImplemented();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveAbstractSelectingDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveAbstractSelectingDelegate.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.id.insert;
 import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
@@ -38,7 +38,7 @@ public interface ReactiveAbstractSelectingDelegate extends ReactiveInsertGenerat
 	Object extractGeneratedValue(ResultSet resultSet, SharedSessionContractImplementor session);
 
 	@Override
-	default CompletionStage<Object> reactivePerformInsert(
+	default InternalStage<Object> reactivePerformInsert(
 			PreparedStatementDetails insertStatementDetails,
 			JdbcValueBindings jdbcValueBindings,
 			Object entity,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveBasicSelectingDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveBasicSelectingDelegate.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.id.insert;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -23,7 +23,7 @@ public class ReactiveBasicSelectingDelegate extends BasicSelectingDelegate imple
 	}
 
 	@Override
-	public CompletionStage<Object> reactivePerformInsert(
+	public InternalStage<Object> reactivePerformInsert(
 			String insertSQL,
 			SharedSessionContractImplementor session,
 			Binder binder) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveInsertGeneratedIdentifierDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveInsertGeneratedIdentifierDelegate.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.id.insert;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
@@ -17,11 +17,11 @@ import org.hibernate.id.insert.Binder;
  */
 public interface ReactiveInsertGeneratedIdentifierDelegate {
 
-	CompletionStage<Object> reactivePerformInsert(
+	InternalStage<Object> reactivePerformInsert(
 			PreparedStatementDetails insertStatementDetails,
 			JdbcValueBindings valueBindings,
 			Object entity,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactivePerformInsert(String insertSQL, SharedSessionContractImplementor session, Binder binder);
+	InternalStage<Object> reactivePerformInsert(String insertSQL, SharedSessionContractImplementor session, Binder binder);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveInsertReturningDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/id/insert/ReactiveInsertReturningDelegate.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.id.insert;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -25,7 +25,7 @@ public class ReactiveInsertReturningDelegate extends InsertReturningDelegate imp
 	}
 
 	@Override
-	public CompletionStage<Object> reactivePerformInsert(
+	public InternalStage<Object> reactivePerformInsert(
 			String insertSQL,
 			SharedSessionContractImplementor session,
 			Binder binder) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/DatabaseSnapshotExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/DatabaseSnapshotExecutor.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
@@ -162,7 +162,7 @@ class DatabaseSnapshotExecutor {
 		return ImmutableFetchList.EMPTY;
 	}
 
-	CompletionStage<Object[]> loadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
+	InternalStage<Object[]> loadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
 		if ( log.isTraceEnabled() ) {
 			log.tracef( "Getting current persistent state for `%s#%s`", entityDescriptor.getEntityName(), id );
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveAbstractMultiIdEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveAbstractMultiIdEntityLoader.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
@@ -55,7 +55,7 @@ public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements Reactive
 	}
 
 	@Override
-	public final <K> CompletionStage<List<T>> load(K[] ids, MultiIdLoadOptions loadOptions, EventSource session) {
+	public final <K> InternalStage<List<T>> load(K[] ids, MultiIdLoadOptions loadOptions, EventSource session) {
 		Objects.requireNonNull( ids );
 
 		return loadOptions.isOrderReturnEnabled()
@@ -63,8 +63,8 @@ public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements Reactive
 				: performUnorderedMultiLoad( ids, loadOptions, session );
 	}
 
-	protected abstract <K> CompletionStage<List<T>> performOrderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
+	protected abstract <K> InternalStage<List<T>> performOrderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
 
-	protected abstract <K> CompletionStage<List<T>> performUnorderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
+	protected abstract <K> InternalStage<List<T>> performUnorderedMultiLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderArrayParam.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.reflect.Array;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -99,7 +99,7 @@ public class ReactiveCollectionBatchLoaderArrayParam extends ReactiveAbstractCol
 	}
 
 	@Override
-	public CompletionStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
 		if ( MULTI_KEY_LOAD_DEBUG_ENABLED ) {
 			MULTI_KEY_LOAD_LOGGER.debugf(
 					"Batch loading entity `%s#%s`",
@@ -134,7 +134,7 @@ public class ReactiveCollectionBatchLoaderArrayParam extends ReactiveAbstractCol
 		return keysToInitialize;
 	}
 
-	private CompletionStage<Void> initializeKeys(Object[] keysToInitialize, SharedSessionContractImplementor session) {
+	private InternalStage<Void> initializeKeys(Object[] keysToInitialize, SharedSessionContractImplementor session) {
 		assert jdbcSelectOperation != null;
 		assert jdbcParameter != null;
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderInPredicate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionBatchLoaderInPredicate.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.ArrayList;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -89,7 +89,7 @@ public class ReactiveCollectionBatchLoaderInPredicate extends ReactiveAbstractCo
 	}
 
 	@Override
-	public CompletionStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
 		if ( MULTI_KEY_LOAD_DEBUG_ENABLED ) {
 			MULTI_KEY_LOAD_LOGGER.debugf(
 					"Loading collection `%s#%s` by batch-fetch",
@@ -134,7 +134,7 @@ public class ReactiveCollectionBatchLoaderInPredicate extends ReactiveAbstractCo
 		}
 	}
 
-	private <T> CompletionStage<Void> initializeKeys(
+	private <T> InternalStage<Void> initializeKeys(
 			T key,
 			T[] keysToInitialize,
 			int nonNullKeysToInitializeCount,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoader.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -29,5 +29,5 @@ public interface ReactiveCollectionLoader extends CollectionLoader {
 	/**
 	 * Load a collection by its key (not necessarily the same as its owner's PK).
 	 */
-	CompletionStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session);
+	InternalStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderNamedQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderNamedQuery.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -22,7 +22,7 @@ public class ReactiveCollectionLoaderNamedQuery implements ReactiveCollectionLoa
 	}
 
 	@Override
-	public CompletionStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
 		throw new UnsupportedOperationException();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSingleKey.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSingleKey.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -84,7 +84,7 @@ public class ReactiveCollectionLoaderSingleKey implements ReactiveCollectionLoad
 	}
 
 	@Override
-	public CompletionStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<PersistentCollection<?>> reactiveLoad(Object key, SharedSessionContractImplementor session) {
 		final CollectionKey collectionKey = new CollectionKey( attributeMapping.getCollectionDescriptor(), key );
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 		final JdbcServices jdbcServices = sessionFactory.getJdbcServices();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSubSelectFetch.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderSubSelectFetch.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
@@ -44,7 +44,7 @@ public class ReactiveCollectionLoaderSubSelectFetch extends CollectionLoaderSubS
 	}
 
 	@Override
-	public CompletionStage<PersistentCollection<?>> reactiveLoad(Object triggerKey, SharedSessionContractImplementor session) {
+	public InternalStage<PersistentCollection<?>> reactiveLoad(Object triggerKey, SharedSessionContractImplementor session) {
 		final CollectionKey collectionKey = new CollectionKey( attributeMapping.getCollectionDescriptor(), triggerKey );
 
 		final SessionFactoryImplementor sessionFactory = session.getFactory();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCompoundNaturalIdLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCompoundNaturalIdLoader.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -18,7 +18,7 @@ import org.hibernate.metamodel.mapping.internal.CompoundNaturalIdMapping;
 import org.hibernate.reactive.loader.ast.spi.ReactiveNaturalIdLoader;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 
-public class ReactiveCompoundNaturalIdLoader<T> extends CompoundNaturalIdLoader<CompletionStage<T>> implements ReactiveNaturalIdLoader<T> {
+public class ReactiveCompoundNaturalIdLoader<T> extends CompoundNaturalIdLoader<InternalStage<T>> implements ReactiveNaturalIdLoader<T> {
 
 	private final ReactiveNaturalIdLoaderDelegate<T> delegate;
 
@@ -48,19 +48,19 @@ public class ReactiveCompoundNaturalIdLoader<T> extends CompoundNaturalIdLoader<
 	}
 
 	@Override
-	public CompletionStage<Object> resolveNaturalIdToId(
+	public InternalStage<Object> resolveNaturalIdToId(
 			Object naturalIdValue,
 			SharedSessionContractImplementor session) {
 		return delegate.resolveNaturalIdToId( naturalIdValue, session );
 	}
 
 	@Override
-	public CompletionStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
 		return delegate.resolveIdToNaturalId( id, session );
 	}
 
 	@Override
-	public CompletionStage<T> load(
+	public InternalStage<T> load(
 			Object naturalIdValue,
 			NaturalIdLoadOptions options,
 			SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderArrayParam.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.reflect.Array;
 import java.util.Locale;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.internal.BatchFetchQueueHelper;
@@ -41,7 +41,7 @@ import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LO
  * @see EntityBatchLoaderArrayParam
  */
 public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEntityLoaderSupport<T>
-		implements EntityBatchLoader<CompletionStage<T>>, ReactiveSingleIdEntityLoader<T>, SqlArrayMultiKeyLoader, Preparable {
+		implements EntityBatchLoader<InternalStage<T>>, ReactiveSingleIdEntityLoader<T>, SqlArrayMultiKeyLoader, Preparable {
 
 	private final int domainBatchSize;
 
@@ -73,12 +73,12 @@ public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEnti
 	}
 
 	@Override
-	public CompletionStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	public InternalStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		return load( pkValue, null, lockOptions, readOnly, session );
 	}
 
 	@Override
-	public final CompletionStage<T> load(
+	public final InternalStage<T> load(
 			Object pkValue,
 			Object entityInstance,
 			LockOptions lockOptions,
@@ -111,7 +111,7 @@ public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEnti
 		return idsToLoad;
 	}
 
-	private CompletionStage<Void> initializeEntities(
+	private InternalStage<Void> initializeEntities(
 			Object[] idsToInitialize,
 			Object pkValue,
 			Object entityInstance,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderInPredicate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderInPredicate.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.loader.ast.internal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.BatchFetchQueue;
@@ -37,7 +37,7 @@ import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LO
  * @see org.hibernate.loader.ast.internal.EntityBatchLoaderInPredicate
  */
 public class ReactiveEntityBatchLoaderInPredicate<T> extends ReactiveSingleIdEntityLoaderSupport<T>
-		implements EntityBatchLoader<CompletionStage<T>>, SqlInPredicateMultiKeyLoader, Preparable {
+		implements EntityBatchLoader<InternalStage<T>>, SqlInPredicateMultiKeyLoader, Preparable {
 
 	private final int domainBatchSize;
 	private final int sqlBatchSize;
@@ -75,12 +75,12 @@ public class ReactiveEntityBatchLoaderInPredicate<T> extends ReactiveSingleIdEnt
 	}
 
 	@Override
-	public final CompletionStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	public final InternalStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		return load( pkValue, null, lockOptions, readOnly, session );
 	}
 
 	@Override
-	public final CompletionStage<T> load(
+	public final InternalStage<T> load(
 			Object pkValue,
 			Object entityInstance,
 			LockOptions lockOptions,
@@ -116,7 +116,7 @@ public class ReactiveEntityBatchLoaderInPredicate<T> extends ReactiveSingleIdEnt
 		);
 	}
 
-	protected CompletionStage<Void> initializeEntities(
+	protected InternalStage<Void> initializeEntities(
 			Object[] idsToInitialize,
 			Object pkValue,
 			Object entityInstance,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveLoaderHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveLoaderHelper.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.loader.ast.internal;
 
 import java.lang.reflect.Array;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -50,7 +50,7 @@ public class ReactiveLoaderHelper {
 	 * @param <R> The type of the model part to load
 	 * @param <K> The type of the keys
 	 */
-	public static <R, K> CompletionStage<List<R>> loadByArrayParameter(
+	public static <R, K> InternalStage<List<R>> loadByArrayParameter(
 			K[] idsToInitialize,
 			SelectStatement sqlAst,
 			JdbcOperationQuerySelect jdbcOperation,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
@@ -9,7 +9,7 @@ import java.lang.reflect.Array;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -75,7 +75,7 @@ public class ReactiveMultiIdEntityLoaderArrayParam<E> extends ReactiveAbstractMu
 	}
 
 	@Override
-	protected <K> CompletionStage<List<E>> performOrderedMultiLoad(
+	protected <K> InternalStage<List<E>> performOrderedMultiLoad(
 			K[] ids,
 			MultiIdLoadOptions loadOptions,
 			EventSource session) {
@@ -232,7 +232,7 @@ public class ReactiveMultiIdEntityLoaderArrayParam<E> extends ReactiveAbstractMu
 	}
 
 	@Override
-	protected <K> CompletionStage<List<E>> performUnorderedMultiLoad(
+	protected <K> InternalStage<List<E>> performUnorderedMultiLoad(
 			K[] ids,
 			MultiIdLoadOptions loadOptions,
 			EventSource session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderStandard.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -74,7 +74,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 	}
 
 	@Override
-	protected CompletionStage<List<T>> performOrderedMultiLoad(
+	protected InternalStage<List<T>> performOrderedMultiLoad(
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
 			EventSource session) {
@@ -159,7 +159,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 			// load the entity state.
 			idsInBatch.add( id );
 
-			CompletionStage<Void> loopResult = voidFuture();
+			InternalStage<Void> loopResult = voidFuture();
 			if ( idsInBatch.size() >= maxBatchSize ) {
 				// we've hit the allotted max-batch-size, perform an "intermediate load"
 				loopResult = loadEntitiesById( idsInBatch, lockOptions, session )
@@ -205,7 +205,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 		} );
 	}
 
-	private CompletionStage<List<T>> loadEntitiesById(
+	private InternalStage<List<T>> loadEntitiesById(
 			List<Object> idsInBatch,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session) {
@@ -283,7 +283,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 		);
 	}
 
-	private CompletionStage<List<T>> performSingleMultiLoad(
+	private InternalStage<List<T>> performSingleMultiLoad(
 			Object id,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session) {
@@ -297,7 +297,7 @@ public class ReactiveMultiIdEntityLoaderStandard<T> extends ReactiveAbstractMult
 	}
 
 	@Override
-	protected CompletionStage<List<T>> performUnorderedMultiLoad(
+	protected InternalStage<List<T>> performUnorderedMultiLoad(
 			Object[] ids,
 			MultiIdLoadOptions loadOptions,
 			EventSource session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiKeyLoadChunker.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiKeyLoadChunker.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.Bindable;
@@ -81,7 +81,7 @@ public class ReactiveMultiKeyLoadChunker<K> {
 	 * @param keyCollector Called for each key as it is processed
 	 * @param boundaryListener Notifications that processing a chunk has completed
 	 */
-	public CompletionStage<Void> processChunks(
+	public InternalStage<Void> processChunks(
 			K[] keys,
 			int nonNullElementCount,
 			ReactiveMultiKeyLoadChunker.SqlExecutionContextCreator sqlExecutionContextCreator,
@@ -111,7 +111,7 @@ public class ReactiveMultiKeyLoadChunker<K> {
 		return voidFuture();
 	}
 
-	private CompletionStage<Void> processChunk(
+	private InternalStage<Void> processChunk(
 			K[] keys,
 			int startIndex,
 			ReactiveMultiKeyLoadChunker.SqlExecutionContextCreator sqlExecutionContextCreator,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Function;
@@ -61,7 +61,7 @@ import static java.util.Collections.singletonList;
  * </p>
  * @param <T>
  */
-public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNaturalIdLoader<CompletionStage<T>> implements ReactiveNaturalIdLoader<T> {
+public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNaturalIdLoader<InternalStage<T>> implements ReactiveNaturalIdLoader<T> {
 
     public ReactiveNaturalIdLoaderDelegate(
             NaturalIdMapping naturalIdMapping,
@@ -70,7 +70,7 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
     }
 
     @Override
-    public CompletionStage<T> load(
+    public InternalStage<T> load(
             Object naturalIdValue,
             NaturalIdLoadOptions options,
             SharedSessionContractImplementor session) {
@@ -111,7 +111,7 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
     }
 
     @Override
-    public CompletionStage<Object> resolveNaturalIdToId(
+    public InternalStage<Object> resolveNaturalIdToId(
             Object naturalIdValue,
             SharedSessionContractImplementor session) {
         return reactiveSelectByNaturalId(
@@ -143,7 +143,7 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
     }
 
     @Override
-    public CompletionStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
+    public InternalStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
         final SessionFactoryImplementor sessionFactory = session.getFactory();
 
         final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
@@ -211,7 +211,7 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
     /**
      * @see AbstractNaturalIdLoader#selectByNaturalId(Object, NaturalIdLoadOptions, BiFunction, LoaderSqlAstCreationState.FetchProcessor, Function, BiConsumer, SharedSessionContractImplementor)
      */
-    public CompletionStage<Object> reactiveSelectByNaturalId(
+    public InternalStage<Object> reactiveSelectByNaturalId(
             Object bindValue,
             NaturalIdLoadOptions options,
             BiFunction<TableGroup, LoaderSqlAstCreationState, DomainResult<?>> domainResultProducer,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSimpleNaturalIdLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSimpleNaturalIdLoader.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -18,7 +18,7 @@ import org.hibernate.metamodel.mapping.internal.SimpleNaturalIdMapping;
 import org.hibernate.reactive.loader.ast.spi.ReactiveNaturalIdLoader;
 import org.hibernate.sql.ast.tree.from.TableGroup;
 
-public class ReactiveSimpleNaturalIdLoader<T> extends SimpleNaturalIdLoader<CompletionStage<T>>
+public class ReactiveSimpleNaturalIdLoader<T> extends SimpleNaturalIdLoader<InternalStage<T>>
 		implements ReactiveNaturalIdLoader<T> {
 
 	private final ReactiveNaturalIdLoaderDelegate<T> delegate;
@@ -51,19 +51,19 @@ public class ReactiveSimpleNaturalIdLoader<T> extends SimpleNaturalIdLoader<Comp
 	 * @see org.hibernate.loader.ast.internal.AbstractNaturalIdLoader#resolveIdToNaturalId(Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session) {
 		return delegate.resolveIdToNaturalId( id, session );
 	}
 
 	@Override
-	public CompletionStage<Object> resolveNaturalIdToId(
+	public InternalStage<Object> resolveNaturalIdToId(
 			Object naturalIdValue,
 			SharedSessionContractImplementor session) {
 		return delegate.resolveNaturalIdToId( naturalIdValue, session );
 	}
 
 	@Override
-	public CompletionStage<T> load(
+	public InternalStage<T> load(
 			Object naturalIdValue,
 			NaturalIdLoadOptions options,
 			SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdArrayLoadPlan.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -30,7 +30,7 @@ public class ReactiveSingleIdArrayLoadPlan extends ReactiveSingleIdLoadPlan<Obje
 	}
 
 	@Override
-	protected RowTransformer<CompletionStage<Object[]>> getRowTransformer() {
+	protected RowTransformer<InternalStage<Object[]>> getRowTransformer() {
 		return RowTransformerDatabaseSnapshotImpl.instance();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderProvidedQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderProvidedQueryImpl.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FlushMode;
 import org.hibernate.LockOptions;
@@ -27,7 +27,7 @@ import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
  */
 public class ReactiveSingleIdEntityLoaderProvidedQueryImpl<T> implements ReactiveSingleIdEntityLoader<T> {
 
-	private static final CompletionStage<Object[]> EMPTY_ARRAY_STAGE = completedFuture( ArrayHelper.EMPTY_OBJECT_ARRAY );
+	private static final InternalStage<Object[]> EMPTY_ARRAY_STAGE = completedFuture( ArrayHelper.EMPTY_OBJECT_ARRAY );
 
 	private final EntityMappingType entityDescriptor;
 	private final NamedQueryMemento namedQueryMemento;
@@ -43,7 +43,7 @@ public class ReactiveSingleIdEntityLoaderProvidedQueryImpl<T> implements Reactiv
 	}
 
 	@Override
-	public CompletionStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	public InternalStage<T> load(Object pkValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		// noinspection unchecked
 		final QueryImplementor<T> query = namedQueryMemento
 				.toQuery( session, (Class<T>) entityDescriptor.getMappedJavaType().getJavaTypeClass() );
@@ -56,7 +56,7 @@ public class ReactiveSingleIdEntityLoaderProvidedQueryImpl<T> implements Reactiv
 	}
 
 	@Override
-	public CompletionStage<T> load(
+	public InternalStage<T> load(
 			Object pkValue,
 			Object entityInstance,
 			LockOptions lockOptions,
@@ -69,7 +69,7 @@ public class ReactiveSingleIdEntityLoaderProvidedQueryImpl<T> implements Reactiv
 	}
 
 	@Override
-	public CompletionStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
 		return EMPTY_ARRAY_STAGE;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.EnumMap;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.Internal;
@@ -29,7 +29,7 @@ import org.hibernate.sql.exec.spi.JdbcParametersList;
  *
  * @see SingleIdEntityLoaderStandardImpl
  */
-public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderStandardImpl<CompletionStage<T>> implements ReactiveSingleIdEntityLoader<T> {
+public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderStandardImpl<InternalStage<T>> implements ReactiveSingleIdEntityLoader<T> {
 
 	private EnumMap<LockMode, ReactiveSingleIdLoadPlan> selectByLockMode = new EnumMap<>( LockMode.class );
 	private EnumMap<CascadingFetchProfile, ReactiveSingleIdLoadPlan> selectByInternalCascadeProfile;
@@ -59,7 +59,7 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 	}
 
 	@Override
-	public CompletionStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
 		if ( databaseSnapshotExecutor == null ) {
 			databaseSnapshotExecutor = new DatabaseSnapshotExecutor( entityDescriptor, sessionFactory );
 		}
@@ -101,13 +101,13 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 	}
 
 	@Override
-	public CompletionStage<T> load(Object key, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	public InternalStage<T> load(Object key, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		final ReactiveSingleIdLoadPlan<T> loadPlan = resolveLoadPlan( lockOptions, session.getLoadQueryInfluencers(), session.getFactory() );
 		return loadPlan.load( key, readOnly, true, session );
 	}
 
 	@Override
-	public CompletionStage<T> load(
+	public InternalStage<T> load(
 			Object key,
 			Object entityInstance,
 			LockOptions lockOptions,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderSupport.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderSupport.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -32,7 +32,7 @@ public abstract class ReactiveSingleIdEntityLoaderSupport<T> implements Reactive
 	}
 
 	@Override
-	public CompletionStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
 		if ( databaseSnapshotExecutor == null ) {
 			databaseSnapshotExecutor = new DatabaseSnapshotExecutor( entityDescriptor, sessionFactory );
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.CollectionKey;
@@ -32,7 +32,7 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.graph.entity.LoadingEntityEntry;
 
-public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<CompletionStage<T>> {
+public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<InternalStage<T>> {
 
 	public ReactiveSingleIdLoadPlan(
 			Loadable persister,
@@ -45,7 +45,7 @@ public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<CompletionStag
 	}
 
 	@Override
-	public CompletionStage<T> load(Object restrictedValue, Object entityInstance, Boolean readOnly, Boolean singleResultExpected, SharedSessionContractImplementor session) {
+	public InternalStage<T> load(Object restrictedValue, Object entityInstance, Boolean readOnly, Boolean singleResultExpected, SharedSessionContractImplementor session) {
 		final int jdbcTypeCount = getRestrictivePart().getJdbcTypeCount();
 		assert getJdbcParameters().size() % jdbcTypeCount == 0;
 		final JdbcParameterBindings jdbcParameterBindings = new JdbcParameterBindingsImpl( jdbcTypeCount );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleUniqueKeyEntityLoaderStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleUniqueKeyEntityLoaderStandard.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.loader.ast.internal;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
@@ -65,7 +65,7 @@ public class ReactiveSingleUniqueKeyEntityLoaderStandard<T> implements ReactiveS
 	}
 
 	@Override
-	public CompletionStage<T> load(Object ukValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	public InternalStage<T> load(Object ukValue, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		final SessionFactoryImplementor sessionFactory = session.getFactory();
 
 		// todo (6.0) : cache the SQL AST and JdbcParameters

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveMultiIdEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveMultiIdEntityLoader.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.loader.ast.spi;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.loader.ast.spi.EntityMultiLoader;
@@ -15,7 +15,7 @@ import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 /**
  * @see org.hibernate.loader.ast.spi.MultiIdEntityLoader
  */
-public interface ReactiveMultiIdEntityLoader<T> extends EntityMultiLoader<CompletionStage<T>> {
+public interface ReactiveMultiIdEntityLoader<T> extends EntityMultiLoader<InternalStage<T>> {
 
-	<K> CompletionStage<List<T>> load(K[] ids, MultiIdLoadOptions options, EventSource session);
+	<K> InternalStage<List<T>> load(K[] ids, MultiIdLoadOptions options, EventSource session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveNaturalIdLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveNaturalIdLoader.java
@@ -5,16 +5,16 @@
  */
 package org.hibernate.reactive.loader.ast.spi;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.NaturalIdLoader;
 
-public interface ReactiveNaturalIdLoader<T> extends NaturalIdLoader<CompletionStage<T>> {
+public interface ReactiveNaturalIdLoader<T> extends NaturalIdLoader<InternalStage<T>> {
 
     @Override
-    CompletionStage<Object> resolveNaturalIdToId(Object naturalIdValue, SharedSessionContractImplementor session);
+    InternalStage<Object> resolveNaturalIdToId(Object naturalIdValue, SharedSessionContractImplementor session);
 
     @Override
-    CompletionStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session);
+    InternalStage<Object> resolveIdToNaturalId(Object id, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveSingleIdEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveSingleIdEntityLoader.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.spi;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.SingleIdEntityLoader;
@@ -18,7 +18,7 @@ import static org.hibernate.reactive.logging.impl.LoggerFactory.make;
  * Reactive version of {@link SingleIdEntityLoader}.
  * @param <T> the entity class
  */
-public interface ReactiveSingleIdEntityLoader<T> extends SingleIdEntityLoader<CompletionStage<T>> {
+public interface ReactiveSingleIdEntityLoader<T> extends SingleIdEntityLoader<InternalStage<T>> {
 
 	/**
 	 * @deprecated use {@link #reactiveLoadDatabaseSnapshot(Object, SharedSessionContractImplementor)}
@@ -29,5 +29,5 @@ public interface ReactiveSingleIdEntityLoader<T> extends SingleIdEntityLoader<Co
 		throw make( Log.class, lookup() ).nonReactiveMethodCall( "reactiveLoadDatabaseSnapshot" );
 	}
 
-	CompletionStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session);
+	InternalStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveSingleUniqueKeyEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveSingleUniqueKeyEntityLoader.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.loader.ast.spi;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.spi.SingleEntityLoader;
@@ -14,7 +14,7 @@ import org.hibernate.loader.ast.spi.SingleEntityLoader;
  * Reactive loader subtype for loading an entity by a single unique-key value.
  * @see org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader
  */
-public interface ReactiveSingleUniqueKeyEntityLoader<T> extends SingleEntityLoader<CompletionStage<T>> {
+public interface ReactiveSingleUniqueKeyEntityLoader<T> extends SingleEntityLoader<InternalStage<T>> {
 
 	/**
 	 * Resolve the matching id

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
@@ -10,7 +10,7 @@ import jakarta.persistence.Parameter;
 import org.hibernate.reactive.mutiny.Mutiny.MutationQuery;
 import org.hibernate.reactive.query.ReactiveQuery;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Supplier;
 
 public class MutinyMutationQueryImpl<R> implements MutationQuery {
@@ -23,7 +23,7 @@ public class MutinyMutationQueryImpl<R> implements MutationQuery {
 		this.factory = factory;
 	}
 
-	private <T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	private <T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return factory.uni( stageSupplier );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -21,7 +21,7 @@ import org.hibernate.reactive.mutiny.Mutiny.Query;
 import org.hibernate.reactive.query.ReactiveQuery;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Supplier;
 
 public class MutinyQueryImpl<R> implements Query<R> {
@@ -34,7 +34,7 @@ public class MutinyQueryImpl<R> implements Query<R> {
 		this.factory = factory;
 	}
 
-	private <T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	private <T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return factory.uni( stageSupplier );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
@@ -21,7 +21,7 @@ import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
 import org.hibernate.reactive.query.ReactiveQuery;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Supplier;
 
 public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
@@ -33,7 +33,7 @@ public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 		this.factory = factory;
 	}
 
-	private <T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	private <T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return factory.uni( stageSupplier );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionFactoryImpl.java
@@ -28,7 +28,7 @@ import org.hibernate.stat.Statistics;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -68,7 +68,7 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory, Implemen
 		this.extensions = new ReactiveSessionFactoryExtensions( delegate );
 	}
 
-	<T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	<T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return Uni.createFrom().completionStage( stageSupplier ).runSubscriptionOn( context );
 	}
 
@@ -138,7 +138,7 @@ public class MutinySessionFactoryImpl implements Mutiny.SessionFactory, Implemen
 				.tenantIdentifier( tenantIdentifier );
 	}
 
-	private CompletionStage<ReactiveConnection> connection(String tenantId) {
+	private InternalStage<ReactiveConnection> connection(String tenantId) {
 		assertUseOnEventLoop();
 		return tenantId == null
 				? connectionPool.getConnection()

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -40,7 +40,7 @@ import org.hibernate.reactive.session.ReactiveSession;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -64,7 +64,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 		this.factory = factory;
 	}
 
-	<T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	<T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return factory.uni( stageSupplier );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.session.ReactiveStatelessSession;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
@@ -43,7 +43,7 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 	}
 
 
-	<T> Uni<T> uni(Supplier<CompletionStage<T>> stageSupplier) {
+	<T> Uni<T> uni(Supplier<InternalStage<T>> stageSupplier) {
 		return factory.uni( stageSupplier );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveAbstractCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveAbstractCollectionPersister.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
@@ -44,30 +44,30 @@ public interface ReactiveAbstractCollectionPersister extends ReactiveCollectionP
     /**
      * @see org.hibernate.persister.collection.AbstractCollectionPersister#recreate(PersistentCollection, Object, SharedSessionContractImplementor)
      */
-    CompletionStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+    InternalStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
     /**
      * @see org.hibernate.persister.collection.AbstractCollectionPersister#remove(Object, SharedSessionContractImplementor)
      */
-    CompletionStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session);
+    InternalStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session);
 
     /**
      * @see org.hibernate.persister.collection.AbstractCollectionPersister#deleteRows(PersistentCollection, Object, SharedSessionContractImplementor)
      */
     @Override
-    CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+    InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
     /**
      * @see org.hibernate.persister.collection.AbstractCollectionPersister#insertRows(PersistentCollection, Object, SharedSessionContractImplementor)
      */
     @Override
-    CompletionStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+    InternalStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
     /**
      * @see org.hibernate.persister.collection.AbstractCollectionPersister#updateRows(PersistentCollection, Object, SharedSessionContractImplementor)
      */
     @Override
-    CompletionStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+    InternalStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
     boolean isRowDeleteEnabled();
     boolean isRowInsertEnabled();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.MappingException;
 import org.hibernate.cache.CacheException;
@@ -139,7 +139,7 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session) {
 		return ( (ReactiveCollectionLoader) determineLoaderToUse( key, session ) )
 				.reactiveLoad( key, session )
 				.thenCompose( CompletionStages::voidFuture );
@@ -149,7 +149,7 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	 * @see org.hibernate.persister.collection.BasicCollectionPersister#remove(Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session) {
 		return getRemoveCoordinator().reactiveDeleteAllRows( id, session );
 	}
 
@@ -157,22 +157,22 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	 * @see org.hibernate.persister.collection.BasicCollectionPersister#recreate(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getCreateEntryCoordinator().reactiveInsertRows( collection, id, collection::includeInRecreate, session );
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getCreateEntryCoordinator().reactiveInsertRows( collection, id, collection::includeInInsert, session );
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getUpdateEntryCoordinator().reactiveUpdateRows( id, collection, session );
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getRemoveEntryCoordinator().reactiveDeleteRows( collection, id, session );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveCollectionPersister.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.impl;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -24,7 +24,7 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of {@link CollectionPersister#recreate(PersistentCollection, Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
 	@Override
 	default void remove(Object id, SharedSessionContractImplementor session) {
@@ -34,7 +34,7 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of {@link CollectionPersister#remove(Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session);
 
 	@Override
 	default void deleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
@@ -44,7 +44,7 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of {@link CollectionPersister#deleteRows(PersistentCollection, Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
 	@Override
 	default void insertRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
@@ -54,7 +54,7 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of {@link CollectionPersister#insertRows(PersistentCollection, Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveInsertRows( PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveInsertRows( PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
 	@Override
 	default void updateRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
@@ -64,7 +64,7 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of  {@link CollectionPersister#updateRows(PersistentCollection, Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session);
 
 	@Override
 	default void initialize(Object key, SharedSessionContractImplementor session) throws HibernateException {
@@ -74,5 +74,5 @@ public interface ReactiveCollectionPersister extends CollectionPersister {
 	/**
 	 * Reactive version of {@link CollectionPersister#initialize(Object, SharedSessionContractImplementor)}
 	 */
-	CompletionStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.impl;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.MappingException;
@@ -174,7 +174,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveInitialize(Object key, SharedSessionContractImplementor session) {
 		return ( (ReactiveCollectionLoader) determineLoaderToUse( key, session ) )
 				.reactiveLoad( key, session )
 				.thenCompose( CompletionStages::voidFuture );
@@ -190,7 +190,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 		return super.isRowInsertEnabled();
 	}
 
-	private CompletionStage<Void> writeIndex(
+	private InternalStage<Void> writeIndex(
 			PersistentCollection<?> collection,
 			Iterator<?> entries,
 			Object key,
@@ -254,7 +254,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	 * @see OneToManyPersister#recreate(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveRecreate(PersistentCollection collection, Object id, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Void> reactiveRecreate(PersistentCollection collection, Object id, SharedSessionContractImplementor session) throws HibernateException {
 		return getInsertRowsCoordinator()
 				.reactiveInsertRows( collection, id, collection::includeInRecreate, session )
 				.thenCompose( unused -> writeIndex( collection, collection.entries( this ), id, true, session ) );
@@ -264,7 +264,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	 * @see OneToManyPersister#insertRows(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) throws HibernateException {
 		return getInsertRowsCoordinator()
 				.reactiveInsertRows( collection, id, collection::includeInInsert, session )
 				.thenCompose( unused -> writeIndex( collection, collection.entries( this ), id, true, session ) );
@@ -274,7 +274,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	 * @see OneToManyPersister#updateRows(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveUpdateRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return 	getUpdateRowsCoordinator().reactiveUpdateRows( id, collection, session );
 	}
 
@@ -283,7 +283,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	 * @see OneToManyPersister#deleteRows(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getDeleteRowsCoordinator().reactiveDeleteRows(collection, id, session);
 	}
 
@@ -291,7 +291,7 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 	 * @see OneToManyPersister#remove(Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveRemove(Object id, SharedSessionContractImplementor session) {
 		return getRemoveCoordinator().reactiveDeleteAllRows( id, session );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinator.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -13,5 +13,5 @@ import org.hibernate.persister.collection.mutation.DeleteRowsCoordinator;
 
 public interface ReactiveDeleteRowsCoordinator extends DeleteRowsCoordinator {
 
-	CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorNoOp.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorNoOp.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -30,7 +30,7 @@ public class ReactiveDeleteRowsCoordinatorNoOp extends DeleteRowsCoordinatorNoOp
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
 		return voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.mutation;
 
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -48,7 +48,7 @@ public class ReactiveDeleteRowsCoordinatorStandard extends DeleteRowsCoordinator
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteRows(PersistentCollection<?> collection, Object key, SharedSessionContractImplementor session) {
 		if ( operationGroup == null ) {
 			operationGroup = createOperationGroup();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinator.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -13,7 +13,7 @@ import org.hibernate.persister.collection.mutation.InsertRowsCoordinator;
 
 public interface ReactiveInsertRowsCoordinator extends InsertRowsCoordinator {
 
-	CompletionStage<Void> reactiveInsertRows(
+	InternalStage<Void> reactiveInsertRows(
 			PersistentCollection<?> collection,
 			Object id,
 			EntryFilter entryChecker,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinatorNoOp.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinatorNoOp.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -41,7 +41,7 @@ public class ReactiveInsertRowsCoordinatorNoOp implements ReactiveInsertRowsCoor
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, EntryFilter entryChecker, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, EntryFilter entryChecker, SharedSessionContractImplementor session) {
 		return voidFuture();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveInsertRowsCoordinatorStandard.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -66,7 +66,7 @@ public class ReactiveInsertRowsCoordinatorStandard implements ReactiveInsertRows
 	 * @see org.hibernate.persister.collection.mutation.InsertRowsCoordinator#insertRows(PersistentCollection, Object, EntryFilter, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, EntryFilter entryChecker, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveInsertRows(PersistentCollection<?> collection, Object id, EntryFilter entryChecker, SharedSessionContractImplementor session) {
 		if ( operationGroup == null ) {
 			operationGroup = createOperationGroup();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinator.java
@@ -5,11 +5,11 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.collection.mutation.RemoveCoordinator;
 
 public interface ReactiveRemoveCoordinator extends RemoveCoordinator {
-	CompletionStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorNoOp.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorNoOp.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.collection.mutation.CollectionMutationTarget;
@@ -20,7 +20,7 @@ public class ReactiveRemoveCoordinatorNoOp extends RemoveCoordinatorNoOp impleme
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session) {
 		return voidFuture();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
@@ -55,7 +55,7 @@ public class ReactiveRemoveCoordinatorStandard extends RemoveCoordinatorStandard
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveDeleteAllRows(Object key, SharedSessionContractImplementor session) {
 		if ( MODEL_MUTATION_LOGGER_DEBUG_ENABLED ) {
 			MODEL_MUTATION_LOGGER
 					.debugf( "Deleting collection - %s : %s", getMutationTarget().getRolePath(), key );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinator.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -14,6 +14,6 @@ import org.hibernate.persister.collection.mutation.UpdateRowsCoordinator;
 
 public interface ReactiveUpdateRowsCoordinator extends UpdateRowsCoordinator {
 
-	CompletionStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session);
+	InternalStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorNoOp.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorNoOp.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -29,7 +29,7 @@ public class ReactiveUpdateRowsCoordinatorNoOp extends UpdateRowsCoordinatorNoOp
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		return voidFuture();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorOneToMany.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorOneToMany.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.persister.collection.mutation;
 
 import java.lang.invoke.MethodHandles;
 import java.util.Iterator;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -58,7 +58,7 @@ public class ReactiveUpdateRowsCoordinatorOneToMany extends UpdateRowsCoordinato
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		MODEL_MUTATION_LOGGER.tracef( "Updating collection rows - %s#%s", getMutationTarget().getRolePath(), key );
 
 		// update all the modified entries
@@ -67,7 +67,7 @@ public class ReactiveUpdateRowsCoordinatorOneToMany extends UpdateRowsCoordinato
 						.debugf( "Updated `%s` collection rows - %s#%s", count, getMutationTarget().getRolePath(), key ) );
 	}
 
-	private CompletionStage<Integer> doReactiveUpdate(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	private InternalStage<Integer> doReactiveUpdate(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		if ( rowMutationOperations.hasDeleteRow() ) {
 			deleteRows( key, collection, session );
 		}
@@ -79,7 +79,7 @@ public class ReactiveUpdateRowsCoordinatorOneToMany extends UpdateRowsCoordinato
 		return completedFuture( 0 );
 	}
 
-	private CompletionStage<Integer> insertRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	private InternalStage<Integer> insertRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		final MutationOperationGroupSingle operationGroup = resolveInsertGroup();
 		final PluralAttributeMapping attributeMapping = getMutationTarget().getTargetPart();
 		final CollectionPersister collectionDescriptor = attributeMapping.getCollectionDescriptor();
@@ -115,7 +115,7 @@ public class ReactiveUpdateRowsCoordinatorOneToMany extends UpdateRowsCoordinato
 		return new BasicBatchKey( getMutationTarget().getRolePath() + "#UPDATE-DELETE" );
 	}
 
-	private CompletionStage<Void> deleteRows(
+	private InternalStage<Void> deleteRows(
 			Object key,
 			PersistentCollection<?> collection,
 			SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveUpdateRowsCoordinatorStandard.java
@@ -9,7 +9,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -52,7 +52,7 @@ public class ReactiveUpdateRowsCoordinatorStandard extends UpdateRowsCoordinator
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveUpdateRows(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		MODEL_MUTATION_LOGGER.tracef( "Updating collection rows - %s#%s", getMutationTarget().getRolePath(), key );
 
 		// update all the modified entries
@@ -61,7 +61,7 @@ public class ReactiveUpdateRowsCoordinatorStandard extends UpdateRowsCoordinator
 						.debugf( "Updated `%s` collection rows - %s#%s", count, getMutationTarget().getRolePath(), key ) );
 	}
 
-	private CompletionStage<Integer> doReactiveUpdate(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
+	private InternalStage<Integer> doReactiveUpdate(Object key, PersistentCollection<?> collection, SharedSessionContractImplementor session) {
 		final ReactiveMutationExecutor mutationExecutor = reactiveMutationExecutor( session, getOperationGroup() );
 		return completedFuture( mutationExecutor )
 				.thenCompose( ignore -> {
@@ -107,7 +107,7 @@ public class ReactiveUpdateRowsCoordinatorStandard extends UpdateRowsCoordinator
 				.whenComplete( (o, throwable) -> mutationExecutor.release() );
 	}
 
-	private CompletionStage<Boolean> processRow(
+	private InternalStage<Boolean> processRow(
 			Object key,
 			PersistentCollection<?> collection,
 			Object entry,
@@ -135,7 +135,7 @@ public class ReactiveUpdateRowsCoordinatorStandard extends UpdateRowsCoordinator
 				.thenCompose( ReactiveUpdateRowsCoordinatorStandard::alwaysTrue );
 	}
 
-	private static CompletionStage<Boolean> alwaysTrue(Object ignore) {
+	private static InternalStage<Boolean> alwaysTrue(Object ignore) {
 		return CompletionStages.trueFuture();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractPersisterDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractPersisterDelegate.java
@@ -10,7 +10,7 @@ import java.util.Arrays;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FetchMode;
 import org.hibernate.LockOptions;
@@ -109,7 +109,7 @@ public class ReactiveAbstractPersisterDelegate {
 	/**
 	 * @see org.hibernate.persister.entity.AbstractEntityPersister#multiLoad(Object[], EventSource, MultiIdLoadOptions)`
 	 */
-	public <K> CompletionStage<? extends List<?>> multiLoad(
+	public <K> InternalStage<? extends List<?>> multiLoad(
 			K[] ids,
 			EventSource session,
 			MultiIdLoadOptions loadOptions) {
@@ -160,7 +160,7 @@ public class ReactiveAbstractPersisterDelegate {
 		return batchSize;
 	}
 
-	public CompletionStage<Void> processInsertGeneratedProperties(
+	public InternalStage<Void> processInsertGeneratedProperties(
 			Object id,
 			Object entity,
 			Object[] state,
@@ -181,7 +181,7 @@ public class ReactiveAbstractPersisterDelegate {
 		return reactiveGeneratedValuesProcessor.processGeneratedValues( id, entity, state, session );
 	}
 
-	public CompletionStage<Void> processUpdateGeneratedProperties(
+	public InternalStage<Void> processUpdateGeneratedProperties(
 			Object id,
 			Object entity,
 			Object[] state,
@@ -221,7 +221,7 @@ public class ReactiveAbstractPersisterDelegate {
 		);
 	}
 
-	public CompletionStage<Object> load(
+	public InternalStage<Object> load(
 			EntityPersister persister,
 			Object id,
 			Object optionalObject,
@@ -240,7 +240,7 @@ public class ReactiveAbstractPersisterDelegate {
 		return generator instanceof IdentityGenerator ? new ReactiveIdentityGenerator() : generator;
 	}
 
-	public CompletionStage<Object> loadEntityIdByNaturalId(
+	public InternalStage<Object> loadEntityIdByNaturalId(
 			Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef( "Resolving natural-id [%s] to id : %s ",

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.entity.impl;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -31,28 +31,28 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	 *
 	 * @see EntityPersister#insert(Object, Object[], Object, SharedSessionContractImplementor)
 	 */
-	CompletionStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session);
+	InternalStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session);
 
 	/**
 	 * Insert the given instance state without blocking.
 	 *
 	 * @see EntityPersister#insert(Object[], Object, SharedSessionContractImplementor)
 	 */
-	CompletionStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session);
+	InternalStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session);
 
 	/**
 	 * Delete the given instance without blocking.
 	 *
 	 * @see EntityPersister#delete(Object, Object, Object, SharedSessionContractImplementor)
 	 */
-	CompletionStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session);
+	InternalStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session);
 
 	/**
 	 * Update the given instance state without blocking.
 	 *
 	 * @see EntityPersister#update(Object, Object[], int[], boolean, Object[], Object, Object, Object, SharedSessionContractImplementor)
 	 */
-	CompletionStage<Void> updateReactive(
+	InternalStage<Void> updateReactive(
 			final Object id,
 			final Object[] values,
 			int[] dirtyAttributeIndexes,
@@ -66,59 +66,59 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	/**
 	 * Obtain a pessimistic lock without blocking
 	 */
-	CompletionStage<Void> reactiveLock(
+	InternalStage<Void> reactiveLock(
 			Object id,
 			Object version,
 			Object object,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session);
 
-	<K> CompletionStage<? extends List<?>> reactiveMultiLoad(
+	<K> InternalStage<? extends List<?>> reactiveMultiLoad(
 			K[] ids,
 			EventSource session,
 			MultiIdLoadOptions loadOptions);
 
-	CompletionStage<Object> reactiveLoad(
+	InternalStage<Object> reactiveLoad(
 			Object id,
 			Object optionalObject,
 			LockMode lockMode,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveLoad(
+	InternalStage<Object> reactiveLoad(
 			Object id,
 			Object optionalObject,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveLoad(
+	InternalStage<Object> reactiveLoad(
 			Object id,
 			Object optionalObject,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session,
 			Boolean readOnly);
 
-	CompletionStage<Object> reactiveLoadByUniqueKey(
+	InternalStage<Object> reactiveLoadByUniqueKey(
 			String propertyName,
 			Object uniqueKey,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveLoadByUniqueKey(
+	InternalStage<Object> reactiveLoadByUniqueKey(
 			String propertyName,
 			Object uniqueKey,
 			Boolean readOnly,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveLoadEntityIdByNaturalId(
+	InternalStage<Object> reactiveLoadEntityIdByNaturalId(
 			Object[] naturalIdValues,
 			LockOptions lockOptions,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveGetCurrentVersion(Object id, SharedSessionContractImplementor session);
+	InternalStage<Object> reactiveGetCurrentVersion(Object id, SharedSessionContractImplementor session);
 
 	/**
 	 * @see EntityPersister#processInsertGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
-	CompletionStage<Void> reactiveProcessInsertGenerated(
+	InternalStage<Void> reactiveProcessInsertGenerated(
 			Object id,
 			Object entity,
 			Object[] state,
@@ -127,7 +127,7 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	/**
 	 * @see EntityPersister#processUpdateGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
-	CompletionStage<Void> reactiveProcessUpdateGenerated(
+	InternalStage<Void> reactiveProcessUpdateGenerated(
 			Object id,
 			Object entity,
 			Object[] state,
@@ -138,19 +138,19 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	 *
 	 * @return null if there is no row in the database
 	 */
-	CompletionStage<Object[]> reactiveGetDatabaseSnapshot(Object id, SharedSessionContractImplementor session);
+	InternalStage<Object[]> reactiveGetDatabaseSnapshot(Object id, SharedSessionContractImplementor session);
 
-	<E, T> CompletionStage<T> reactiveInitializeLazyProperty(
+	<E, T> InternalStage<T> reactiveInitializeLazyProperty(
 			Attribute<E, T> field,
 			E entity,
 			SharedSessionContractImplementor session);
 
-	<E, T> CompletionStage<T> reactiveInitializeLazyProperty(
+	<E, T> InternalStage<T> reactiveInitializeLazyProperty(
 			String field,
 			E entity,
 			SharedSessionContractImplementor session);
 
-	CompletionStage<Object> reactiveInitializeEnhancedEntityUsedAsProxy(
+	InternalStage<Object> reactiveInitializeEnhancedEntityUsedAsProxy(
 			Object entity,
 			String nameOfAttributeBeingAccessed,
 			SharedSessionContractImplementor session);
@@ -159,7 +159,7 @@ public interface ReactiveEntityPersister extends EntityPersister {
 	 * @see org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor#forceInitialize(Object, String, SharedSessionContractImplementor, boolean)
 	 */
 	//TODO find somewhere else for this function to live
-	static CompletionStage<Object> forceInitialize(
+	static InternalStage<Object> forceInitialize(
 			Object target,
 			String attributeName,
 			Object entityId,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveGeneratedValuesProcessor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveGeneratedValuesProcessor.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.entity.impl;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -48,7 +48,7 @@ class ReactiveGeneratedValuesProcessor {
         this.sessionFactory = sessionFactory;
     }
 
-    CompletionStage<Void> processGeneratedValues(Object id,
+    InternalStage<Void> processGeneratedValues(Object id,
                                                         Object entity,
                                                         Object[] state,
                                                         SharedSessionContractImplementor session) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
@@ -52,7 +52,7 @@ import org.hibernate.type.EntityType;
 
 import java.sql.PreparedStatement;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 
 /**
@@ -185,23 +185,23 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public CompletionStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() ).coordinateReactiveInsert( id, fields, object, session )
 				.thenCompose( CompletionStages::voidFuture );
 	}
 
 	@Override
-	public CompletionStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() ).coordinateReactiveInsert( null, fields, object, session );
 	}
 
 	@Override
-	public CompletionStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveDeleteCoordinator) getDeleteCoordinator() ).coordinateReactiveDelete( object, id, version, session );
 	}
 
 	@Override
-	public CompletionStage<Void> updateReactive(
+	public InternalStage<Void> updateReactive(
 			Object id,
 			Object[] values,
 			int[] dirtyAttributeIndexes,
@@ -219,7 +219,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public <K> CompletionStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+	public <K> InternalStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
 		return reactiveDelegate.multiLoad( ids, session, loadOptions );
 	}
 
@@ -264,7 +264,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	 * @see AbstractEntityPersister#processInsertGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processInsertGeneratedProperties( id, entity, state,
 				getInsertGeneratedValuesProcessor(), session, getEntityName() );
 	}
@@ -275,7 +275,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	 * @see AbstractEntityPersister#processUpdateGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processUpdateGeneratedProperties( id, entity, state,
 				getUpdateGeneratedValuesProcessor(), session, getEntityName() );
 	}
@@ -286,7 +286,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
 		return reactiveLoad( id, optionalObject, new LockOptions().setLockMode( lockMode ), session );
 	}
 
@@ -296,7 +296,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		return doReactiveLoad( id, optionalObject, lockOptions, null, session );
 	}
 
@@ -306,11 +306,11 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
 		return doReactiveLoad( id, optionalObject, lockOptions, readOnly, session );
 	}
 
-	private CompletionStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	private InternalStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		return reactiveDelegate.load( this, id, optionalObject, lockOptions, readOnly, session );
 	}
 
@@ -330,12 +330,12 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
 		return reactiveLoadByUniqueKey( propertyName, uniqueKey, null, session );
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
 		return getReactiveUniqueKeyLoader( propertyName )
 				.load( uniqueKey, LockOptions.NONE, readOnly, session );
 	}
@@ -344,7 +344,7 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	 * @see AbstractEntityPersister#loadEntityIdByNaturalId(Object[], LockOptions, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		verifyHasNaturalId();
 		return reactiveDelegate.loadEntityIdByNaturalId( orderedNaturalIdValues, lockOptions, session );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.persister.entity.impl;
 
 import java.sql.PreparedStatement;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FetchMode;
 import org.hibernate.HibernateException;
@@ -218,7 +218,7 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	 * @see AbstractEntityPersister#processInsertGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processInsertGeneratedProperties( id, entity, state,
 				getInsertGeneratedValuesProcessor(), session, getEntityName() );
 	}
@@ -229,7 +229,7 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	 * @see AbstractEntityPersister#processUpdateGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processUpdateGeneratedProperties( id, entity, state,
 				getUpdateGeneratedValuesProcessor(), session, getEntityName() );
 	}
@@ -238,13 +238,13 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	 * @see AbstractEntityPersister#loadEntityIdByNaturalId(Object[], LockOptions, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		verifyHasNaturalId();
 		return reactiveDelegate.loadEntityIdByNaturalId( orderedNaturalIdValues, lockOptions, session );
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
 		return reactiveLoad( id, optionalObject, new LockOptions().setLockMode( lockMode ), session );
 	}
 
@@ -254,7 +254,7 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		return doReactiveLoad( id, optionalObject, lockOptions, null, session );
 	}
 
@@ -264,27 +264,27 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
 		return doReactiveLoad( id, optionalObject, lockOptions, readOnly, session );
 	}
 
-	private CompletionStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	private InternalStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		return reactiveDelegate.load( this, id, optionalObject, lockOptions, readOnly, session );
 	}
 
 	@Override
-	public CompletionStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() ).coordinateReactiveInsert( null, fields, object, session );
 	}
 
 	@Override
-	public CompletionStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() ).coordinateReactiveInsert( id, fields, object, session )
 				.thenCompose( CompletionStages::voidFuture );
 	}
 
 	@Override
-	public CompletionStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveDeleteCoordinator) getDeleteCoordinator() ).coordinateReactiveDelete( object, id, version, session );
 	}
 
@@ -292,7 +292,7 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	 * Update an object
 	 */
 	@Override
-	public CompletionStage<Void> updateReactive(
+	public InternalStage<Void> updateReactive(
 			final Object id,
 			final Object[] values,
 			int[] dirtyAttributeIndexes,
@@ -310,7 +310,7 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	}
 
 	@Override
-	public <K> CompletionStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+	public <K> InternalStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
 		return reactiveDelegate.multiLoad( ids, session, loadOptions );
 	}
 
@@ -330,12 +330,12 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
 		return reactiveLoadByUniqueKey( propertyName, uniqueKey, null, session );
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
 		return getReactiveUniqueKeyLoader( propertyName )
 				.load( uniqueKey, LockOptions.NONE, readOnly, session );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.persister.entity.impl;
 import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FetchMode;
 import org.hibernate.HibernateException;
@@ -245,7 +245,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	 * @see AbstractEntityPersister#processInsertGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessInsertGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processInsertGeneratedProperties( id, entity, state,
 				getInsertGeneratedValuesProcessor(), session, getEntityName() );
 	}
@@ -256,7 +256,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	 * @see AbstractEntityPersister#processUpdateGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
+	public InternalStage<Void> reactiveProcessUpdateGenerated(Object id, Object entity, Object[] state, SharedSessionContractImplementor session) {
 		return reactiveDelegate.processUpdateGeneratedProperties( id, entity, state,
 				getUpdateGeneratedValuesProcessor(), session, getEntityName() );
 
@@ -268,7 +268,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockMode lockMode, SharedSessionContractImplementor session) {
 		return reactiveLoad( id, optionalObject, new LockOptions().setLockMode( lockMode ), session );
 	}
 
@@ -278,7 +278,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		return doReactiveLoad( id, optionalObject, lockOptions, null, session );
 	}
 
@@ -288,34 +288,34 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
+	public InternalStage<Object> reactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, SharedSessionContractImplementor session, Boolean readOnly) {
 		return doReactiveLoad( id, optionalObject, lockOptions, readOnly, session );
 	}
 
-	private CompletionStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
+	private InternalStage<Object> doReactiveLoad(Object id, Object optionalObject, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
 		return reactiveDelegate.load( this, id, optionalObject, lockOptions, readOnly, session );
 	}
 
 	@Override
-	public CompletionStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> insertReactive(Object id, Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() )
 				.coordinateReactiveInsert( id, fields, object, session )
 				.thenCompose( CompletionStages::voidFuture );
 	}
 
 	@Override
-	public CompletionStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Object> insertReactive(Object[] fields, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveInsertCoordinator) getInsertCoordinator() )
 				.coordinateReactiveInsert( null, fields, object, session );
 	}
 
 	@Override
-	public CompletionStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
+	public InternalStage<Void> deleteReactive(Object id, Object version, Object object, SharedSessionContractImplementor session) {
 		return ( (ReactiveDeleteCoordinator) getDeleteCoordinator() ).coordinateReactiveDelete( object, id, version, session );
 	}
 
 	@Override
-	public CompletionStage<Void> updateReactive(
+	public InternalStage<Void> updateReactive(
 			Object id,
 			Object[] values,
 			int[] dirtyAttributeIndexes,
@@ -333,7 +333,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public <K> CompletionStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
+	public <K> InternalStage<? extends List<?>> reactiveMultiLoad(K[] ids, EventSource session, MultiIdLoadOptions loadOptions) {
 		return reactiveDelegate.multiLoad( ids, session, loadOptions );
 	}
 
@@ -341,7 +341,7 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	 * @see AbstractEntityPersister#loadEntityIdByNaturalId(Object[], LockOptions, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
+	public InternalStage<Object> reactiveLoadEntityIdByNaturalId(Object[] orderedNaturalIdValues, LockOptions lockOptions, SharedSessionContractImplementor session) {
 		verifyHasNaturalId();
 		return reactiveDelegate.loadEntityIdByNaturalId( orderedNaturalIdValues, lockOptions, session );
 	}
@@ -362,12 +362,12 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, SharedSessionContractImplementor session) throws HibernateException {
 		return reactiveLoadByUniqueKey( propertyName, uniqueKey, null, session );
 	}
 
 	@Override
-	public CompletionStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
+	public InternalStage<Object> reactiveLoadByUniqueKey(String propertyName, Object uniqueKey, Boolean readOnly, SharedSessionContractImplementor session) throws HibernateException {
 		return getReactiveUniqueKeyLoader( propertyName )
 				.load( uniqueKey, LockOptions.NONE, readOnly, session );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/GeneratorValueUtil.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/GeneratorValueUtil.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.entity.mutation;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
 import org.hibernate.generator.EventType;
@@ -26,7 +26,7 @@ final class GeneratorValueUtil {
     }
 
 
-    static CompletionStage<?> generateValue(
+    static InternalStage<?> generateValue(
             SharedSessionContractImplementor session, Object entity, Object currentValue,
             BeforeExecutionGenerator generator, EventType eventType) {
         if (generator instanceof StageGenerator) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveDeleteCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveDeleteCoordinator.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.persister.entity.mutation;
 
 import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.MutationExecutor;
@@ -35,7 +35,7 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	private CompletionStage<Void> stage;
+	private InternalStage<Void> stage;
 
 	public ReactiveDeleteCoordinator(AbstractEntityPersister entityPersister, SessionFactoryImplementor factory) {
 		super( entityPersister, factory );
@@ -46,7 +46,7 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 		throw LOG.nonReactiveMethodCall( "coordinateReactiveDelete" );
 	}
 
-	public CompletionStage<Void> coordinateReactiveDelete(Object entity, Object id, Object version, SharedSessionContractImplementor session) {
+	public InternalStage<Void> coordinateReactiveDelete(Object entity, Object id, Object version, SharedSessionContractImplementor session) {
 		try {
 			super.coordinateDelete( entity, id, version, session );
 			return stage != null ? stage : voidFuture();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveInsertCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveInsertCoordinator.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.entity.mutation;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.Internal;
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
@@ -45,7 +45,7 @@ public class ReactiveInsertCoordinator extends InsertCoordinator {
 		throw LOG.nonReactiveMethodCall( "coordinateReactiveInsert" );
 	}
 
-	public CompletionStage<Object> coordinateReactiveInsert(Object id, Object[] currentValues, Object entity, SharedSessionContractImplementor session) {
+	public InternalStage<Object> coordinateReactiveInsert(Object id, Object[] currentValues, Object entity, SharedSessionContractImplementor session) {
 		return reactivePreInsertInMemoryValueGeneration( currentValues, entity, session )
 				.thenCompose( v -> entityPersister().getEntityMetamodel().isDynamicInsert()
 						? doDynamicInserts( id, currentValues, entity, session )
@@ -53,8 +53,8 @@ public class ReactiveInsertCoordinator extends InsertCoordinator {
 				);
 	}
 
-	private CompletionStage<Void> reactivePreInsertInMemoryValueGeneration(Object[] currentValues, Object entity, SharedSessionContractImplementor session) {
-		CompletionStage<Void> stage = voidFuture();
+	private InternalStage<Void> reactivePreInsertInMemoryValueGeneration(Object[] currentValues, Object entity, SharedSessionContractImplementor session) {
+		InternalStage<Void> stage = voidFuture();
 
 		final EntityMetamodel entityMetamodel = entityPersister().getEntityMetamodel();
 		if ( entityMetamodel.hasPreInsertGeneratedValues() ) {
@@ -91,7 +91,7 @@ public class ReactiveInsertCoordinator extends InsertCoordinator {
 		throw LOG.nonReactiveMethodCall( "decomposeForReactiveInsert" );
 	}
 
-	protected CompletionStage<Void> decomposeForReactiveInsert(
+	protected InternalStage<Void> decomposeForReactiveInsert(
 			MutationExecutor mutationExecutor,
 			Object id,
 			Object[] values,
@@ -126,7 +126,7 @@ public class ReactiveInsertCoordinator extends InsertCoordinator {
 	}
 
 	@Override
-	protected CompletionStage<Object> doDynamicInserts(Object id, Object[] values, Object object, SharedSessionContractImplementor session) {
+	protected InternalStage<Object> doDynamicInserts(Object id, Object[] values, Object object, SharedSessionContractImplementor session) {
 		final boolean[] insertability = getPropertiesToInsert( values );
 		final MutationOperationGroup insertGroup = generateDynamicInsertSqlGroup( insertability );
 		final ReactiveMutationExecutor mutationExecutor = getReactiveMutationExecutor( session, insertGroup );
@@ -154,7 +154,7 @@ public class ReactiveInsertCoordinator extends InsertCoordinator {
 	}
 
 	@Override
-	protected CompletionStage<Object> doStaticInserts(Object id, Object[] values, Object object, SharedSessionContractImplementor session) {
+	protected InternalStage<Object> doStaticInserts(Object id, Object[] values, Object object, SharedSessionContractImplementor session) {
 		final InsertValuesAnalysis insertValuesAnalysis = new InsertValuesAnalysis( entityPersister(), values );
 		final TableInclusionChecker tableInclusionChecker = getTableInclusionChecker( insertValuesAnalysis );
 		final ReactiveMutationExecutor mutationExecutor = getReactiveMutationExecutor( session, getStaticInsertGroup() );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveScopedUpdateCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveScopedUpdateCoordinator.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.entity.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 
@@ -18,7 +18,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
  */
 public interface ReactiveScopedUpdateCoordinator {
 
-	CompletionStage<Void> coordinateReactiveUpdate(
+	InternalStage<Void> coordinateReactiveUpdate(
 			Object entity,
 			Object id,
 			Object rowId,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveUpdateCoordinatorNoOp.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveUpdateCoordinatorNoOp.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.persister.entity.mutation;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.AbstractEntityPersister;
@@ -33,7 +33,7 @@ public class ReactiveUpdateCoordinatorNoOp extends UpdateCoordinatorNoOp impleme
 	}
 
 	@Override
-	public CompletionStage<Void> coordinateReactiveUpdate(
+	public InternalStage<Void> coordinateReactiveUpdate(
 			Object entity,
 			Object id,
 			Object rowId,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveUpdateCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveUpdateCoordinatorStandard.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.persister.entity.mutation;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -68,7 +68,7 @@ public class ReactiveUpdateCoordinatorStandard extends UpdateCoordinatorStandard
 	}
 
 	@Override
-	public CompletionStage<Void> coordinateReactiveUpdate(
+	public InternalStage<Void> coordinateReactiveUpdate(
 			Object entity,
 			Object id,
 			Object rowId,
@@ -103,7 +103,7 @@ public class ReactiveUpdateCoordinatorStandard extends UpdateCoordinatorStandard
 			return updateResultStage;
 		}
 
-		CompletionStage<Void> s = voidFuture();
+		InternalStage<Void> s = voidFuture();
 		return s.thenCompose( v -> reactivePreUpdateInMemoryValueGeneration(entity, values, session) )
 				.thenCompose( preUpdateGeneratedAttributeIndexes -> {
 					final int[] dirtyAttributeIndexes = dirtyAttributeIndexes( incomingDirtyAttributeIndexes, preUpdateGeneratedAttributeIndexes );
@@ -166,7 +166,7 @@ public class ReactiveUpdateCoordinatorStandard extends UpdateCoordinatorStandard
 				});
 	}
 
-	private CompletionStage<int[]> reactivePreUpdateInMemoryValueGeneration(
+	private InternalStage<int[]> reactivePreUpdateInMemoryValueGeneration(
 			Object entity,
 			Object[] currentValues,
 			SharedSessionContractImplementor session) {
@@ -175,7 +175,7 @@ public class ReactiveUpdateCoordinatorStandard extends UpdateCoordinatorStandard
 			return completedFuture(EMPTY_INT_ARRAY);
 		}
 
-		CompletionStage<Void> result = voidFuture();
+		InternalStage<Void> result = voidFuture();
 
 		final Generator[] generators = entityMetamodel.getGenerators();
 		if ( generators.length != 0 ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
@@ -9,7 +9,7 @@ package org.hibernate.reactive.pool;
 import java.sql.ResultSet;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 
 import io.vertx.sqlclient.spi.DatabaseMetadata;
@@ -62,7 +62,7 @@ public class BatchingConnection implements ReactiveConnection {
 	}
 
 	@Override
-	public CompletionStage<Void> executeBatch() {
+	public InternalStage<Void> executeBatch() {
 		if ( !hasBatch() ) {
 			return voidFuture();
 		}
@@ -89,7 +89,7 @@ public class BatchingConnection implements ReactiveConnection {
 		}
 	}
 
-	public CompletionStage<Void> update(
+	public InternalStage<Void> update(
 			String sql, Object[] paramValues,
 			boolean allowBatching, Expectation expectation) {
 		if ( allowBatching && batchSize > 0 ) {
@@ -103,7 +103,7 @@ public class BatchingConnection implements ReactiveConnection {
 					return voidFuture();
 				}
 				else {
-					CompletionStage<Void> lastBatch = executeBatch();
+					InternalStage<Void> lastBatch = executeBatch();
 					newBatch( sql, paramValues, expectation );
 					return lastBatch;
 				}
@@ -125,67 +125,67 @@ public class BatchingConnection implements ReactiveConnection {
 		return batchedSql != null;
 	}
 
-	public CompletionStage<Void> execute(String sql) {
+	public InternalStage<Void> execute(String sql) {
 		return delegate.execute( sql );
 	}
 
-	public CompletionStage<Void> executeUnprepared(String sql) {
+	public InternalStage<Void> executeUnprepared(String sql) {
 		return delegate.executeUnprepared( sql );
 	}
 
-	public CompletionStage<Void> executeOutsideTransaction(String sql) {
+	public InternalStage<Void> executeOutsideTransaction(String sql) {
 		return delegate.executeOutsideTransaction( sql );
 	}
 
-	public CompletionStage<Integer> update(String sql) {
+	public InternalStage<Integer> update(String sql) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.update( sql ) ) :
 				delegate.update( sql );
 	}
 
 	@Override
-	public CompletionStage<Integer> update(String sql, Object[] paramValues) {
+	public InternalStage<Integer> update(String sql, Object[] paramValues) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.update( sql, paramValues ) ) :
 				delegate.update( sql, paramValues );
 	}
 
-	public CompletionStage<int[]> update(String sql, List<Object[]> paramValues) {
+	public InternalStage<int[]> update(String sql, List<Object[]> paramValues) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.update( sql, paramValues ) ) :
 				delegate.update( sql, paramValues );
 	}
 
-	public <T> CompletionStage<T> insertAndSelectIdentifier(String sql, Object[] paramValues, Class<T> idClass, String idColumnName) {
+	public <T> InternalStage<T> insertAndSelectIdentifier(String sql, Object[] paramValues, Class<T> idClass, String idColumnName) {
 		return hasBatch()
 				? executeBatch().thenCompose( v -> delegate.insertAndSelectIdentifier( sql, paramValues, idClass, idColumnName ) )
 				: delegate.insertAndSelectIdentifier( sql, paramValues, idClass, idColumnName );
 	}
 
-	public CompletionStage<ReactiveConnection.Result> select(String sql) {
+	public InternalStage<ReactiveConnection.Result> select(String sql) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.select( sql ) ) :
 				delegate.select( sql );
 	}
 
-	public CompletionStage<ReactiveConnection.Result> select(String sql, Object[] paramValues) {
+	public InternalStage<ReactiveConnection.Result> select(String sql, Object[] paramValues) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.select( sql, paramValues ) ) :
 				delegate.select( sql, paramValues );
 	}
 
-	public CompletionStage<ResultSet> selectJdbc(String sql, Object[] paramValues) {
+	public InternalStage<ResultSet> selectJdbc(String sql, Object[] paramValues) {
 		return hasBatch() ?
 				executeBatch().thenCompose( v -> delegate.selectJdbc( sql, paramValues ) ) :
 				delegate.selectJdbc( sql, paramValues );
 	}
 
 	@Override
-	public CompletionStage<ResultSet> selectJdbcOutsideTransaction(String sql, Object[] paramValues) {
+	public InternalStage<ResultSet> selectJdbcOutsideTransaction(String sql, Object[] paramValues) {
 		return delegate.selectJdbcOutsideTransaction( sql, paramValues );
 	}
 
-	public <T> CompletionStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass) {
+	public <T> InternalStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass) {
 		// Do not want to execute the batch here
 		// because we want to be able to select
 		// multiple ids before sending off a batch
@@ -193,19 +193,19 @@ public class BatchingConnection implements ReactiveConnection {
 		return delegate.selectIdentifier( sql, paramValues, idClass );
 	}
 
-	public CompletionStage<Void> beginTransaction() {
+	public InternalStage<Void> beginTransaction() {
 		return delegate.beginTransaction();
 	}
 
-	public CompletionStage<Void> commitTransaction() {
+	public InternalStage<Void> commitTransaction() {
 		return delegate.commitTransaction();
 	}
 
-	public CompletionStage<Void> rollbackTransaction() {
+	public InternalStage<Void> rollbackTransaction() {
 		return delegate.rollbackTransaction();
 	}
 
-	public CompletionStage<Void> close() {
+	public InternalStage<Void> close() {
 		return delegate.close();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
@@ -10,7 +10,7 @@ import org.hibernate.Incubating;
 import java.sql.ResultSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.Incubating;
 
@@ -39,28 +39,28 @@ public interface ReactiveConnection {
 
 	DatabaseMetadata getDatabaseMetadata();
 
-	CompletionStage<Void> execute(String sql);
+	InternalStage<Void> execute(String sql);
 
-	CompletionStage<Void> executeOutsideTransaction(String sql);
+	InternalStage<Void> executeOutsideTransaction(String sql);
 
 	/**
 	 * Run sql as statement (instead of preparedStatement)
 	 */
-	CompletionStage<Void> executeUnprepared(String sql);
+	InternalStage<Void> executeUnprepared(String sql);
 
-	CompletionStage<Integer> update(String sql);
+	InternalStage<Integer> update(String sql);
 
-	CompletionStage<Integer> update(String sql, Object[] paramValues);
+	InternalStage<Integer> update(String sql, Object[] paramValues);
 
-	CompletionStage<Void> update(String sql, Object[] paramValues, boolean allowBatching, Expectation expectation);
+	InternalStage<Void> update(String sql, Object[] paramValues, boolean allowBatching, Expectation expectation);
 
-	CompletionStage<int[]> update(String sql, List<Object[]> paramValues);
+	InternalStage<int[]> update(String sql, List<Object[]> paramValues);
 
-	CompletionStage<Result> select(String sql);
+	InternalStage<Result> select(String sql);
 
-	CompletionStage<Result> select(String sql, Object[] paramValues);
+	InternalStage<Result> select(String sql, Object[] paramValues);
 
-	CompletionStage<ResultSet> selectJdbc(String sql, Object[] paramValues);
+	InternalStage<ResultSet> selectJdbc(String sql, Object[] paramValues);
 
 	/**
 	 * This method is intended to be used only for queries returning
@@ -75,27 +75,27 @@ public interface ReactiveConnection {
 	 * @param sql - the query to execute outside of a transaction
 	 * @param paramValues - a non-null array of parameter values
 	 *
-	 * @return the CompletionStage<ResultSet> from executing the query.
+	 * @return the InternalStage<ResultSet> from executing the query.
 	 */
-	CompletionStage<ResultSet> selectJdbcOutsideTransaction(String sql, Object[] paramValues);
+	InternalStage<ResultSet> selectJdbcOutsideTransaction(String sql, Object[] paramValues);
 
-	<T> CompletionStage<T> insertAndSelectIdentifier(String sql, Object[] paramValues, Class<T> idClass, String idColumnName);
+	<T> InternalStage<T> insertAndSelectIdentifier(String sql, Object[] paramValues, Class<T> idClass, String idColumnName);
 
-	<T> CompletionStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass);
+	<T> InternalStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass);
 
 	interface Result extends Iterator<Object[]> {
 		int size();
 	}
 
-	CompletionStage<Void> beginTransaction();
+	InternalStage<Void> beginTransaction();
 
-	CompletionStage<Void> commitTransaction();
+	InternalStage<Void> commitTransaction();
 
-	CompletionStage<Void> rollbackTransaction();
+	InternalStage<Void> rollbackTransaction();
 
 	ReactiveConnection withBatchSize(int batchSize);
 
-	CompletionStage<Void> executeBatch();
+	InternalStage<Void> executeBatch();
 
-	CompletionStage<Void> close();
+	InternalStage<Void> close();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnectionPool.java
@@ -10,7 +10,7 @@ import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.reactive.provider.ReactiveServiceRegistryBuilder;
 import org.hibernate.service.Service;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * A Hibernate {@link Service} that provides access to pooled
@@ -40,20 +40,20 @@ public interface ReactiveConnectionPool extends Service {
 	 * Obtain a reactive connection, returning the connection
 	 * via a {@link CompletionStage}.
 	 */
-	CompletionStage<ReactiveConnection> getConnection();
+	InternalStage<ReactiveConnection> getConnection();
 
 	/**
 	 * Obtain a reactive connection, returning the connection
 	 * via a {@link CompletionStage} and overriding the default
 	 * {@link SqlExceptionHelper} for the pool.
 	 */
-	CompletionStage<ReactiveConnection> getConnection(SqlExceptionHelper sqlExceptionHelper);
+	InternalStage<ReactiveConnection> getConnection(SqlExceptionHelper sqlExceptionHelper);
 
 	/**
 	 * Obtain a reactive connection for the given tenant id,
 	 * returning the connection via a {@link CompletionStage}.
 	 */
-	CompletionStage<ReactiveConnection> getConnection(String tenantId);
+	InternalStage<ReactiveConnection> getConnection(String tenantId);
 
 	/**
 	 * Obtain a reactive connection for the given tenant id,
@@ -61,7 +61,7 @@ public interface ReactiveConnectionPool extends Service {
 	 * and overriding the default {@link SqlExceptionHelper}
 	 * for the pool.
 	 */
-	CompletionStage<ReactiveConnection> getConnection(String tenantId, SqlExceptionHelper sqlExceptionHelper);
+	InternalStage<ReactiveConnection> getConnection(String tenantId, SqlExceptionHelper sqlExceptionHelper);
 
 	/**
 	 * The shutdown of the pool is actually asynchronous but the
@@ -70,5 +70,5 @@ public interface ReactiveConnectionPool extends Service {
 	 * after closing the SessionFactory you can get the CompletionStage
 	 * instance from this getter.
 	 */
-	CompletionStage<Void> getCloseFuture();
+	InternalStage<Void> getCloseFuture();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -12,7 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.ServiceConfigurationError;
 import java.util.ServiceLoader;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
@@ -140,7 +140,7 @@ public class DefaultSqlClientPool extends SqlClientPool
 	}
 
 	@Override
-	public CompletionStage<Void> getCloseFuture() {
+	public InternalStage<Void> getCloseFuture() {
 		return closeFuture.toCompletionStage();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/ExternalSqlClientPool.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.pool.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
@@ -79,7 +79,7 @@ public final class ExternalSqlClientPool extends SqlClientPool {
 	 * successfully completed CompletionStage.
 	 */
 	@Override
-	public CompletionStage<Void> getCloseFuture() {
+	public InternalStage<Void> getCloseFuture() {
 		return CompletionStages.voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.pool.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
 import org.hibernate.engine.jdbc.spi.SqlStatementLogger;
@@ -68,31 +68,31 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 	}
 
 	@Override
-	public CompletionStage<ReactiveConnection> getConnection() {
+	public InternalStage<ReactiveConnection> getConnection() {
 		return getConnectionFromPool( getPool() );
 	}
 
 	@Override
-	public CompletionStage<ReactiveConnection> getConnection(SqlExceptionHelper sqlExceptionHelper) {
+	public InternalStage<ReactiveConnection> getConnection(SqlExceptionHelper sqlExceptionHelper) {
 		return getConnectionFromPool( getPool(), sqlExceptionHelper );
 	}
 
 	@Override
-	public CompletionStage<ReactiveConnection> getConnection(String tenantId) {
+	public InternalStage<ReactiveConnection> getConnection(String tenantId) {
 		return getConnectionFromPool( getTenantPool( tenantId ) );
 	}
 
 	@Override
-	public CompletionStage<ReactiveConnection> getConnection(String tenantId, SqlExceptionHelper sqlExceptionHelper) {
+	public InternalStage<ReactiveConnection> getConnection(String tenantId, SqlExceptionHelper sqlExceptionHelper) {
 		return getConnectionFromPool( getTenantPool( tenantId ), sqlExceptionHelper );
 	}
 
-	private CompletionStage<ReactiveConnection> getConnectionFromPool(Pool pool) {
+	private InternalStage<ReactiveConnection> getConnectionFromPool(Pool pool) {
 		return pool.getConnection()
 				.toCompletionStage().thenApply( this::newConnection );
 	}
 
-	private CompletionStage<ReactiveConnection> getConnectionFromPool(Pool pool, SqlExceptionHelper sqlExceptionHelper) {
+	private InternalStage<ReactiveConnection> getConnectionFromPool(Pool pool, SqlExceptionHelper sqlExceptionHelper) {
 		return pool.getConnection()
 				.toCompletionStage().thenApply( sqlConnection -> newConnection( sqlConnection, sqlExceptionHelper ) );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcEnvironmentInitiator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcEnvironmentInitiator.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.provider.service;
 
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.boot.registry.StandardServiceInitiator;
 import org.hibernate.dialect.Dialect;
@@ -78,7 +78,7 @@ public class NoJdbcEnvironmentInitiator implements StandardServiceInitiator<Jdbc
 					.toCompletableFuture().join();
 		}
 
-		private static CompletionStage<ReactiveDialectResolutionInfo> buildResolutionInfo(ReactiveConnection connection) {
+		private static InternalStage<ReactiveDialectResolutionInfo> buildResolutionInfo(ReactiveConnection connection) {
 			final DatabaseMetadata databaseMetadata = connection.getDatabaseMetadata();
 			return resolutionInfoStage( connection, databaseMetadata )
 					.handle( CompletionStages::handle )
@@ -97,7 +97,7 @@ public class NoJdbcEnvironmentInitiator implements StandardServiceInitiator<Jdbc
 					} );
 		}
 
-		private static CompletionStage<ReactiveDialectResolutionInfo> resolutionInfoStage(ReactiveConnection connection, DatabaseMetadata databaseMetadata) {
+		private static InternalStage<ReactiveDialectResolutionInfo> resolutionInfoStage(ReactiveConnection connection, DatabaseMetadata databaseMetadata) {
 			if ( databaseMetadata.productName().equalsIgnoreCase( "PostgreSQL" ) ) {
 				// We need to check if the database is PostgreSQL or CockroachDB
 				// Hibernate ORM does it using a query, so we need to check in advance

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactiveGenerationTarget.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactiveGenerationTarget.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.CountDownLatch;
 
 import org.hibernate.reactive.logging.impl.Log;
@@ -88,8 +88,8 @@ public class ReactiveGenerationTarget implements GenerationTarget {
 	 * Execute all commands and log exceptions without propagating them.
 	 * This method never fails.
 	 */
-	private CompletionStage<Void> executeCommands(ReactiveConnection reactiveConnection) {
-		CompletionStage<Void> result = voidFuture();
+	private InternalStage<Void> executeCommands(ReactiveConnection reactiveConnection) {
+		InternalStage<Void> result = voidFuture();
 		for ( String command : commands ) {
 			result = result.thenApply( v -> command )
 					.thenCompose( reactiveConnection::execute )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactiveImprovedExtractionContextImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/ReactiveImprovedExtractionContextImpl.java
@@ -34,7 +34,7 @@ import java.sql.Timestamp;
 import java.util.Calendar;
 import java.util.Map;
 import java.util.Properties;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.Executor;
 
 import org.hibernate.boot.model.relational.SqlStringGenerationContext;
@@ -74,7 +74,7 @@ public class ReactiveImprovedExtractionContextImpl extends ImprovedExtractionCon
 			Object[] positionalParameters,
 			ResultSetProcessor<T> resultSetProcessor) throws SQLException {
 
-		final CompletionStage<ReactiveConnection> connectionStage = service.getConnection();
+		final InternalStage<ReactiveConnection> connectionStage = service.getConnection();
 
 		try (final ResultSet resultSet = getQueryResultSet( queryString, positionalParameters, connectionStage )) {
 			return resultSetProcessor.process( resultSet );
@@ -92,7 +92,7 @@ public class ReactiveImprovedExtractionContextImpl extends ImprovedExtractionCon
 		return reactiveConnection;
 	}
 
-	private static CompletionStage<Void> closeConnection(ReactiveConnection connection) {
+	private static InternalStage<Void> closeConnection(ReactiveConnection connection) {
 		// Avoid NullPointerException if we couldn't create a connection
 		return connection != null ? connection.close() : voidFuture();
 	}
@@ -100,7 +100,7 @@ public class ReactiveImprovedExtractionContextImpl extends ImprovedExtractionCon
 	private ResultSet getQueryResultSet(
 			String queryString,
 			Object[] positionalParameters,
-			CompletionStage<ReactiveConnection> connectionStage) {
+			InternalStage<ReactiveConnection> connectionStage) {
 		final Object[] parametersToUse = positionalParameters != null ? positionalParameters : new Object[0];
 		final Parameters parametersDialectSpecific = Parameters.instance(
 				getJdbcEnvironment().getDialect()

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveMutationQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveMutationQuery.java
@@ -10,7 +10,7 @@ import java.util.Calendar;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FlushMode;
 import org.hibernate.query.BindableType;
@@ -24,7 +24,7 @@ import jakarta.persistence.TemporalType;
  * @see org.hibernate.query.MutationQuery
  */
 public interface ReactiveMutationQuery<R> extends CommonQueryContract {
-	CompletionStage<Integer> executeReactiveUpdate();
+	InternalStage<Integer> executeReactiveUpdate();
 
 	@Override
 	ReactiveMutationQuery<R> setParameter(String name, Object value);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
@@ -38,19 +38,19 @@ public interface ReactiveSelectionQuery<R> extends CommonQueryContract {
 
 	String getQueryString();
 
-	default CompletionStage<List<R>> getReactiveResultList() {
+	default InternalStage<List<R>> getReactiveResultList() {
 		return reactiveList();
 	}
 
-	CompletionStage<List<R>> reactiveList();
+	InternalStage<List<R>> reactiveList();
 
-	CompletionStage<R> getReactiveSingleResult();
+	InternalStage<R> getReactiveSingleResult();
 
-	CompletionStage<R> getReactiveSingleResultOrNull();
+	InternalStage<R> getReactiveSingleResultOrNull();
 
-	CompletionStage<R> reactiveUnique();
+	InternalStage<R> reactiveUnique();
 
-	CompletionStage<Optional<R>> reactiveUniqueResultOptional();
+	InternalStage<Optional<R>> reactiveUniqueResultOptional();
 
 	ReactiveSelectionQuery<R> setHint(String hintName, Object value);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
@@ -9,7 +9,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -53,7 +53,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 	private final Supplier<QueryOptions> queryOptionsSupplier;
 
 	private final SharedSessionContractImplementor session;
-	private final Supplier<CompletionStage<List<R>>> doList;
+	private final Supplier<InternalStage<List<R>>> doList;
 	private final Supplier<SqmStatement<?>> getStatement;
 
 	private final Supplier<TupleMetadata> getTupleMetadata;
@@ -74,7 +74,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 	public ReactiveAbstractSelectionQuery(
 			InterpretationsKeySource interpretationKeySource,
 			SharedSessionContractImplementor session,
-			Supplier<CompletionStage<List<R>>> doList,
+			Supplier<InternalStage<List<R>>> doList,
 			Supplier<SqmStatement<?>> getStatement,
 			Supplier<TupleMetadata> getTupleMetadata,
 			Supplier<DomainParameterXref> getDomainParameterXref,
@@ -102,7 +102,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 	public ReactiveAbstractSelectionQuery(
 			Supplier<QueryOptions> queryOptionsSupplier,
 			SharedSessionContractImplementor session,
-			Supplier<CompletionStage<List<R>>> doList,
+			Supplier<InternalStage<List<R>>> doList,
 			Supplier<SqmStatement<?>> getStatement,
 			Supplier<TupleMetadata> getTupleMetadata,
 			Supplier<DomainParameterXref> getDomainParameterXref,
@@ -126,17 +126,17 @@ public class ReactiveAbstractSelectionQuery<R> {
 		this.interpretationsKeySource = interpretationsKeySource;
 	}
 
-	public CompletionStage<R> reactiveUnique() {
+	public InternalStage<R> reactiveUnique() {
 		return reactiveList()
 				.thenApply( uniqueElement );
 	}
 
-	public CompletionStage<Optional<R>> reactiveUniqueResultOptional() {
+	public InternalStage<Optional<R>> reactiveUniqueResultOptional() {
 		return reactiveUnique()
 				.thenApply( Optional::ofNullable );
 	}
 
-	public CompletionStage<R> getReactiveSingleResult() {
+	public InternalStage<R> getReactiveSingleResult() {
 		return reactiveList()
 				.thenApply( this::reactiveSingleResult )
 				.exceptionally( this::convertException );
@@ -149,7 +149,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 		return uniqueElement.apply( list );
 	}
 
-	public CompletionStage<R> getReactiveSingleResultOrNull() {
+	public InternalStage<R> getReactiveSingleResultOrNull() {
 		return reactiveList()
 				.thenApply( uniqueElement )
 				.exceptionally( this::convertException );
@@ -174,7 +174,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 		return getQueryOptions().getLockOptions();
 	}
 
-	public CompletionStage<List<R>> reactiveList() {
+	public InternalStage<List<R>> reactiveList() {
 		beforeQuery.run();
 		return doReactiveList()
 				.handle( (list, error) -> {
@@ -260,7 +260,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 		return session;
 	}
 
-	private CompletionStage<List<R>> doReactiveList() {
+	private InternalStage<List<R>> doReactiveList() {
 		return doList.get();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
@@ -10,7 +10,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -45,7 +45,7 @@ public class ReactiveNativeNonSelectQueryPlan implements ReactiveNonSelectQueryP
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		ReactiveSharedSessionContractImplementor reactiveSession = (ReactiveSharedSessionContractImplementor) executionContext.getSession();
 		return reactiveSession.reactiveAutoFlushIfRequired( affectedTableNames )
 						.thenCompose( aBoolean -> {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.CacheMode;
 import org.hibernate.FlushMode;
@@ -108,7 +108,7 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 				null
 		);
 	}
-	private CompletionStage<List<R>> doReactiveList() {
+	private InternalStage<List<R>> doReactiveList() {
 		return reactiveSelectPlan().reactivePerformList( this );
 	}
 
@@ -147,7 +147,7 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate() {
+	public InternalStage<Integer> executeReactiveUpdate() {
 		return reactiveNonSelectPlan().executeReactiveUpdate( this );
 	}
 
@@ -157,7 +157,7 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResult() {
+	public InternalStage<R> getReactiveSingleResult() {
 		return selectionQueryDelegate.getReactiveSingleResult();
 	}
 
@@ -167,17 +167,17 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResultOrNull() {
+	public InternalStage<R> getReactiveSingleResultOrNull() {
 		return selectionQueryDelegate.getReactiveSingleResultOrNull();
 	}
 
 	@Override
-	public CompletionStage<Optional<R>> reactiveUniqueResultOptional() {
+	public InternalStage<Optional<R>> reactiveUniqueResultOptional() {
 		throw new UnsupportedOperationException();
 	}
 
 	@Override
-	public CompletionStage<R> reactiveUnique() {
+	public InternalStage<R> reactiveUnique() {
 		return selectionQueryDelegate.reactiveUnique();
 	}
 
@@ -187,7 +187,7 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactiveList() {
+	public InternalStage<List<R>> reactiveList() {
 		return selectionQueryDelegate.reactiveList();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeSelectQueryPlanImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeSelectQueryPlanImpl.java
@@ -10,7 +10,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.query.results.ResultSetMapping;
@@ -66,7 +66,7 @@ public class ReactiveNativeSelectQueryPlanImpl<R> extends NativeSelectQueryPlanI
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
+	public InternalStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
 		final QueryOptions queryOptions = executionContext.getQueryOptions();
 		if ( queryOptions.getEffectiveLimit().getMaxRowsJpa() == 0 ) {
 			return completedFuture( emptyList() );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/spi/ReactiveNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/spi/ReactiveNonSelectQueryPlan.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sql.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.spi.NonSelectQueryPlan;
@@ -25,5 +25,5 @@ public interface ReactiveNonSelectQueryPlan extends NonSelectQueryPlan {
 		throw LOG.nonReactiveMethodCall( "executeReactiveUpdate" );
 	}
 
-	CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext);
+	InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/AggregatedSelectReactiveQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/AggregatedSelectReactiveQueryPlan.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -30,7 +30,7 @@ public class AggregatedSelectReactiveQueryPlan<R> implements ReactiveSelectQuery
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
+	public InternalStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
 		final Limit effectiveLimit = executionContext.getQueryOptions().getEffectiveLimit();
 		final int maxRowsJpa = effectiveLimit.getMaxRowsJpa();
 		if ( maxRowsJpa == 0 ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ConcreteSqmSelectReactiveQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ConcreteSqmSelectReactiveQueryPlan.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Supplier;
 
 import org.hibernate.ScrollMode;
@@ -82,7 +82,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 				listInterpreter( hql, domainParameterXref, executionContext, sqmInterpretation, jdbcParameterBindings, rowTransformer );
 	}
 
-	private static <R> CompletionStage<List<R>> listInterpreter(
+	private static <R> InternalStage<List<R>> listInterpreter(
 			String hql,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext executionContext,
@@ -116,13 +116,13 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
+	public InternalStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext) {
 		return executionContext.getQueryOptions().getEffectiveLimit().getMaxRowsJpa() == 0
 				? completedFuture( emptyList() )
 				: withCacheableSqmInterpretation( executionContext, listInterpreter );
 	}
 
-	private <T, X> CompletionStage<T> withCacheableSqmInterpretation(DomainQueryExecutionContext executionContext, SqmInterpreter<T, X> interpreter) {
+	private <T, X> InternalStage<T> withCacheableSqmInterpretation(DomainQueryExecutionContext executionContext, SqmInterpreter<T, X> interpreter) {
 		// NOTE : VERY IMPORTANT - intentional double-lock checking
 		//		The other option would be to leverage `java.util.concurrent.locks.ReadWriteLock`
 		//		to protect access.  However, synchronized is much simpler here.  We will verify
@@ -247,7 +247,7 @@ public class ConcreteSqmSelectReactiveQueryPlan<R> extends ConcreteSqmSelectQuer
 	}
 
 	private interface SqmInterpreter<T, X> {
-		CompletionStage<T> interpret(
+		InternalStage<T> interpret(
 				X context,
 				DomainQueryExecutionContext executionContext,
 				CacheableSqmInterpretation sqmInterpretation,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveAggregatedNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveAggregatedNonSelectQueryPlan.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
@@ -24,7 +24,7 @@ public class ReactiveAggregatedNonSelectQueryPlan implements ReactiveNonSelectQu
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		return total( aggregatedQueryPlans, nonSelectQueryPlan -> nonSelectQueryPlan
 				.executeReactiveUpdate( executionContext ) );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableDeleteQueryPlan.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -32,7 +32,7 @@ public class ReactiveMultiTableDeleteQueryPlan implements ReactiveNonSelectQuery
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
 		return deleteStrategy.reactiveExecuteDelete( sqmDelete, domainParameterXref, executionContext );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableInsertQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableInsertQueryPlan.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -32,7 +32,7 @@ public class ReactiveMultiTableInsertQueryPlan implements ReactiveNonSelectQuery
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
 		return mutationStrategy.reactiveExecuteInsert( sqmInsert, domainParameterXref, executionContext );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableUpdateQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableUpdateQueryPlan.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -32,7 +32,7 @@ public class ReactiveMultiTableUpdateQueryPlan implements ReactiveNonSelectQuery
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
 		return mutationStrategy.reactiveExecuteUpdate( sqmUpdate, domainParameterXref, executionContext );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
@@ -13,7 +13,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.stream.Stream;
 
 import org.hibernate.CacheMode;
@@ -129,27 +129,27 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 	}
 
 	@Override
-	public CompletionStage<R> reactiveUnique() {
+	public InternalStage<R> reactiveUnique() {
 		return selectionQueryDelegate.reactiveUnique();
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResult() {
+	public InternalStage<R> getReactiveSingleResult() {
 		return selectionQueryDelegate.getReactiveSingleResult();
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResultOrNull() {
+	public InternalStage<R> getReactiveSingleResultOrNull() {
 		return selectionQueryDelegate.getReactiveSingleResultOrNull();
 	}
 
 	@Override
-	public CompletionStage<Optional<R>> reactiveUniqueResultOptional() {
+	public InternalStage<Optional<R>> reactiveUniqueResultOptional() {
 		return selectionQueryDelegate.reactiveUniqueResultOptional();
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactiveList() {
+	public InternalStage<List<R>> reactiveList() {
 		return selectionQueryDelegate.reactiveList();
 	}
 
@@ -183,7 +183,7 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 		return selectionQueryDelegate.getResultStream();
 	}
 
-	private CompletionStage<List<R>> doReactiveList() {
+	private InternalStage<List<R>> doReactiveList() {
 		verifySelect();
 		getSession().prepareForQueryExecution( requiresTxn( getQueryOptions().getLockOptions().findGreatestLockMode() ) );
 
@@ -279,7 +279,7 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate() {
+	public InternalStage<Integer> executeReactiveUpdate() {
 		verifyUpdate();
 		getSession().checkTransactionNeededForUpdateOperation( "Executing an update/delete query" );
 		beforeQuery();
@@ -291,7 +291,7 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 				.whenComplete( (rs, throwable) -> afterQuery( throwable == null ) );
 	}
 
-	public CompletionStage<Integer> doExecuteReactiveUpdate() {
+	public InternalStage<Integer> doExecuteReactiveUpdate() {
 		getSession().prepareForQueryExecution( true );
 		return resolveNonSelectQueryPlan().executeReactiveUpdate( this );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.query.sqm.internal;
 import java.sql.PreparedStatement;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -96,7 +96,7 @@ public class ReactiveSimpleDeleteQueryPlan extends SimpleDeleteQueryPlan impleme
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleInsertQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleInsertQueryPlan.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -58,7 +58,7 @@ public class ReactiveSimpleInsertQueryPlan implements ReactiveNonSelectQueryPlan
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		SqlAstTranslator<JdbcOperationQueryInsert> insertTranslator = null;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleUpdateQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleUpdateQueryPlan.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -54,7 +54,7 @@ public class ReactiveSimpleUpdateQueryPlan implements ReactiveNonSelectQueryPlan
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
 		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		SqlAstTranslator<JdbcOperationQueryUpdate> updateTranslator = null;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
@@ -14,7 +14,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.stream.Stream;
 
 import org.hibernate.CacheMode;
@@ -89,7 +89,7 @@ public class ReactiveSqmSelectionQueryImpl<R> extends SqmSelectionQueryImpl<R> i
 		);
 	}
 
-	private CompletionStage<List<R>> doReactiveList() {
+	private InternalStage<List<R>> doReactiveList() {
 		getSession().prepareForQueryExecution( requiresTxn( getQueryOptions().getLockOptions()
 																	.findGreatestLockMode() ) );
 
@@ -177,27 +177,27 @@ public class ReactiveSqmSelectionQueryImpl<R> extends SqmSelectionQueryImpl<R> i
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResult() {
+	public InternalStage<R> getReactiveSingleResult() {
 		return selectionQueryDelegate.getReactiveSingleResult();
 	}
 
 	@Override
-	public CompletionStage<List<R>> reactiveList() {
+	public InternalStage<List<R>> reactiveList() {
 		return selectionQueryDelegate.reactiveList();
 	}
 
 	@Override
-	public CompletionStage<R> getReactiveSingleResultOrNull() {
+	public InternalStage<R> getReactiveSingleResultOrNull() {
 		return selectionQueryDelegate.getReactiveSingleResultOrNull();
 	}
 
 	@Override
-	public CompletionStage<R> reactiveUnique() {
+	public InternalStage<R> reactiveUnique() {
 		return selectionQueryDelegate.reactiveUnique();
 	}
 
 	@Override
-	public CompletionStage<Optional<R>> reactiveUniqueResultOptional() {
+	public InternalStage<Optional<R>> reactiveUniqueResultOptional() {
 		return selectionQueryDelegate.reactiveUniqueResultOptional();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/ReactiveHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/ReactiveHandler.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 
@@ -22,5 +22,5 @@ public interface ReactiveHandler {
 	 *
 	 * @return The "number of rows affected" count
 	 */
-	CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext);
+	InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/ReactiveSqmMutationStrategyHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/ReactiveSqmMutationStrategyHelper.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.mutation.internal;
 
 import java.sql.PreparedStatement;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiFunction;
 
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -35,7 +35,7 @@ public class ReactiveSqmMutationStrategyHelper {
 	private ReactiveSqmMutationStrategyHelper() {
 	}
 
-//	public static CompletionStage<Void> visitCollectionTables(EntityMappingType entityDescriptor, Consumer<PluralAttributeMapping> consumer) {
+//	public static InternalStage<Void> visitCollectionTables(EntityMappingType entityDescriptor, Consumer<PluralAttributeMapping> consumer) {
 //		if ( !entityDescriptor.getEntityPersister().hasCollections() ) {
 //			// none to clean-up
 //			return voidFuture();
@@ -70,7 +70,7 @@ public class ReactiveSqmMutationStrategyHelper {
 //		}
 //	}
 
-//	private static CompletionStage<Void> visitCollectionTables(EmbeddedAttributeMapping attributeMapping, Consumer<PluralAttributeMapping> consumer) {
+//	private static InternalStage<Void> visitCollectionTables(EmbeddedAttributeMapping attributeMapping, Consumer<PluralAttributeMapping> consumer) {
 //		final CompletableFuture<Void> stage = new CompletableFuture<>();
 //
 //		try {
@@ -103,7 +103,7 @@ public class ReactiveSqmMutationStrategyHelper {
 //		}
 //	}
 
-	public static CompletionStage<Void> cleanUpCollectionTables(
+	public static InternalStage<Void> cleanUpCollectionTables(
 			EntityMappingType entityDescriptor,
 			BiFunction<TableReference, PluralAttributeMapping, Predicate> restrictionProducer,
 			JdbcParameterBindings jdbcParameterBindings,
@@ -148,7 +148,7 @@ public class ReactiveSqmMutationStrategyHelper {
 		}
 	}
 
-	private static CompletionStage<Void> cleanUpCollectionTables(
+	private static InternalStage<Void> cleanUpCollectionTables(
 			EmbeddedAttributeMapping attributeMapping,
 			EntityMappingType entityDescriptor,
 			BiFunction<TableReference, PluralAttributeMapping, Predicate> restrictionProducer,
@@ -187,7 +187,7 @@ public class ReactiveSqmMutationStrategyHelper {
 		}
 	}
 
-	private static CompletionStage<Void> cleanUpCollectionTable(
+	private static InternalStage<Void> cleanUpCollectionTable(
 			PluralAttributeMapping attributeMapping,
 			EntityMappingType entityDescriptor,
 			BiFunction<TableReference, PluralAttributeMapping, Predicate> restrictionProducer,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveAbstractCteMutationHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveAbstractCteMutationHandler.java
@@ -11,7 +11,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
@@ -77,7 +77,7 @@ public interface ReactiveAbstractCteMutationHandler extends ReactiveAbstractMuta
 	 * @see org.hibernate.query.sqm.mutation.internal.cte.AbstractCteMutationHandler#execute(DomainQueryExecutionContext)
 	 */
 	@Override
-	default CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
+	default InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
 		final SqmDeleteOrUpdateStatement<?> sqmMutationStatement = getSqmDeleteOrUpdateStatement();
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
 		final EntityMappingType entityDescriptor = getEntityDescriptor();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteInsertHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteInsertHandler.java
@@ -13,7 +13,7 @@ import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -103,7 +103,7 @@ public class ReactiveCteInsertHandler extends CteInsertHandler implements Reacti
 	// Pretty much a copy and paste of the method in the super class
 	// We should refactor this
 	@Override
-	public CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
 		final SqmInsertStatement<?> sqmInsertStatement = getSqmStatement();
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
 		final EntityPersister entityDescriptor = getEntityDescriptor().getEntityPersister();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteInsertStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteInsertStrategy.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.cte;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
@@ -31,7 +31,7 @@ public class ReactiveCteInsertStrategy extends CteInsertStrategy implements Reac
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteInsert(
+	public InternalStage<Integer> reactiveExecuteInsert(
 			SqmInsertStatement<?> sqmInsertStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteMutationStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveCteMutationStrategy.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.cte;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
@@ -28,7 +28,7 @@ public class ReactiveCteMutationStrategy extends CteMutationStrategy implements 
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteUpdate(
+	public InternalStage<Integer> reactiveExecuteUpdate(
 			SqmUpdateStatement<?> sqmUpdateStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -38,7 +38,7 @@ public class ReactiveCteMutationStrategy extends CteMutationStrategy implements 
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteDelete(
+	public InternalStage<Integer> reactiveExecuteDelete(
 			SqmDeleteStatement<?> sqmDeleteStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveInsertExecutionDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveInsertExecutionDelegate.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.mutation.internal.cte;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -68,7 +68,7 @@ public class ReactiveInsertExecutionDelegate extends InsertExecutionDelegate imp
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecute(ExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(ExecutionContext executionContext) {
 		return null;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveExecuteWithTemporaryTableHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveExecuteWithTemporaryTableHelper.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.LockMode;
@@ -64,7 +64,7 @@ public final class ReactiveExecuteWithTemporaryTableHelper {
 	private ReactiveExecuteWithTemporaryTableHelper() {
 	}
 
-	public static CompletionStage<Integer> saveMatchingIdsIntoIdTable(
+	public static InternalStage<Integer> saveMatchingIdsIntoIdTable(
 			MultiTableSqmMutationConverter sqmConverter,
 			Predicate suppliedPredicate,
 			TemporaryTable idTable,
@@ -137,7 +137,7 @@ public final class ReactiveExecuteWithTemporaryTableHelper {
 		return saveIntoTemporaryTable( idTableInsert, jdbcParameterBindings, executionContext );
 	}
 
-	public static CompletionStage<Integer> saveIntoTemporaryTable(
+	public static InternalStage<Integer> saveIntoTemporaryTable(
 			InsertSelectStatement temporaryTableInsert,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext) {
@@ -289,7 +289,7 @@ public final class ReactiveExecuteWithTemporaryTableHelper {
 		}
 	}
 
-	public static CompletionStage<Void> performBeforeTemporaryTableUseActions(
+	public static InternalStage<Void> performBeforeTemporaryTableUseActions(
 			TemporaryTable temporaryTable,
 			ExecutionContext executionContext) {
 		final SessionFactoryImplementor factory = executionContext.getSession().getFactory();
@@ -305,7 +305,7 @@ public final class ReactiveExecuteWithTemporaryTableHelper {
 		return voidFuture();
 	}
 
-	public static CompletionStage<Void> performAfterTemporaryTableUseActions(
+	public static InternalStage<Void> performAfterTemporaryTableUseActions(
 			TemporaryTable temporaryTable,
 			Function<SharedSessionContractImplementor, String> sessionUidAccess,
 			AfterUseAction afterUseAction,
@@ -322,7 +322,7 @@ public final class ReactiveExecuteWithTemporaryTableHelper {
 		}
 	}
 
-	private static CompletionStage<Void> dropAction(
+	private static InternalStage<Void> dropAction(
 			TemporaryTable temporaryTable,
 			ExecutionContext executionContext,
 			SessionFactoryImplementor factory,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableInsertStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableInsertStrategy.java
@@ -5,8 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -23,9 +22,9 @@ import org.hibernate.reactive.query.sqm.mutation.spi.ReactiveSqmMultiTableInsert
 public class ReactiveGlobalTemporaryTableInsertStrategy extends GlobalTemporaryTableStrategy
 		implements ReactiveGlobalTemporaryTableStrategy, ReactiveSqmMultiTableInsertStrategy {
 
-	private final CompletableFuture<Void> tableCreatedStage = new CompletableFuture<>();
+	private final InternalStage<Void> tableCreatedStage = InternalStage.newStage();
 
-	private final CompletableFuture<Void> tableDroppedStage = new CompletableFuture<>();
+	private final InternalStage<Void> tableDroppedStage = InternalStage.newStage();
 
 	private boolean prepared;
 
@@ -48,7 +47,7 @@ public class ReactiveGlobalTemporaryTableInsertStrategy extends GlobalTemporaryT
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteInsert(
+	public InternalStage<Integer> reactiveExecuteInsert(
 			SqmInsertStatement<?> sqmInsertStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -86,12 +85,12 @@ public class ReactiveGlobalTemporaryTableInsertStrategy extends GlobalTemporaryT
 	}
 
 	@Override
-	public CompletionStage<Void> getDropTableActionStage() {
+	public InternalStage<Void> getDropTableActionStage() {
 		return tableDroppedStage;
 	}
 
 	@Override
-	public CompletionStage<Void> getCreateTableActionStage() {
+	public InternalStage<Void> getCreateTableActionStage() {
 		return tableCreatedStage;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableMutationStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableMutationStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -50,7 +50,7 @@ public class ReactiveGlobalTemporaryTableMutationStrategy extends GlobalTemporar
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteUpdate(
+	public InternalStage<Integer> reactiveExecuteUpdate(
 			SqmUpdateStatement<?> sqmUpdateStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -66,7 +66,7 @@ public class ReactiveGlobalTemporaryTableMutationStrategy extends GlobalTemporar
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteDelete(
+	public InternalStage<Integer> reactiveExecuteDelete(
 			SqmDeleteStatement<?> sqmDeleteStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -82,12 +82,12 @@ public class ReactiveGlobalTemporaryTableMutationStrategy extends GlobalTemporar
 	}
 
 	@Override
-	public CompletionStage<Void> getDropTableActionStage() {
+	public InternalStage<Void> getDropTableActionStage() {
 		return tableDroppedStage;
 	}
 
 	@Override
-	public CompletionStage<Void> getCreateTableActionStage() {
+	public InternalStage<Void> getCreateTableActionStage() {
 		return tableCreatedStage;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveGlobalTemporaryTableStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -43,9 +43,9 @@ public interface ReactiveGlobalTemporaryTableStrategy {
 
 	TemporaryTable getTemporaryTable();
 
-	CompletionStage<Void> getDropTableActionStage();
+	InternalStage<Void> getDropTableActionStage();
 
-	CompletionStage<Void> getCreateTableActionStage();
+	InternalStage<Void> getCreateTableActionStage();
 
 	SessionFactoryImplementor getSessionFactory();
 
@@ -83,7 +83,7 @@ public interface ReactiveGlobalTemporaryTableStrategy {
 				);
 	}
 
-	private CompletionStage<Void> releaseConnection(ReactiveConnection connection) {
+	private InternalStage<Void> releaseConnection(ReactiveConnection connection) {
 		if ( connection == null ) {
 			return voidFuture();
 		}
@@ -107,7 +107,7 @@ public interface ReactiveGlobalTemporaryTableStrategy {
 		}
 	}
 
-	private CompletionStage<ReactiveConnection> createTable(ReactiveConnection connection) {
+	private InternalStage<ReactiveConnection> createTable(ReactiveConnection connection) {
 		try {
 			return new ReactiveTemporaryTableHelper.TemporaryTableCreationWork(
 					getTemporaryTable(),
@@ -129,7 +129,7 @@ public interface ReactiveGlobalTemporaryTableStrategy {
 		) );
 	}
 
-	private CompletionStage<ReactiveConnection> connectionStage() {
+	private InternalStage<ReactiveConnection> connectionStage() {
 		try {
 			return getSessionFactory().getServiceRegistry()
 					.getService( ReactiveConnectionPool.class )
@@ -167,7 +167,7 @@ public interface ReactiveGlobalTemporaryTableStrategy {
 				);
 	}
 
-	private CompletionStage<ReactiveConnection> dropTable(ReactiveConnection connection) {
+	private InternalStage<ReactiveConnection> dropTable(ReactiveConnection connection) {
 		try {
 			return new ReactiveTemporaryTableHelper.TemporaryTableDropWork( getTemporaryTable(), getSessionFactory() )
 					.reactiveExecute( connection )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveLocalTemporaryTableInsertStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveLocalTemporaryTableInsertStrategy.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -23,7 +23,7 @@ public class ReactiveLocalTemporaryTableInsertStrategy extends LocalTemporaryTab
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteInsert(
+	public InternalStage<Integer> reactiveExecuteInsert(
 			SqmInsertStatement<?> sqmInsertStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveLocalTemporaryTableMutationStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveLocalTemporaryTableMutationStrategy.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -29,7 +29,7 @@ public class ReactiveLocalTemporaryTableMutationStrategy extends LocalTemporaryT
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteUpdate(
+	public InternalStage<Integer> reactiveExecuteUpdate(
 			SqmUpdateStatement<?> sqmUpdate,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -44,7 +44,7 @@ public class ReactiveLocalTemporaryTableMutationStrategy extends LocalTemporaryT
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteDelete(
+	public InternalStage<Integer> reactiveExecuteDelete(
 			SqmDeleteStatement<?> sqmDelete,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableInsertStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableInsertStrategy.java
@@ -5,8 +5,7 @@
  */
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -20,9 +19,9 @@ import org.hibernate.reactive.query.sqm.mutation.spi.ReactiveSqmMultiTableInsert
 public class ReactivePersistentTableInsertStrategy extends PersistentTableInsertStrategy
 		implements ReactivePersistentTableStrategy, ReactiveSqmMultiTableInsertStrategy {
 
-	private final CompletableFuture<Void> tableCreatedStage = new CompletableFuture<>();
+	private final InternalStage<Void> tableCreatedStage = InternalStage.newStage();
 
-	private final CompletableFuture<Void> tableDroppedStage = new CompletableFuture<>();
+	private final InternalStage<Void> tableDroppedStage = InternalStage.newStage();
 
 	private boolean prepared;
 
@@ -45,7 +44,7 @@ public class ReactivePersistentTableInsertStrategy extends PersistentTableInsert
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteInsert(
+	public InternalStage<Integer> reactiveExecuteInsert(
 			SqmInsertStatement<?> sqmInsertStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -81,12 +80,12 @@ public class ReactivePersistentTableInsertStrategy extends PersistentTableInsert
 	}
 
 	@Override
-	public CompletionStage<Void> getDropTableActionStage() {
+	public InternalStage<Void> getDropTableActionStage() {
 		return tableDroppedStage;
 	}
 
 	@Override
-	public CompletionStage<Void> getCreateTableActionStage() {
+	public InternalStage<Void> getCreateTableActionStage() {
 		return tableCreatedStage;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableMutationStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableMutationStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.jdbc.connections.spi.JdbcConnectionAccess;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -47,7 +47,7 @@ public class ReactivePersistentTableMutationStrategy extends PersistentTableMuta
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteUpdate(
+	public InternalStage<Integer> reactiveExecuteUpdate(
 			SqmUpdateStatement<?> sqmUpdateStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -63,7 +63,7 @@ public class ReactivePersistentTableMutationStrategy extends PersistentTableMuta
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecuteDelete(
+	public InternalStage<Integer> reactiveExecuteDelete(
 			SqmDeleteStatement<?> sqmDeleteStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context) {
@@ -79,12 +79,12 @@ public class ReactivePersistentTableMutationStrategy extends PersistentTableMuta
 	}
 
 	@Override
-	public CompletionStage<Void> getDropTableActionStage() {
+	public InternalStage<Void> getDropTableActionStage() {
 		return tableDroppedStage;
 	}
 
 	@Override
-	public CompletionStage<Void> getCreateTableActionStage() {
+	public InternalStage<Void> getCreateTableActionStage() {
 		return tableCreatedStage;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactivePersistentTableStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
 import org.hibernate.engine.config.spi.ConfigurationService;
@@ -42,9 +42,9 @@ public interface ReactivePersistentTableStrategy {
 
 	TemporaryTable getTemporaryTable();
 
-	CompletionStage<Void> getDropTableActionStage();
+	InternalStage<Void> getDropTableActionStage();
 
-	CompletionStage<Void> getCreateTableActionStage();
+	InternalStage<Void> getCreateTableActionStage();
 
 	SessionFactoryImplementor getSessionFactory();
 
@@ -52,7 +52,7 @@ public interface ReactivePersistentTableStrategy {
 		return session.getSessionIdentifier().toString();
 	}
 
-	default void prepare(MappingModelCreationProcess mappingModelCreationProcess, JdbcConnectionAccess connectionAccess, CompletableFuture<Void> tableCreatedStage) {
+	default void prepare(MappingModelCreationProcess mappingModelCreationProcess, JdbcConnectionAccess connectionAccess, InternalStage<Void> tableCreatedStage) {
 		if ( isPrepared() ) {
 			return;
 		}
@@ -86,7 +86,7 @@ public interface ReactivePersistentTableStrategy {
 				);
 	}
 
-	private CompletionStage<Void> releaseConnection(ReactiveConnection connection) {
+	private InternalStage<Void> releaseConnection(ReactiveConnection connection) {
 		if ( connection == null ) {
 			return voidFuture();
 		}
@@ -110,7 +110,7 @@ public interface ReactivePersistentTableStrategy {
 		}
 	}
 
-	private CompletionStage<ReactiveConnection> createTable(ReactiveConnection connection) {
+	private InternalStage<ReactiveConnection> createTable(ReactiveConnection connection) {
 		try {
 			return new ReactiveTemporaryTableHelper.TemporaryTableCreationWork(
 					getTemporaryTable(),
@@ -132,7 +132,7 @@ public interface ReactivePersistentTableStrategy {
 		) );
 	}
 
-	private CompletionStage<ReactiveConnection> connectionStage() {
+	private InternalStage<ReactiveConnection> connectionStage() {
 		try {
 			return getSessionFactory().getServiceRegistry()
 					.getService( ReactiveConnectionPool.class )
@@ -146,7 +146,7 @@ public interface ReactivePersistentTableStrategy {
 	default void release(
 			SessionFactoryImplementor sessionFactory,
 			JdbcConnectionAccess connectionAccess,
-			CompletableFuture<Void> tableDroppedStage) {
+			InternalStage<Void> tableDroppedStage) {
 		if ( !isDropIdTables() ) {
 			tableDroppedStage.complete( null );
 		}
@@ -170,7 +170,7 @@ public interface ReactivePersistentTableStrategy {
 				);
 	}
 
-	private CompletionStage<ReactiveConnection> dropTable(ReactiveConnection connection) {
+	private InternalStage<ReactiveConnection> dropTable(ReactiveConnection connection) {
 		try {
 			return new ReactiveTemporaryTableHelper.TemporaryTableDropWork( getTemporaryTable(), getSessionFactory() )
 					.reactiveExecute( connection )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedDeleteHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedDeleteHandler.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -31,7 +31,7 @@ public class ReactiveTableBasedDeleteHandler extends TableBasedDeleteHandler imp
 			throw LOG.nonReactiveMethodCall( "reactiveExecute" );
 		}
 
-		CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext);
+		InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext);
 	}
 
 	public ReactiveTableBasedDeleteHandler(
@@ -45,7 +45,7 @@ public class ReactiveTableBasedDeleteHandler extends TableBasedDeleteHandler imp
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(
 					"Starting multi-table delete execution - %s",

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedInsertHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedInsertHandler.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -44,7 +44,7 @@ public class ReactiveTableBasedInsertHandler extends TableBasedInsertHandler imp
 			throw LOG.nonReactiveMethodCall( "reactiveExecute" );
 		}
 
-		CompletionStage<Integer> reactiveExecute(ExecutionContext executionContext);
+		InternalStage<Integer> reactiveExecute(ExecutionContext executionContext);
 	}
 
 	public ReactiveTableBasedInsertHandler(
@@ -58,7 +58,7 @@ public class ReactiveTableBasedInsertHandler extends TableBasedInsertHandler imp
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(
 					"Starting multi-table insert execution - %s",

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedUpdateHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTableBasedUpdateHandler.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -43,7 +43,7 @@ public class ReactiveTableBasedUpdateHandler extends TableBasedUpdateHandler imp
 			throw LOG.nonReactiveMethodCall( "reactiveExecute" );
 		}
 
-		CompletionStage<Integer> reactiveExecute(ExecutionContext executionContext);
+		InternalStage<Integer> reactiveExecute(ExecutionContext executionContext);
 	}
 
 	public ReactiveTableBasedUpdateHandler(
@@ -62,7 +62,7 @@ public class ReactiveTableBasedUpdateHandler extends TableBasedUpdateHandler imp
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(DomainQueryExecutionContext executionContext) {
 		if ( LOG.isTraceEnabled() ) {
 			LOG.tracef(
 					"Starting multi-table update execution - %s",

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTemporaryTableHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveTemporaryTableHelper.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.internal.temptable;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.dialect.temptable.TemporaryTable;
@@ -39,7 +39,7 @@ public class ReactiveTemporaryTableHelper {
 	 * @see org.hibernate.jdbc.Work
 	 */
 	public interface ReactiveWork {
-		CompletionStage<Void> reactiveExecute(ReactiveConnection connection);
+		InternalStage<Void> reactiveExecute(ReactiveConnection connection);
 	}
 
 	public static class TemporaryTableCreationWork implements ReactiveWork {
@@ -67,7 +67,7 @@ public class ReactiveTemporaryTableHelper {
 		}
 
 		@Override
-		public CompletionStage<Void> reactiveExecute(ReactiveConnection connection) {
+		public InternalStage<Void> reactiveExecute(ReactiveConnection connection) {
 			final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 
 			try {
@@ -115,7 +115,7 @@ public class ReactiveTemporaryTableHelper {
 		}
 
 		@Override
-		public CompletionStage<Void> reactiveExecute(ReactiveConnection connection) {
+		public InternalStage<Void> reactiveExecute(ReactiveConnection connection) {
 			final JdbcServices jdbcServices = sessionFactory.getJdbcServices();
 
 			try {
@@ -139,7 +139,7 @@ public class ReactiveTemporaryTableHelper {
 	// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 	// Clean
 
-	public static CompletionStage<Void> cleanTemporaryTableRows(
+	public static InternalStage<Void> cleanTemporaryTableRows(
 			TemporaryTable temporaryTable,
 			TemporaryTableExporter exporter,
 			Function<SharedSessionContractImplementor, String> sessionUidAccess,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -99,7 +99,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 	}
 
 	@Override
-	public CompletionStage<Integer> reactiveExecute(ExecutionContext executionContext) {
+	public InternalStage<Integer> reactiveExecute(ExecutionContext executionContext) {
 		return performBeforeTemporaryTableUseActions(
 						getIdTable(),
 						executionContext
@@ -120,7 +120,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 							executionContext
 					);
 
-					final CompletionStage<Void>[] resultStage = new CompletionStage[] { voidFuture() };
+					final InternalStage<Void>[] resultStage = new CompletionStage[] { voidFuture() };
 					getEntityDescriptor().visitConstraintOrderedTables(
 							(tableExpression, tableKeyColumnVisitationSupplier) -> resultStage[0] = resultStage[0].thenCompose(
 									v -> reactiveUpdateTable(
@@ -144,7 +144,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 				);
 	}
 
-	private CompletionStage<Void> reactiveUpdateTable(
+	private InternalStage<Void> reactiveUpdateTable(
 			String tableExpression,
 			Supplier<Consumer<SelectableConsumer>> tableKeyColumnVisitationSupplier,
 			int expectedUpdateCount,
@@ -200,7 +200,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 	}
 
 
-	private CompletionStage<Integer> executeUpdate(QuerySpec idTableSubQuery, ExecutionContext executionContext, List<Assignment> assignments, NamedTableReference dmlTableReference, SqlAstTranslatorFactory sqlAstTranslatorFactory, Expression keyExpression) {
+	private InternalStage<Integer> executeUpdate(QuerySpec idTableSubQuery, ExecutionContext executionContext, List<Assignment> assignments, NamedTableReference dmlTableReference, SqlAstTranslatorFactory sqlAstTranslatorFactory, Expression keyExpression) {
 		final UpdateStatement sqlAst = new UpdateStatement(
 				dmlTableReference,
 				assignments,
@@ -224,7 +224,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 		);
 	}
 
-	private CompletionStage<Integer> executeInsert(
+	private InternalStage<Integer> executeInsert(
 			String targetTableExpression,
 			NamedTableReference targetTableReference,
 			Expression targetTableKeyExpression,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/spi/ReactiveSqmMultiTableInsertStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/spi/ReactiveSqmMultiTableInsertStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
@@ -27,7 +27,7 @@ public interface ReactiveSqmMultiTableInsertStrategy extends SqmMultiTableInsert
 		throw LOG.nonReactiveMethodCall( "reactiveExecuteInsert" );
 	}
 
-	CompletionStage<Integer> reactiveExecuteInsert(
+	InternalStage<Integer> reactiveExecuteInsert(
 			SqmInsertStatement<?> sqmInsertStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/spi/ReactiveSqmMultiTableMutationStrategy.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/spi/ReactiveSqmMultiTableMutationStrategy.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.query.sqm.mutation.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
@@ -28,7 +28,7 @@ public interface ReactiveSqmMultiTableMutationStrategy extends SqmMultiTableMuta
 		throw LOG.nonReactiveMethodCall( "reactiveExecuteUpdate" );
 	}
 
-	CompletionStage<Integer> reactiveExecuteUpdate(
+	InternalStage<Integer> reactiveExecuteUpdate(
 			SqmUpdateStatement<?> sqmUpdateStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context);
@@ -41,7 +41,7 @@ public interface ReactiveSqmMultiTableMutationStrategy extends SqmMultiTableMuta
 		throw LOG.nonReactiveMethodCall( "reactiveExecuteDelete" );
 	}
 
-	CompletionStage<Integer> reactiveExecuteDelete(
+	InternalStage<Integer> reactiveExecuteDelete(
 			SqmDeleteStatement<?> sqmDeleteStatement,
 			DomainParameterXref domainParameterXref,
 			DomainQueryExecutionContext context);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/spi/ReactiveSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/spi/ReactiveSelectQueryPlan.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.query.sqm.spi;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.ScrollMode;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -36,5 +36,5 @@ public interface ReactiveSelectQueryPlan<R> extends SelectQueryPlan<R> {
 	/**
 	 * Perform (execute) the query returning a List
 	 */
-	CompletionStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext);
+	InternalStage<List<R>> reactivePerformList(DomainQueryExecutionContext executionContext);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.session;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.Incubating;
 import org.hibernate.dialect.Dialect;
@@ -14,6 +14,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.criteria.JpaCriteriaInsertSelect;
 import org.hibernate.reactive.common.AffectedEntities;
 import org.hibernate.reactive.common.ResultSetMapping;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.reactive.query.ReactiveMutationQuery;
 import org.hibernate.reactive.query.ReactiveNativeQuery;
 import org.hibernate.reactive.query.ReactiveQuery;
@@ -41,9 +42,9 @@ public interface ReactiveQueryProducer extends ReactiveConnectionSupplier {
 
 	Dialect getDialect();
 
-	<T> CompletionStage<T> reactiveFetch(T association, boolean unproxy);
+	<T> InternalStage<T> reactiveFetch(T association, boolean unproxy);
 
-	CompletionStage<Object> reactiveInternalLoad(String entityName, Object id, boolean eager, boolean nullable);
+	InternalStage<Object> reactiveInternalLoad(String entityName, Object id, boolean eager, boolean nullable);
 
 	<T> EntityGraph<T> createEntityGraph(Class<T> entity);
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.session;
 
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
@@ -24,6 +23,7 @@ import org.hibernate.event.spi.MergeContext;
 import org.hibernate.event.spi.PersistContext;
 import org.hibernate.event.spi.RefreshContext;
 import org.hibernate.reactive.engine.ReactiveActionQueue;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.reactive.engine.spi.ReactiveSharedSessionContractImplementor;
 
 import jakarta.persistence.EntityGraph;
@@ -46,49 +46,49 @@ public interface ReactiveSession extends ReactiveQueryProducer, ReactiveSharedSe
 
 	SessionImplementor getSharedContract();
 
-	<E,T> CompletionStage<T> reactiveFetch(E entity, Attribute<E,T> field);
+	<E,T> InternalStage<T> reactiveFetch(E entity, Attribute<E,T> field);
 
-	CompletionStage<Void> reactivePersist(Object entity);
+	InternalStage<Void> reactivePersist(Object entity);
 
-	CompletionStage<Void> reactivePersist(Object object, PersistContext copiedAlready);
+	InternalStage<Void> reactivePersist(Object object, PersistContext copiedAlready);
 
-	CompletionStage<Void> reactivePersistOnFlush(Object entity, PersistContext copiedAlready);
+	InternalStage<Void> reactivePersistOnFlush(Object entity, PersistContext copiedAlready);
 
-	CompletionStage<Void> reactiveRemove(Object entity);
+	InternalStage<Void> reactiveRemove(Object entity);
 
-	CompletionStage<Void> reactiveRemove(String entityName, boolean isCascadeDeleteEnabled, DeleteContext transientObjects);
+	InternalStage<Void> reactiveRemove(String entityName, boolean isCascadeDeleteEnabled, DeleteContext transientObjects);
 
-	CompletionStage<Void> reactiveRemove(String entityName, Object child, boolean isCascadeDeleteEnabled, DeleteContext transientEntities);
+	InternalStage<Void> reactiveRemove(String entityName, Object child, boolean isCascadeDeleteEnabled, DeleteContext transientEntities);
 
-	<T> CompletionStage<T> reactiveMerge(T object);
+	<T> InternalStage<T> reactiveMerge(T object);
 
-	CompletionStage<Void> reactiveMerge(Object object, MergeContext copiedAlready);
+	InternalStage<Void> reactiveMerge(Object object, MergeContext copiedAlready);
 
-	CompletionStage<Void> reactiveFlush();
+	InternalStage<Void> reactiveFlush();
 
-	CompletionStage<Void> reactiveAutoflush();
+	InternalStage<Void> reactiveAutoflush();
 
-	CompletionStage<Void> reactiveForceFlush(EntityEntry entry);
+	InternalStage<Void> reactiveForceFlush(EntityEntry entry);
 
-	CompletionStage<Void> reactiveRefresh(Object entity, LockOptions lockMode);
+	InternalStage<Void> reactiveRefresh(Object entity, LockOptions lockMode);
 
-	CompletionStage<Void> reactiveRefresh(Object child, RefreshContext refreshedAlready);
+	InternalStage<Void> reactiveRefresh(Object child, RefreshContext refreshedAlready);
 
-	CompletionStage<Void> reactiveLock(Object entity, LockOptions lockMode);
+	InternalStage<Void> reactiveLock(Object entity, LockOptions lockMode);
 
-	<T> CompletionStage<T> reactiveGet(Class<T> entityClass, Object id);
+	<T> InternalStage<T> reactiveGet(Class<T> entityClass, Object id);
 
-	<T> CompletionStage<T> reactiveFind(Class<T> entityClass, Object id, LockOptions lockOptions, EntityGraph<T> fetchGraph);
+	<T> InternalStage<T> reactiveFind(Class<T> entityClass, Object id, LockOptions lockOptions, EntityGraph<T> fetchGraph);
 
-	<T> CompletionStage<List<T>> reactiveFind(Class<T> entityClass, Object... ids);
+	<T> InternalStage<List<T>> reactiveFind(Class<T> entityClass, Object... ids);
 
-	<T> CompletionStage<T> reactiveFind(Class<T> entityClass, Map<String,Object> naturalIds);
+	<T> InternalStage<T> reactiveFind(Class<T> entityClass, Map<String,Object> naturalIds);
 
-	CompletionStage<Object> reactiveImmediateLoad(String entityName, Object id);
+	InternalStage<Object> reactiveImmediateLoad(String entityName, Object id);
 
-	CompletionStage<Void> reactiveInitializeCollection(PersistentCollection<?> collection, boolean writing);
+	InternalStage<Void> reactiveInitializeCollection(PersistentCollection<?> collection, boolean writing);
 
-	CompletionStage<Void> reactiveRemoveOrphanBeforeUpdates(String entityName, Object child);
+	InternalStage<Void> reactiveRemoveOrphanBeforeUpdates(String entityName, Object child);
 
 	void setHibernateFlushMode(FlushMode flushMode);
 	FlushMode getHibernateFlushMode();
@@ -134,5 +134,5 @@ public interface ReactiveSession extends ReactiveQueryProducer, ReactiveSharedSe
 	boolean isOpen();
 
 	// Different approach so that we can overload the method in SessionImpl
-	CompletionStage<Void> reactiveClose();
+	InternalStage<Void> reactiveClose();
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
@@ -10,8 +10,7 @@ import org.hibernate.LockMode;
 import org.hibernate.reactive.engine.spi.ReactiveSharedSessionContractImplementor;
 
 import jakarta.persistence.EntityGraph;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**Mutiny
  * A contract with the Hibernate stateless session backing the user-visible
@@ -26,41 +25,41 @@ import java.util.concurrent.CompletionStage;
 @Incubating
 public interface ReactiveStatelessSession extends ReactiveQueryProducer, ReactiveSharedSessionContractImplementor {
 
-	<T> CompletionStage<T> reactiveGet(Class<? extends T> entityClass, Object id);
+	<T> InternalStage<T> reactiveGet(Class<? extends T> entityClass, Object id);
 
-	<T> CompletionStage<T> reactiveGet(String entityName, Object id);
+	<T> InternalStage<T> reactiveGet(String entityName, Object id);
 
-	<T> CompletionStage<T> reactiveGet(Class<? extends T> entityClass, Object id, LockMode lockMode, EntityGraph<T> fetchGraph);
+	<T> InternalStage<T> reactiveGet(Class<? extends T> entityClass, Object id, LockMode lockMode, EntityGraph<T> fetchGraph);
 
-	<T> CompletionStage<T> reactiveGet(String entityName, Object id, LockMode lockMode, EntityGraph<T> fetchGraph);
+	<T> InternalStage<T> reactiveGet(String entityName, Object id, LockMode lockMode, EntityGraph<T> fetchGraph);
 
-	CompletionStage<Void> reactiveInsert(Object entity);
+	InternalStage<Void> reactiveInsert(Object entity);
 
-	CompletionStage<Void> reactiveDelete(Object entity);
+	InternalStage<Void> reactiveDelete(Object entity);
 
-	CompletionStage<Void> reactiveUpdate(Object entity);
+	InternalStage<Void> reactiveUpdate(Object entity);
 
-	CompletionStage<Void> reactiveRefresh(Object entity);
+	InternalStage<Void> reactiveRefresh(Object entity);
 
-	CompletionStage<Void> reactiveRefresh(Object entity, LockMode lockMode);
+	InternalStage<Void> reactiveRefresh(Object entity, LockMode lockMode);
 
-	CompletionStage<Void> reactiveInsertAll(Object... entities);
+	InternalStage<Void> reactiveInsertAll(Object... entities);
 
-	CompletionStage<Void> reactiveInsertAll(int batchSize, Object... entities);
+	InternalStage<Void> reactiveInsertAll(int batchSize, Object... entities);
 
-	CompletionStage<Void> reactiveUpdateAll(Object... entities);
+	InternalStage<Void> reactiveUpdateAll(Object... entities);
 
-	CompletionStage<Void> reactiveUpdateAll(int batchSize, Object... entities);
+	InternalStage<Void> reactiveUpdateAll(int batchSize, Object... entities);
 
-	CompletionStage<Void> reactiveDeleteAll(Object... entities);
+	InternalStage<Void> reactiveDeleteAll(Object... entities);
 
-	CompletionStage<Void> reactiveDeleteAll(int batchSize, Object... entities);
+	InternalStage<Void> reactiveDeleteAll(int batchSize, Object... entities);
 
-	CompletionStage<Void> reactiveRefreshAll(Object... entities);
+	InternalStage<Void> reactiveRefreshAll(Object... entities);
 
-	CompletionStage<Void> reactiveRefreshAll(int batchSize, Object... entities);
+	InternalStage<Void> reactiveRefreshAll(int batchSize, Object... entities);
 
 	boolean isOpen();
 
-	void close(CompletableFuture<Void> closing);
+	void close(InternalStage<Void> closing);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryExtensions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryExtensions.java
@@ -1,4 +1,133 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
 package org.hibernate.reactive.session.impl;
 
-public class ReactiveSessionFactoryExtensions {
+import java.util.Objects;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.event.service.spi.EventListenerRegistry;
+import org.hibernate.event.spi.AutoFlushEventListener;
+import org.hibernate.event.spi.ClearEventListener;
+import org.hibernate.event.spi.DeleteEventListener;
+import org.hibernate.event.spi.DirtyCheckEventListener;
+import org.hibernate.event.spi.EventType;
+import org.hibernate.event.spi.EvictEventListener;
+import org.hibernate.event.spi.FlushEntityEventListener;
+import org.hibernate.event.spi.FlushEventListener;
+import org.hibernate.event.spi.InitializeCollectionEventListener;
+import org.hibernate.event.spi.LoadEventListener;
+import org.hibernate.event.spi.LockEventListener;
+import org.hibernate.event.spi.MergeEventListener;
+import org.hibernate.event.spi.PersistEventListener;
+import org.hibernate.event.spi.PostCollectionRecreateEventListener;
+import org.hibernate.event.spi.PostCollectionRemoveEventListener;
+import org.hibernate.event.spi.PostCollectionUpdateEventListener;
+import org.hibernate.event.spi.PostDeleteEventListener;
+import org.hibernate.event.spi.PostInsertEventListener;
+import org.hibernate.event.spi.PostLoadEventListener;
+import org.hibernate.event.spi.PostUpdateEventListener;
+import org.hibernate.event.spi.PreCollectionRecreateEventListener;
+import org.hibernate.event.spi.PreCollectionRemoveEventListener;
+import org.hibernate.event.spi.PreCollectionUpdateEventListener;
+import org.hibernate.event.spi.PreDeleteEventListener;
+import org.hibernate.event.spi.PreInsertEventListener;
+import org.hibernate.event.spi.PreLoadEventListener;
+import org.hibernate.event.spi.PreUpdateEventListener;
+import org.hibernate.event.spi.RefreshEventListener;
+import org.hibernate.event.spi.ReplicateEventListener;
+import org.hibernate.event.spi.ResolveNaturalIdEventListener;
+import org.hibernate.event.spi.SaveOrUpdateEventListener;
+import org.hibernate.reactive.event.ReactiveEventListenerGroup;
+import org.hibernate.reactive.event.impl.ReactiveEventListenerGroupAdaptor;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+public final class ReactiveSessionFactoryExtensions {
+
+	public final ReactiveEventListenerGroup<AutoFlushEventListener> eventListenerGroup_AUTO_FLUSH;
+	public final ReactiveEventListenerGroup<ClearEventListener> eventListenerGroup_CLEAR;
+	public final ReactiveEventListenerGroup<DeleteEventListener> eventListenerGroup_DELETE;
+	public final ReactiveEventListenerGroup<DirtyCheckEventListener> eventListenerGroup_DIRTY_CHECK;
+	public final ReactiveEventListenerGroup<EvictEventListener> eventListenerGroup_EVICT;
+	public final ReactiveEventListenerGroup<FlushEntityEventListener> eventListenerGroup_FLUSH_ENTITY;
+	public final ReactiveEventListenerGroup<FlushEventListener> eventListenerGroup_FLUSH;
+	public final ReactiveEventListenerGroup<InitializeCollectionEventListener> eventListenerGroup_INIT_COLLECTION;
+	public final ReactiveEventListenerGroup<LoadEventListener> eventListenerGroup_LOAD;
+	public final ReactiveEventListenerGroup<LockEventListener> eventListenerGroup_LOCK;
+	public final ReactiveEventListenerGroup<MergeEventListener> eventListenerGroup_MERGE;
+	public final ReactiveEventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST;
+	public final ReactiveEventListenerGroup<PersistEventListener> eventListenerGroup_PERSIST_ONFLUSH;
+	public final ReactiveEventListenerGroup<PostCollectionRecreateEventListener> eventListenerGroup_POST_COLLECTION_RECREATE;
+	public final ReactiveEventListenerGroup<PostCollectionRemoveEventListener> eventListenerGroup_POST_COLLECTION_REMOVE;
+	public final ReactiveEventListenerGroup<PostCollectionUpdateEventListener> eventListenerGroup_POST_COLLECTION_UPDATE;
+	public final ReactiveEventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_COMMIT_DELETE;
+	public final ReactiveEventListenerGroup<PostDeleteEventListener> eventListenerGroup_POST_DELETE;
+	public final ReactiveEventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_COMMIT_INSERT;
+	public final ReactiveEventListenerGroup<PostInsertEventListener> eventListenerGroup_POST_INSERT;
+	public final ReactiveEventListenerGroup<PostLoadEventListener> eventListenerGroup_POST_LOAD; //Frequently used by 2LC initialization:
+	public final ReactiveEventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_COMMIT_UPDATE;
+	public final ReactiveEventListenerGroup<PostUpdateEventListener> eventListenerGroup_POST_UPDATE;
+	public final ReactiveEventListenerGroup<PreCollectionRecreateEventListener> eventListenerGroup_PRE_COLLECTION_RECREATE;
+	public final ReactiveEventListenerGroup<PreCollectionRemoveEventListener> eventListenerGroup_PRE_COLLECTION_REMOVE;
+	public final ReactiveEventListenerGroup<PreCollectionUpdateEventListener> eventListenerGroup_PRE_COLLECTION_UPDATE;
+	public final ReactiveEventListenerGroup<PreDeleteEventListener> eventListenerGroup_PRE_DELETE;
+	public final ReactiveEventListenerGroup<PreInsertEventListener> eventListenerGroup_PRE_INSERT;
+	public final ReactiveEventListenerGroup<PreLoadEventListener> eventListenerGroup_PRE_LOAD;
+	public final ReactiveEventListenerGroup<PreUpdateEventListener> eventListenerGroup_PRE_UPDATE;
+	public final ReactiveEventListenerGroup<RefreshEventListener> eventListenerGroup_REFRESH;
+	public final ReactiveEventListenerGroup<ReplicateEventListener> eventListenerGroup_REPLICATE;
+	public final ReactiveEventListenerGroup<ResolveNaturalIdEventListener> eventListenerGroup_RESOLVE_NATURAL_ID;
+	public final ReactiveEventListenerGroup<SaveOrUpdateEventListener> eventListenerGroup_SAVE;
+	public final ReactiveEventListenerGroup<SaveOrUpdateEventListener> eventListenerGroup_SAVE_UPDATE;
+	public final ReactiveEventListenerGroup<SaveOrUpdateEventListener> eventListenerGroup_UPDATE;
+
+	public ReactiveSessionFactoryExtensions(SessionFactoryImplementor sessionFactory) {
+		Objects.requireNonNull( sessionFactory );
+		final ServiceRegistryImplementor serviceRegistry = sessionFactory.getServiceRegistry();
+		// Pre-compute all iterators on Event listeners:
+		final EventListenerRegistry eventListenerRegistry = serviceRegistry.getService( EventListenerRegistry.class );
+		this.eventListenerGroup_AUTO_FLUSH = listeners( eventListenerRegistry, EventType.AUTO_FLUSH );
+		this.eventListenerGroup_CLEAR = listeners( eventListenerRegistry, EventType.CLEAR );
+		this.eventListenerGroup_DELETE = listeners( eventListenerRegistry, EventType.DELETE );
+		this.eventListenerGroup_DIRTY_CHECK = listeners( eventListenerRegistry, EventType.DIRTY_CHECK );
+		this.eventListenerGroup_EVICT = listeners( eventListenerRegistry, EventType.EVICT );
+		this.eventListenerGroup_FLUSH = listeners( eventListenerRegistry, EventType.FLUSH );
+		this.eventListenerGroup_FLUSH_ENTITY = listeners( eventListenerRegistry, EventType.FLUSH_ENTITY );
+		this.eventListenerGroup_INIT_COLLECTION = listeners( eventListenerRegistry, EventType.INIT_COLLECTION );
+		this.eventListenerGroup_LOAD = listeners( eventListenerRegistry, EventType.LOAD );
+		this.eventListenerGroup_LOCK = listeners( eventListenerRegistry, EventType.LOCK );
+		this.eventListenerGroup_MERGE = listeners( eventListenerRegistry, EventType.MERGE );
+		this.eventListenerGroup_PERSIST = listeners( eventListenerRegistry, EventType.PERSIST );
+		this.eventListenerGroup_PERSIST_ONFLUSH = listeners( eventListenerRegistry, EventType.PERSIST_ONFLUSH );
+		this.eventListenerGroup_POST_COLLECTION_RECREATE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_RECREATE );
+		this.eventListenerGroup_POST_COLLECTION_REMOVE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_REMOVE );
+		this.eventListenerGroup_POST_COLLECTION_UPDATE = listeners( eventListenerRegistry, EventType.POST_COLLECTION_UPDATE );
+		this.eventListenerGroup_POST_COMMIT_DELETE = listeners( eventListenerRegistry, EventType.POST_COMMIT_DELETE );
+		this.eventListenerGroup_POST_COMMIT_INSERT = listeners( eventListenerRegistry, EventType.POST_COMMIT_INSERT );
+		this.eventListenerGroup_POST_COMMIT_UPDATE = listeners( eventListenerRegistry, EventType.POST_COMMIT_UPDATE );
+		this.eventListenerGroup_POST_DELETE = listeners( eventListenerRegistry, EventType.POST_DELETE );
+		this.eventListenerGroup_POST_INSERT = listeners( eventListenerRegistry, EventType.POST_INSERT );
+		this.eventListenerGroup_POST_LOAD = listeners( eventListenerRegistry, EventType.POST_LOAD );
+		this.eventListenerGroup_POST_UPDATE = listeners( eventListenerRegistry, EventType.POST_UPDATE );
+		this.eventListenerGroup_PRE_COLLECTION_RECREATE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_RECREATE );
+		this.eventListenerGroup_PRE_COLLECTION_REMOVE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_REMOVE );
+		this.eventListenerGroup_PRE_COLLECTION_UPDATE = listeners( eventListenerRegistry, EventType.PRE_COLLECTION_UPDATE );
+		this.eventListenerGroup_PRE_DELETE = listeners( eventListenerRegistry, EventType.PRE_DELETE );
+		this.eventListenerGroup_PRE_INSERT = listeners( eventListenerRegistry, EventType.PRE_INSERT );
+		this.eventListenerGroup_PRE_LOAD = listeners( eventListenerRegistry, EventType.PRE_LOAD );
+		this.eventListenerGroup_PRE_UPDATE = listeners( eventListenerRegistry, EventType.PRE_UPDATE );
+		this.eventListenerGroup_REFRESH = listeners( eventListenerRegistry, EventType.REFRESH );
+		this.eventListenerGroup_REPLICATE = listeners( eventListenerRegistry, EventType.REPLICATE );
+		this.eventListenerGroup_RESOLVE_NATURAL_ID = listeners( eventListenerRegistry, EventType.RESOLVE_NATURAL_ID );
+		this.eventListenerGroup_SAVE = listeners( eventListenerRegistry, EventType.SAVE );
+		this.eventListenerGroup_SAVE_UPDATE = listeners( eventListenerRegistry, EventType.SAVE_UPDATE );
+		this.eventListenerGroup_UPDATE = listeners( eventListenerRegistry, EventType.UPDATE );
+	}
+
+	private static <T> ReactiveEventListenerGroup<T> listeners(EventListenerRegistry elr, EventType<T> type) {
+		return new ReactiveEventListenerGroupAdaptor( elr.getEventListenerGroup( type ) );
+	}
+
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryExtensions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryExtensions.java
@@ -1,0 +1,4 @@
+package org.hibernate.reactive.session.impl;
+
+public class ReactiveSessionFactoryExtensions {
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/StandardReactiveJdbcMutationExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/StandardReactiveJdbcMutationExecutor.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.sql.exec.internal;
 import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -43,7 +43,7 @@ public class StandardReactiveJdbcMutationExecutor implements ReactiveJdbcMutatio
 	}
 
 	@Override
-	public CompletionStage<Integer> executeReactive(
+	public InternalStage<Integer> executeReactive(
 			JdbcOperationQueryMutation jdbcMutation,
 			JdbcParameterBindings jdbcParameterBindings,
 			Function<String, PreparedStatement> statementCreator,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/StandardReactiveSelectExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/StandardReactiveSelectExecutor.java
@@ -11,7 +11,7 @@ import java.sql.PreparedStatement;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 
@@ -67,7 +67,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 	private StandardReactiveSelectExecutor() {
 	}
 
-	public <R> CompletionStage<List<R>> list(
+	public <R> InternalStage<List<R>> list(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,
@@ -76,7 +76,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 		return list( jdbcSelect, jdbcParameterBindings, executionContext, rowTransformer, null, uniqueSemantic );
 	}
 
-	public <R> CompletionStage<List<R>> list(
+	public <R> InternalStage<List<R>> list(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,
@@ -97,7 +97,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 	}
 
 	@Override
-	public <T, R> CompletionStage<T> executeQuery(
+	public <T, R> InternalStage<T> executeQuery(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,
@@ -128,7 +128,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 				} );
 	}
 
-	private <T, R> CompletionStage<T> doExecuteQuery(
+	private <T, R> InternalStage<T> doExecuteQuery(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,
@@ -242,7 +242,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 		return rowTransformer;
 	}
 
-	public CompletionStage<ReactiveValuesResultSet> resolveJdbcValuesSource(String queryIdentifier, JdbcOperationQuerySelect jdbcSelect, boolean canBeCached, ExecutionContext executionContext, ReactiveResultSetAccess resultSetAccess) {
+	public InternalStage<ReactiveValuesResultSet> resolveJdbcValuesSource(String queryIdentifier, JdbcOperationQuerySelect jdbcSelect, boolean canBeCached, ExecutionContext executionContext, ReactiveResultSetAccess resultSetAccess) {
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 		final boolean queryCacheEnabled = factory.getSessionFactoryOptions().isQueryCacheEnabled();
@@ -332,7 +332,7 @@ public class StandardReactiveSelectExecutor implements ReactiveSelectExecutor {
 		else {
 			// If we need to put the values into the cache, we need to be able to capture the JdbcValuesMetadata
 			final CapturingJdbcValuesMetadata capturingMetadata = new CapturingJdbcValuesMetadata( resultSetAccess );
-			final CompletionStage<JdbcValuesMapping> stage;
+			final InternalStage<JdbcValuesMapping> stage;
 			if ( cachedResults.isEmpty() || !( cachedResults.get( 0 ) instanceof JdbcValuesMetadata ) ) {
 				stage = mappingProducer.reactiveResolve( resultSetAccess, session.getLoadQueryInfluencers(), factory );
 			}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveJdbcMutationExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveJdbcMutationExecutor.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.sql.exec.spi;
 
 import java.sql.PreparedStatement;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.Function;
 
@@ -19,7 +19,7 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
  */
 public interface ReactiveJdbcMutationExecutor {
 
-	CompletionStage<Integer> executeReactive(
+	InternalStage<Integer> executeReactive(
 			JdbcOperationQueryMutation jdbcMutation,
 			JdbcParameterBindings jdbcParameterBindings,
 			Function<String, PreparedStatement> statementCreator,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveRowProcessingState.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveRowProcessingState.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.sql.exec.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.query.spi.QueryOptions;
 import org.hibernate.reactive.logging.impl.Log;
@@ -52,7 +52,7 @@ public class ReactiveRowProcessingState extends BaseExecutionContext implements 
 		this.jdbcValues = jdbcValues;
 	}
 
-	public CompletionStage<Boolean> next() {
+	public InternalStage<Boolean> next() {
 		return jdbcValues.next();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveSelectExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveSelectExecutor.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.sql.exec.spi;
 
 import java.sql.PreparedStatement;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.reactive.sql.results.spi.ReactiveListResultsConsumer;
@@ -22,7 +22,7 @@ import org.hibernate.sql.results.spi.RowTransformer;
  */
 public interface ReactiveSelectExecutor {
 
-	<T, R> CompletionStage<T> executeQuery(
+	<T, R> InternalStage<T> executeQuery(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,
@@ -31,7 +31,7 @@ public interface ReactiveSelectExecutor {
 			Function<String, PreparedStatement> statementCreator,
 			ReactiveResultsConsumer<T, R> resultsConsumer);
 
-	<R> CompletionStage<List<R>> list(
+	<R> InternalStage<List<R>> list(
 			JdbcOperationQuerySelect jdbcSelect,
 			JdbcParameterBindings jdbcParameterBindings,
 			ExecutionContext executionContext,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveValuesResultSet.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/spi/ReactiveValuesResultSet.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.sql.exec.spi;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.cache.spi.QueryKey;
@@ -74,7 +74,7 @@ public class ReactiveValuesResultSet {
 		return new QueryCachePutManagerEnabledImpl( queryCache, factory.getStatistics(), queryCacheKey, queryIdentifier, metadataForCache );
 	}
 
-	public final CompletionStage<Boolean> next() {
+	public final InternalStage<Boolean> next() {
 		return processNext()
 				.thenApply( hadRow -> {
 					if ( hadRow ) {
@@ -84,14 +84,14 @@ public class ReactiveValuesResultSet {
 				} );
 	}
 
-	protected final CompletionStage<Boolean> processNext() {
+	protected final InternalStage<Boolean> processNext() {
 		return advance( () -> resultSetAccess
 				.getReactiveResultSet()
 				.thenCompose( this::doNext )
 		);
 	}
 
-	private CompletionStage<Boolean> doNext(ResultSet resultSet) {
+	private InternalStage<Boolean> doNext(ResultSet resultSet) {
 		try {
 			return completedFuture( resultSet.next() );
 		}
@@ -121,16 +121,16 @@ public class ReactiveValuesResultSet {
 
 	@FunctionalInterface
 	private interface Advancer {
-		CompletionStage<Boolean> advance();
+		InternalStage<Boolean> advance();
 	}
 
-	private CompletionStage<Boolean> advance(Advancer advancer) {
+	private InternalStage<Boolean> advance(Advancer advancer) {
 		return advancer
 				.advance()
 				.thenCompose( this::readCurrentRowValues );
 	}
 
-	private CompletionStage<Boolean> readCurrentRowValues(boolean hasResults) {
+	private InternalStage<Boolean> readCurrentRowValues(boolean hasResults) {
 		if ( !hasResults ) {
 			return falseFuture();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/ReactiveResultSetMapping.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/ReactiveResultSetMapping.java
@@ -9,7 +9,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -53,7 +53,7 @@ public class ReactiveResultSetMapping implements ResultSetMapping, ReactiveValue
 	}
 
 	@Override
-	public CompletionStage<JdbcValuesMapping> reactiveResolve(
+	public InternalStage<JdbcValuesMapping> reactiveResolve(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			LoadQueryInfluencers loadQueryInfluencers,
 			SessionFactoryImplementor sessionFactory) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/ReactiveDomainResultsAssembler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/ReactiveDomainResultsAssembler.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.graph;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.Incubating;
 import org.hibernate.reactive.logging.impl.Log;
@@ -32,14 +32,14 @@ public interface ReactiveDomainResultsAssembler<J> extends DomainResultAssembler
 				.nonReactiveMethodCall( "reactiveAssemble" );
 	}
 
-	CompletionStage<J> reactiveAssemble(
+	InternalStage<J> reactiveAssemble(
 			ReactiveRowProcessingState rowProcessingState,
 			JdbcValuesSourceProcessingOptions options);
 
 	/**
 	 * Convenience form of {@link #assemble(RowProcessingState, JdbcValuesSourceProcessingOptions)}
 	 */
-	default CompletionStage<J> reactiveAssemble(ReactiveRowProcessingState rowProcessingState) {
+	default InternalStage<J> reactiveAssemble(ReactiveRowProcessingState rowProcessingState) {
 		return reactiveAssemble(
 				rowProcessingState,
 				rowProcessingState.getJdbcValuesSourceProcessingState().getProcessingOptions()

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/ReactiveInitializer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/ReactiveInitializer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.graph;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.Incubating;
 import org.hibernate.reactive.sql.exec.spi.ReactiveRowProcessingState;
@@ -16,8 +16,8 @@ import org.hibernate.reactive.sql.exec.spi.ReactiveRowProcessingState;
 @Incubating
 public interface ReactiveInitializer {
 
-	CompletionStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState);
+	InternalStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState);
 
-	CompletionStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState);
+	InternalStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState);
 
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntityAssembler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntityAssembler.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.sql.results.graph.entity.internal;
 
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.reactive.sql.exec.spi.ReactiveRowProcessingState;
 import org.hibernate.reactive.sql.results.graph.ReactiveDomainResultsAssembler;
@@ -34,7 +34,7 @@ public class ReactiveEntityAssembler<T> implements ReactiveDomainResultsAssemble
 	}
 
 	@Override
-	public CompletionStage<T> reactiveAssemble(ReactiveRowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
+	public InternalStage<T> reactiveAssemble(ReactiveRowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
 		// Ensure that the instance really is initialized
 		// This is important for key-many-to-ones that are part of a collection key fk,
 		// as the instance is needed for resolveKey before initializing the instance in RowReader

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntityDelayedFetchInitializer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntityDelayedFetchInitializer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.graph.entity.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.bytecode.enhance.spi.LazyPropertyInitializer;
 import org.hibernate.engine.spi.EntityKey;
@@ -45,7 +45,7 @@ public class ReactiveEntityDelayedFetchInitializer extends EntityDelayedFetchIni
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState) {
 		if ( getEntityInstance() != null ) {
 			return voidFuture();
 		}
@@ -61,7 +61,7 @@ public class ReactiveEntityDelayedFetchInitializer extends EntityDelayedFetchIni
 
 		setIdentifier( getIdentifierAssembler().assemble( rowProcessingState ) );
 
-		CompletionStage<Void> stage = voidFuture();
+		InternalStage<Void> stage = voidFuture();
 		if ( getIdentifier() == null ) {
 			setEntityInstance( null );
 		}
@@ -156,7 +156,7 @@ public class ReactiveEntityDelayedFetchInitializer extends EntityDelayedFetchIni
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
 		return voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntitySelectFetchByUniqueKeyInitializer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntitySelectFetchByUniqueKeyInitializer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.graph.entity.internal;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.EntityUniqueKey;
 import org.hibernate.engine.spi.PersistenceContext;
@@ -40,7 +40,7 @@ public class ReactiveEntitySelectFetchByUniqueKeyInitializer extends ReactiveEnt
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
 		if ( entityInstance != null || isInitialized ) {
 			return voidFuture();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntitySelectFetchInitializer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/internal/ReactiveEntitySelectFetchInitializer.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.sql.results.graph.entity.internal;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.FetchNotFoundException;
 import org.hibernate.annotations.NotFoundAction;
@@ -76,13 +76,13 @@ public class ReactiveEntitySelectFetchInitializer extends EntitySelectFetchIniti
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> reactiveResolveInstance(ReactiveRowProcessingState rowProcessingState) {
 		NavigablePath[] np = { getNavigablePath().getParent() };
 		if ( np[0] == null ) {
 			return voidFuture();
 		}
 		return whileLoop( () -> {
-			CompletionStage<Void> loop = voidFuture();
+			InternalStage<Void> loop = voidFuture();
 			// Defer the select by default to the initialize phase
 			// We only need to select in this phase if this is part of an identifier or foreign key
 			if ( np[0] instanceof EntityIdentifierNavigablePath
@@ -98,7 +98,7 @@ public class ReactiveEntitySelectFetchInitializer extends EntitySelectFetchIniti
 	}
 
 	@Override
-	public CompletionStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> reactiveInitializeInstance(ReactiveRowProcessingState rowProcessingState) {
 		if ( getEntityInstance() != null || isEntityInitialized() ) {
 			return voidFuture();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveDeferredResultSetAccess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveDeferredResultSetAccess.java
@@ -10,7 +10,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import org.hibernate.HibernateException;
@@ -45,7 +45,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 
 	private final ExecutionContext executionContext;
 
-	private CompletionStage<ResultSet> resultSetStage;
+	private InternalStage<ResultSet> resultSetStage;
 
 
 	private Integer columnCount;
@@ -71,7 +71,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 	}
 
 	@Override
-	public CompletionStage<ResultSet> getReactiveResultSet() {
+	public InternalStage<ResultSet> getReactiveResultSet() {
 		if ( resultSetStage == null ) {
 			resultSetStage = executeQuery()
 					.thenApply( this::saveResultSet );
@@ -88,7 +88,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 		return columnCount;
 	}
 
-	public CompletionStage<Integer> getReactiveColumnCount() {
+	public InternalStage<Integer> getReactiveColumnCount() {
 		return getReactiveResultSet()
 				.thenApply( ReactiveDeferredResultSetAccess::columnCount )
 				.thenApply( this::saveColumnCount );
@@ -109,7 +109,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 		return super.resolveType( position, explicitJavaType, typeConfiguration );
 	}
 
-	public CompletionStage<JdbcValuesMetadata> resolveJdbcValueMetadata() {
+	public InternalStage<JdbcValuesMetadata> resolveJdbcValueMetadata() {
 		return getReactiveResultSet().thenApply( this::convertToMetadata );
 	}
 
@@ -118,7 +118,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 	}
 
 	@Override
-	public CompletionStage<ResultSetMetaData> getReactiveMetadata() {
+	public InternalStage<ResultSetMetaData> getReactiveMetadata() {
 		return getReactiveResultSet().thenApply( this::reactiveMetadata );
 	}
 
@@ -140,7 +140,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 		}
 	}
 
-	private CompletionStage<ResultSet> executeQuery() {
+	private InternalStage<ResultSet> executeQuery() {
 		final LogicalConnectionImplementor logicalConnection = getPersistenceContext().getJdbcCoordinator().getLogicalConnection();
 		return completedFuture( logicalConnection )
 				.thenCompose( lg -> {
@@ -199,7 +199,7 @@ public class ReactiveDeferredResultSetAccess extends DeferredResultSetAccess imp
 		return resultSet;
 	}
 
-	private CompletionStage<ResultSet> reactiveSkipRows(ResultSet resultSet) {
+	private InternalStage<ResultSet> reactiveSkipRows(ResultSet resultSet) {
 		try {
 			skipRows( resultSet );
 			return completedFuture( resultSet );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveDirectResultSetAccess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveDirectResultSetAccess.java
@@ -9,7 +9,7 @@ import java.lang.invoke.MethodHandles;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
@@ -64,22 +64,22 @@ public class ReactiveDirectResultSetAccess extends DirectResultSetAccess impleme
 	}
 
 	@Override
-	public CompletionStage<ResultSet> getReactiveResultSet() {
+	public InternalStage<ResultSet> getReactiveResultSet() {
 		return completedFuture( resultSet );
 	}
 
 	@Override
-	public CompletionStage<ResultSetMetaData> getReactiveMetadata() {
+	public InternalStage<ResultSetMetaData> getReactiveMetadata() {
 		return completedFuture( getMetaData() );
 	}
 
 	@Override
-	public CompletionStage<Integer> getReactiveColumnCount() {
+	public InternalStage<Integer> getReactiveColumnCount() {
 		return completedFuture( getColumnCount() );
 	}
 
 	@Override
-	public CompletionStage<JdbcValuesMetadata> resolveJdbcValueMetadata() {
+	public InternalStage<JdbcValuesMetadata> resolveJdbcValueMetadata() {
 		throw LOG.notYetImplemented();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveInitializersList.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveInitializersList.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.sql.results.internal;
 
 import java.util.ArrayList;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.reactive.sql.exec.spi.ReactiveRowProcessingState;
 import org.hibernate.reactive.sql.results.graph.ReactiveInitializer;
@@ -56,7 +56,7 @@ public final class ReactiveInitializersList {
 		}
 	}
 
-	public CompletionStage<Void> initializeInstance(final ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> initializeInstance(final ReactiveRowProcessingState rowProcessingState) {
 		return loop( initializers, initializer -> {
 			if ( initializer instanceof ReactiveInitializer ) {
 				return ( (ReactiveInitializer) initializer ).reactiveInitializeInstance( rowProcessingState );
@@ -80,7 +80,7 @@ public final class ReactiveInitializersList {
 		}
 	}
 
-	public CompletionStage<Void> resolveInstances(final ReactiveRowProcessingState rowProcessingState) {
+	public InternalStage<Void> resolveInstances(final ReactiveRowProcessingState rowProcessingState) {
 		return loop( sortedNonCollectionsFirst, initializer -> {
 			if ( initializer instanceof ReactiveInitializer ) {
 				return ( (ReactiveInitializer) initializer ).reactiveResolveInstance( rowProcessingState );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveResultSetAccess.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveResultSetAccess.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.sql.results.internal;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
@@ -26,11 +26,11 @@ import jakarta.persistence.EnumType;
  * @see org.hibernate.sql.results.jdbc.internal.ResultSetAccess
  */
 public interface ReactiveResultSetAccess extends JdbcValuesMetadata {
-	CompletionStage<ResultSet> getReactiveResultSet();
-	CompletionStage<ResultSetMetaData> getReactiveMetadata();
-	CompletionStage<Integer> getReactiveColumnCount();
+	InternalStage<ResultSet> getReactiveResultSet();
+	InternalStage<ResultSetMetaData> getReactiveMetadata();
+	InternalStage<Integer> getReactiveColumnCount();
 
-	CompletionStage<JdbcValuesMetadata> resolveJdbcValueMetadata();
+	InternalStage<JdbcValuesMetadata> resolveJdbcValueMetadata();
 
 	ResultSet getResultSet();
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardRowReader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardRowReader.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.sql.results.internal;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.internal.util.collections.ArrayHelper;
@@ -53,7 +53,7 @@ public class ReactiveStandardRowReader<R> implements ReactiveRowReader<R> {
 	}
 
 	@Override
-	public CompletionStage<R> reactiveReadRow(ReactiveRowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
+	public InternalStage<R> reactiveReadRow(ReactiveRowProcessingState rowProcessingState, JdbcValuesSourceProcessingOptions options) {
 		LOGGER.trace( "ReactiveStandardRowReader#readRow" );
 
 		return coordinateInitializers( rowProcessingState )
@@ -120,7 +120,7 @@ public class ReactiveStandardRowReader<R> implements ReactiveRowReader<R> {
 		initializers.finishUpRow( rowProcessingState );
 	}
 
-	private CompletionStage<Void> coordinateInitializers(ReactiveRowProcessingState rowProcessingState) {
+	private InternalStage<Void> coordinateInitializers(ReactiveRowProcessingState rowProcessingState) {
 		initializers.resolveKeys( rowProcessingState );
 		return initializers.resolveInstances( rowProcessingState )
 				.thenCompose( v -> initializers.initializeInstance( rowProcessingState ) );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardValuesMappingProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardValuesMappingProducer.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.sql.results.internal;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -42,7 +42,7 @@ public class ReactiveStandardValuesMappingProducer extends JdbcValuesMappingProd
 	}
 
 	@Override
-		public CompletionStage<JdbcValuesMapping> reactiveResolve(
+		public InternalStage<JdbcValuesMapping> reactiveResolve(
 				JdbcValuesMetadata jdbcResultsMetadata,
 				LoadQueryInfluencers loadQueryInfluencers,
 				SessionFactoryImplementor sessionFactory) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveListResultsConsumer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveListResultsConsumer.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Supplier;
 
 import org.hibernate.HibernateException;
@@ -75,7 +75,7 @@ public class ReactiveListResultsConsumer<R> implements ReactiveResultsConsumer<L
 	}
 
 	@Override
-	public CompletionStage<List<R>> consume(
+	public InternalStage<List<R>> consume(
 			ReactiveValuesResultSet jdbcValues,
 			SharedSessionContractImplementor session,
 			JdbcValuesSourceProcessingOptions processingOptions,
@@ -101,7 +101,7 @@ public class ReactiveListResultsConsumer<R> implements ReactiveResultsConsumer<L
 						? new EntityResult<>( domainResultJavaType )
 						: new Results<>( domainResultJavaType );
 
-		Supplier<CompletionStage<Void>> addToResultsSupplier = addToResultsSupplier( results, rowReader, rowProcessingState, processingOptions, isEntityResultType );
+		Supplier<InternalStage<Void>> addToResultsSupplier = addToResultsSupplier( results, rowReader, rowProcessingState, processingOptions, isEntityResultType );
 		return whileLoop( () -> rowProcessingState.next()
 					.thenCompose( hasNext -> {
 						if ( hasNext ) {
@@ -121,7 +121,7 @@ public class ReactiveListResultsConsumer<R> implements ReactiveResultsConsumer<L
 		} );
 	}
 
-	private Supplier<CompletionStage<Void>> addToResultsSupplier(
+	private Supplier<InternalStage<Void>> addToResultsSupplier(
 			ReactiveListResultsConsumer.Results<R> results,
 			ReactiveRowReader<R> rowReader,
 			ReactiveRowProcessingState rowProcessingState,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveResultsConsumer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveResultsConsumer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.spi;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.reactive.sql.exec.spi.ReactiveRowProcessingState;
@@ -15,7 +15,7 @@ import org.hibernate.sql.results.jdbc.spi.JdbcValuesSourceProcessingOptions;
 
 public interface ReactiveResultsConsumer<T, R> {
 
-	CompletionStage<T> consume(
+	InternalStage<T> consume(
 			ReactiveValuesResultSet jdbcValues,
 			SharedSessionContractImplementor session,
 			JdbcValuesSourceProcessingOptions processingOptions,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveRowReader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveRowReader.java
@@ -6,7 +6,7 @@
 package org.hibernate.reactive.sql.results.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
@@ -20,7 +20,7 @@ public interface ReactiveRowReader<R> extends RowReader<R> {
 
 	Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
-	CompletionStage<R> reactiveReadRow(ReactiveRowProcessingState processingState, JdbcValuesSourceProcessingOptions options);
+	InternalStage<R> reactiveReadRow(ReactiveRowProcessingState processingState, JdbcValuesSourceProcessingOptions options);
 
 	@Override
 	default InitializersList getInitializersList() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveValuesMappingProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/spi/ReactiveValuesMappingProducer.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.sql.results.spi;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
@@ -17,7 +17,7 @@ import org.hibernate.sql.results.jdbc.spi.JdbcValuesMetadata;
  */
 public interface ReactiveValuesMappingProducer {
 
-	CompletionStage<JdbcValuesMapping> reactiveResolve(
+	InternalStage<JdbcValuesMapping> reactiveResolve(
 			JdbcValuesMetadata jdbcResultsMetadata,
 			LoadQueryInfluencers loadQueryInfluencers,
 			SessionFactoryImplementor sessionFactory);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -7,7 +7,7 @@ package org.hibernate.reactive.stage;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
@@ -167,7 +167,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.Query#getSingleResult()
 		 */
-		CompletionStage<R> getSingleResult();
+		InternalStage<R> getSingleResult();
 
 		/**
 		 * Asynchronously execute this query, returning a single row that
@@ -181,7 +181,7 @@ public interface Stage {
 		 *
 		 * @see #getSingleResult()
 		 */
-		CompletionStage<R> getSingleResultOrNull();
+		InternalStage<R> getSingleResultOrNull();
 
 		/**
 		 * Asynchronously execute this query, returning the query results
@@ -193,7 +193,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.Query#getResultList()
 		 */
-		CompletionStage<List<R>> getResultList();
+		InternalStage<List<R>> getResultList();
 
 		/**
 		 * Set the read-only/modifiable mode for entities and proxies
@@ -371,7 +371,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.Query#executeUpdate()
 		 */
-		CompletionStage<Integer> executeUpdate();
+		InternalStage<Integer> executeUpdate();
 
 		@Override
 		MutationQuery setParameter(int parameter, Object argument);
@@ -503,7 +503,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#find(Class, Object)
 		 */
-		<T> CompletionStage<T> find(Class<T> entityClass, Object id);
+		<T> InternalStage<T> find(Class<T> entityClass, Object id);
 
 		/**
 		 * Asynchronously return the persistent instance of the given entity
@@ -518,7 +518,7 @@ public interface Stage {
 		 * @see #find(Class,Object)
 		 * @see #lock(Object, LockMode) this discussion of lock modes
 		 */
-		<T> CompletionStage<T> find(Class<T> entityClass, Object id, LockMode lockMode);
+		<T> InternalStage<T> find(Class<T> entityClass, Object id, LockMode lockMode);
 
 		/**
 		 * Asynchronously return the persistent instance of the given entity
@@ -533,7 +533,7 @@ public interface Stage {
 		 * @see #find(Class,Object)
 		 * @see #lock(Object, LockMode) this discussion of lock modes
 		 */
-		default <T> CompletionStage<T> find(Class<T> entityClass, Object id, LockModeType lockModeType) {
+		default <T> InternalStage<T> find(Class<T> entityClass, Object id, LockModeType lockModeType) {
 			return find( entityClass, id, convertToLockMode(lockModeType) );
 		}
 
@@ -550,7 +550,7 @@ public interface Stage {
 //		 * @see #find(Class,Object)
 //		 * @see #lock(Object, LockMode) this discussion of lock modes
 //		 */
-//		<T> CompletionStage<T> find(Class<T> entityClass, Object id, LockOptions lockOptions);
+//		<T> InternalStage<T> find(Class<T> entityClass, Object id, LockOptions lockOptions);
 
 		 /**
 		 * Asynchronously return the persistent instance with the given
@@ -563,7 +563,7 @@ public interface Stage {
 		 *
 		 * @see #find(Class,Object)
 		 */
-		<T> CompletionStage<T> find(EntityGraph<T> entityGraph, Object id);
+		<T> InternalStage<T> find(EntityGraph<T> entityGraph, Object id);
 
 		/**
 		 * Asynchronously return the persistent instances of the given entity
@@ -575,7 +575,7 @@ public interface Stage {
 		 *
 		 * @return a list of persistent instances and nulls via a {@code CompletionStage}
 		 */
-		<T> CompletionStage<List<T>> find(Class<T> entityClass, Object... ids);
+		<T> InternalStage<List<T>> find(Class<T> entityClass, Object... ids);
 
 		/**
 		 * Asynchronously return the persistent instance of the given entity
@@ -588,7 +588,7 @@ public interface Stage {
 		 * @return a persistent instance or null via a {@code CompletionStage}
 		 */
 		@Incubating
-		<T> CompletionStage<T> find(Class<T> entityClass, Identifier<T> naturalId);
+		<T> InternalStage<T> find(Class<T> entityClass, Identifier<T> naturalId);
 
 		/**
 		 * Return the persistent instance of the given entity class with the
@@ -640,14 +640,14 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#persist(Object)
 		 */
-		CompletionStage<Void> persist(Object entity);
+		InternalStage<Void> persist(Object entity);
 
 		/**
 		 * Persist multiple transient entity instances at once.
 		 *
 		 * @see #persist(Object)
 		 */
-		CompletionStage<Void> persist(Object... entities);
+		InternalStage<Void> persist(Object... entities);
 
 		/**
 		 * Asynchronously remove a persistent instance from the datastore. The
@@ -668,14 +668,14 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#remove(Object)
 		 */
-		CompletionStage<Void> remove(Object entity);
+		InternalStage<Void> remove(Object entity);
 
 		/**
 		 * Remove multiple entity instances at once.
 		 *
 		 * @see #remove(Object)
 		 */
-		CompletionStage<Void> remove(Object... entities);
+		InternalStage<Void> remove(Object... entities);
 
 		/**
 		 * Copy the state of the given object onto the persistent instance with
@@ -694,14 +694,14 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#merge(Object)
 		 */
-		<T> CompletionStage<T> merge(T entity);
+		<T> InternalStage<T> merge(T entity);
 
 		/**
 		 * Merge multiple entity instances at once.
 		 *
 		 * @see #merge(Object)
 		 */
-		CompletionStage<Void> merge(Object... entities);
+		InternalStage<Void> merge(Object... entities);
 
 		/**
 		 * Re-read the state of the given instance from the underlying database.
@@ -721,7 +721,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#refresh(Object)
 		 */
-		CompletionStage<Void> refresh(Object entity);
+		InternalStage<Void> refresh(Object entity);
 
 		/**
 		 * Re-read the state of the given instance from the underlying database,
@@ -732,7 +732,7 @@ public interface Stage {
 		 *
 		 * @see #refresh(Object)
 		 */
-		CompletionStage<Void> refresh(Object entity, LockMode lockMode);
+		InternalStage<Void> refresh(Object entity, LockMode lockMode);
 
 		/**
 		 * Re-read the state of the given instance from the underlying database,
@@ -743,7 +743,7 @@ public interface Stage {
 		 *
 		 * @see #refresh(Object)
 		 */
-		default CompletionStage<Void> refresh(Object entity, LockModeType lockModeType) {
+		default InternalStage<Void> refresh(Object entity, LockModeType lockModeType) {
 			return refresh( entity, convertToLockMode(lockModeType) );
 		}
 
@@ -756,14 +756,14 @@ public interface Stage {
 //		 *
 //		 * @see #refresh(Object)
 //		 */
-//		CompletionStage<Void> refresh(Object entity, LockOptions lockOptions);
+//		InternalStage<Void> refresh(Object entity, LockOptions lockOptions);
 
 		/**
 		 * Refresh multiple entity instances at once.
 		 *
 		 * @see #refresh(Object)
 		 */
-		CompletionStage<Void> refresh(Object... entities);
+		InternalStage<Void> refresh(Object... entities);
 
 		/**
 		 * Obtain the specified lock level upon the given object. For example,
@@ -787,7 +787,7 @@ public interface Stage {
 		 *
 		 * @throws IllegalArgumentException if the given instance is not managed
 		 */
-		CompletionStage<Void> lock(Object entity, LockMode lockMode);
+		InternalStage<Void> lock(Object entity, LockMode lockMode);
 
 		/**
 		 * Obtain the specified lock level upon the given object. For example,
@@ -811,7 +811,7 @@ public interface Stage {
 		 *
 		 * @throws IllegalArgumentException if the given instance is not managed
 		 */
-		default CompletionStage<Void> lock(Object entity, LockModeType lockModeType) {
+		default InternalStage<Void> lock(Object entity, LockModeType lockModeType) {
 			return lock( entity, convertToLockMode(lockModeType) );
 		}
 
@@ -824,7 +824,7 @@ public interface Stage {
 //		 *
 //		 * @throws IllegalArgumentException if the given instance is not managed
 //		 */
-//		CompletionStage<Void> lock(Object entity, LockOptions lockOptions);
+//		InternalStage<Void> lock(Object entity, LockOptions lockOptions);
 
 		/**
 		 * Force this session to flush asynchronously. Must be called at the
@@ -838,7 +838,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#flush()
 		 */
-		CompletionStage<Void> flush();
+		InternalStage<Void> flush();
 
 		/**
 		 * Asynchronously fetch an association that's configured for lazy loading.
@@ -854,7 +854,7 @@ public interface Stage {
 		 * @see Stage#fetch(Object)
 		 * @see org.hibernate.Hibernate#initialize(Object)
 		 */
-		<T> CompletionStage<T> fetch(T association);
+		<T> InternalStage<T> fetch(T association);
 
 		/**
 		 * Fetch a lazy property of the given entity, identified by a JPA
@@ -865,7 +865,7 @@ public interface Stage {
 		 * {@code session.fetch(book, Book_.isbn).thenAccept(isbn -> print(isbn))}
 		 * </pre>
 		 */
-		<E,T> CompletionStage<T> fetch(E entity, Attribute<E,T> field);
+		<E,T> InternalStage<T> fetch(E entity, Attribute<E,T> field);
 
 		/**
 		 * Asynchronously fetch an association that's configured for lazy loading,
@@ -881,7 +881,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.Hibernate#unproxy(Object)
 		 */
-		<T> CompletionStage<T> unproxy(T association);
+		<T> InternalStage<T> unproxy(T association);
 
 		/**
 		 * Determine the current lock mode of the given entity.
@@ -1372,7 +1372,7 @@ public interface Stage {
 		 *
 		 * @see SessionFactory#withTransaction(BiFunction)
 		 */
-		<T> CompletionStage<T> withTransaction(Function<Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withTransaction(Function<Transaction, InternalStage<T>> work);
 
 		/**
 		 * Obtain the transaction currently associated with this session,
@@ -1439,7 +1439,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#get(Class, Object)
 		 */
-		<T> CompletionStage<T> get(Class<T> entityClass, Object id);
+		<T> InternalStage<T> get(Class<T> entityClass, Object id);
 
 		/**
 		 * Retrieve a row, obtaining the specified lock mode.
@@ -1452,7 +1452,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#get(Class, Object, LockMode)
 		 */
-		<T> CompletionStage<T> get(Class<T> entityClass, Object id, LockMode lockMode);
+		<T> InternalStage<T> get(Class<T> entityClass, Object id, LockMode lockMode);
 
 		/**
 		 * Retrieve a row, obtaining the specified lock mode.
@@ -1465,7 +1465,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#get(Class, Object, LockMode)
 		 */
-		default <T> CompletionStage<T> get(Class<T> entityClass, Object id, LockModeType lockModeType) {
+		default <T> InternalStage<T> get(Class<T> entityClass, Object id, LockModeType lockModeType) {
 			return get( entityClass, id, convertToLockMode(lockModeType) );
 		}
 
@@ -1478,7 +1478,7 @@ public interface Stage {
 		 *
 		 * @return a detached entity instance, via a {@code CompletionStage}
 		 */
-		<T> CompletionStage<T> get(EntityGraph<T> entityGraph, Object id);
+		<T> InternalStage<T> get(EntityGraph<T> entityGraph, Object id);
 
 		/**
 		 * Create an instance of {@link Query} for the given HQL/JPQL query
@@ -1598,7 +1598,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#insert(Object)
 		 */
-		CompletionStage<Void> insert(Object entity);
+		InternalStage<Void> insert(Object entity);
 
 		/**
 		 * Insert multiple rows.
@@ -1607,7 +1607,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#insert(Object)
 		 */
-		CompletionStage<Void> insert(Object... entities);
+		InternalStage<Void> insert(Object... entities);
 
 		/**
 		 * Insert multiple rows.
@@ -1617,7 +1617,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#insert(Object)
 		 */
-		CompletionStage<Void> insert(int batchSize, Object... entities);
+		InternalStage<Void> insert(int batchSize, Object... entities);
 
 		/**
 		 * Delete a row.
@@ -1626,7 +1626,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#delete(Object)
 		 */
-		CompletionStage<Void> delete(Object entity);
+		InternalStage<Void> delete(Object entity);
 
 		/**
 		 * Delete multiple rows.
@@ -1635,7 +1635,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#delete(Object)
 		 */
-		CompletionStage<Void> delete(Object... entities);
+		InternalStage<Void> delete(Object... entities);
 
 		/**
 		 * Delete multiple rows.
@@ -1645,7 +1645,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#delete(Object)
 		 */
-		CompletionStage<Void> delete(int batchSize, Object... entities);
+		InternalStage<Void> delete(int batchSize, Object... entities);
 
 		/**
 		 * Update a row.
@@ -1654,7 +1654,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#update(Object)
 		 */
-		CompletionStage<Void> update(Object entity);
+		InternalStage<Void> update(Object entity);
 
 		/**
 		 * Update multiple rows.
@@ -1663,7 +1663,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#update(Object)
 		 */
-		CompletionStage<Void> update(Object... entities);
+		InternalStage<Void> update(Object... entities);
 
 		/**
 		 * Update multiple rows.
@@ -1673,7 +1673,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#update(Object)
 		 */
-		CompletionStage<Void> update(int batchSize, Object... entities);
+		InternalStage<Void> update(int batchSize, Object... entities);
 
 		/**
 		 * Refresh the entity instance state from the database.
@@ -1682,7 +1682,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#refresh(Object)
 		 */
-		CompletionStage<Void> refresh(Object entity);
+		InternalStage<Void> refresh(Object entity);
 
 		/**
 		 * Refresh the entity instance state from the database.
@@ -1691,7 +1691,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#refresh(Object)
 		 */
-		CompletionStage<Void> refresh(Object... entities);
+		InternalStage<Void> refresh(Object... entities);
 
 		/**
 		 * Refresh the entity instance state from the database.
@@ -1701,7 +1701,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#refresh(Object)
 		 */
-		CompletionStage<Void> refresh(int batchSize, Object... entities);
+		InternalStage<Void> refresh(int batchSize, Object... entities);
 
 		/**
 		 * Refresh the entity instance state from the database.
@@ -1711,7 +1711,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#refresh(Object, LockMode)
 		 */
-		CompletionStage<Void> refresh(Object entity, LockMode lockMode);
+		InternalStage<Void> refresh(Object entity, LockMode lockMode);
 
 		/**
 		 * Refresh the entity instance state from the database.
@@ -1721,7 +1721,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.StatelessSession#refresh(Object, LockMode)
 		 */
-		default CompletionStage<Void> refresh(Object entity, LockModeType lockModeType) {
+		default InternalStage<Void> refresh(Object entity, LockModeType lockModeType) {
 			return refresh( entity, convertToLockMode(lockModeType) );
 		}
 
@@ -1741,7 +1741,7 @@ public interface Stage {
 		 *
 		 * @see org.hibernate.Hibernate#initialize(Object)
 		 */
-		<T> CompletionStage<T> fetch(T association);
+		<T> InternalStage<T> fetch(T association);
 
 		/**
 		 * Obtain a native SQL result set mapping defined via the annotation
@@ -1783,7 +1783,7 @@ public interface Stage {
 		 *
 		 * @see SessionFactory#withTransaction(BiFunction)
 		 */
-		<T> CompletionStage<T> withTransaction(Function<Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withTransaction(Function<Transaction, InternalStage<T>> work);
 
 		/**
 		 * Obtain the transaction currently associated with this session,
@@ -1806,7 +1806,7 @@ public interface Stage {
 		 * Close the reactive session and release the underlying database
 		 * connection.
 		 */
-		CompletionStage<Void> close();
+		InternalStage<Void> close();
 
 		/**
 		 * The {@link SessionFactory} which created this session.
@@ -1875,7 +1875,7 @@ public interface Stage {
 		 *
 		 * @see #withSession(Function)
 		 */
-		CompletionStage<Session> openSession();
+		InternalStage<Session> openSession();
 
 		/**
 		 * Obtain a new {@link Session reactive session} {@link CompletionStage} for a
@@ -1890,7 +1890,7 @@ public interface Stage {
 		 *
 		 * @see #withSession(Function)
 		 */
-		CompletionStage<Session> openSession(String tenantId);
+		InternalStage<Session> openSession(String tenantId);
 
 		/**
 		 * Obtain a {@link StatelessSession reactive stateless session}
@@ -1901,7 +1901,7 @@ public interface Stage {
 		 * The client must explicitly close the session by calling
 		 * {@link StatelessSession#close()}.
 		 */
-		CompletionStage<StatelessSession> openStatelessSession();
+		InternalStage<StatelessSession> openStatelessSession();
 
 		/**
 		 * Obtain a {@link StatelessSession reactive stateless session}
@@ -1914,7 +1914,7 @@ public interface Stage {
 		 *
 		 * @param tenantId the id of the tenant
 		 */
-		CompletionStage<StatelessSession> openStatelessSession(String tenantId);
+		InternalStage<StatelessSession> openStatelessSession(String tenantId);
 
 		/**
 		 * Perform work using a {@link Session reactive session}.
@@ -1933,7 +1933,7 @@ public interface Stage {
 		 * @param work a function which accepts the session and returns
 		 *             the result of the work as a {@link CompletionStage}.
 		 */
-		<T> CompletionStage<T> withSession(Function<Session, CompletionStage<T>> work);
+		<T> InternalStage<T> withSession(Function<Session, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link Session reactive session} for a
@@ -1953,7 +1953,7 @@ public interface Stage {
 		 * @param work a function which accepts the session and returns
 		 *             the result of the work as a {@link CompletionStage}.
 		 */
-		<T> CompletionStage<T> withSession(String tenantId, Function<Session, CompletionStage<T>> work);
+		<T> InternalStage<T> withSession(String tenantId, Function<Session, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link Session reactive session} within an
@@ -1977,7 +1977,7 @@ public interface Stage {
 		 * @see #withSession(Function)
 		 * @see Session#withTransaction(Function)
 		 */
-		<T> CompletionStage<T> withTransaction(BiFunction<Session, Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withTransaction(BiFunction<Session, Transaction, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link Session reactive session} within an
@@ -2000,7 +2000,7 @@ public interface Stage {
 		 * @see #withTransaction(BiFunction)
 		 * @see Session#withTransaction(Function)
 		 */
-		default <T> CompletionStage<T> withTransaction(Function<Session, CompletionStage<T>> work) {
+		default <T> InternalStage<T> withTransaction(Function<Session, InternalStage<T>> work) {
 			return withTransaction( (session, transaction) -> work.apply( session ) );
 		}
 
@@ -2026,7 +2026,7 @@ public interface Stage {
 		 * @see #withSession(String, Function)
 		 * @see Session#withTransaction(Function)
 		 */
-		<T> CompletionStage<T> withTransaction(String tenantId, BiFunction<Session, Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withTransaction(String tenantId, BiFunction<Session, Transaction, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link StatelessSession reactive session} within an
@@ -2048,7 +2048,7 @@ public interface Stage {
 		 * @see #withStatelessSession(Function)
 		 * @see StatelessSession#withTransaction(Function)
 		 */
-		default <T> CompletionStage<T> withStatelessTransaction(Function<StatelessSession, CompletionStage<T>> work) {
+		default <T> InternalStage<T> withStatelessTransaction(Function<StatelessSession, InternalStage<T>> work) {
 			return withStatelessTransaction( ( (statelessSession, transaction) -> work.apply( statelessSession ) ) );
 		}
 
@@ -2072,7 +2072,7 @@ public interface Stage {
 		 * @see #withStatelessSession(Function)
 		 * @see StatelessSession#withTransaction(Function)
 		 */
-		<T> CompletionStage<T> withStatelessTransaction(BiFunction<StatelessSession, Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withStatelessTransaction(BiFunction<StatelessSession, Transaction, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link StatelessSession reactive session} within an
@@ -2095,7 +2095,7 @@ public interface Stage {
 		 * @see #withStatelessSession(String, Function)
 		 * @see StatelessSession#withTransaction(Function)
 		 */
-		<T> CompletionStage<T> withStatelessTransaction(String tenantId, BiFunction<StatelessSession, Transaction, CompletionStage<T>> work);
+		<T> InternalStage<T> withStatelessTransaction(String tenantId, BiFunction<StatelessSession, Transaction, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link StatelessSession stateless session}.
@@ -2113,7 +2113,7 @@ public interface Stage {
 		 * @param work a function which accepts the session and returns
 		 *             the result of the work as a {@link CompletionStage}.
 		 */
-		<T> CompletionStage<T> withStatelessSession(Function<StatelessSession, CompletionStage<T>> work);
+		<T> InternalStage<T> withStatelessSession(Function<StatelessSession, InternalStage<T>> work);
 
 		/**
 		 * Perform work using a {@link StatelessSession stateless session}.
@@ -2132,7 +2132,7 @@ public interface Stage {
 		 * @param work a function which accepts the session and returns
 		 *             the result of the work as a {@link CompletionStage}.
 		 */
-		<T> CompletionStage<T> withStatelessSession(String tenantId, Function<StatelessSession, CompletionStage<T>> work);
+		<T> InternalStage<T> withStatelessSession(String tenantId, Function<StatelessSession, InternalStage<T>> work);
 
 		/**
 		 * @return an instance of {@link CriteriaBuilder} for creating
@@ -2173,7 +2173,7 @@ public interface Stage {
 	 * An object whose {@link #close()} method returns a {@link CompletionStage}.
 	 */
 	interface Closeable {
-		CompletionStage<Void> close();
+		InternalStage<Void> close();
 	}
 
 	/**
@@ -2189,7 +2189,7 @@ public interface Stage {
 	 *
 	 * @see org.hibernate.Hibernate#initialize(Object)
 	 */
-	static <T> CompletionStage<T> fetch(T association) {
+	static <T> InternalStage<T> fetch(T association) {
 		if ( association == null ) {
 			return CompletionStages.nullFuture();
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageMutationQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageMutationQueryImpl.java
@@ -9,7 +9,7 @@ import jakarta.persistence.Parameter;
 import org.hibernate.reactive.query.ReactiveMutationQuery;
 import org.hibernate.reactive.stage.Stage.MutationQuery;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 public class StageMutationQueryImpl<T> implements MutationQuery {
 
@@ -20,7 +20,7 @@ public class StageMutationQueryImpl<T> implements MutationQuery {
 	}
 
 	@Override
-	public CompletionStage<Integer> executeUpdate() {
+	public InternalStage<Integer> executeUpdate() {
 		return delegate.executeReactiveUpdate();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -20,7 +20,7 @@ import org.hibernate.reactive.query.ReactiveQuery;
 import org.hibernate.reactive.stage.Stage.Query;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 public class StageQueryImpl<R> implements Query<R> {
 	private final ReactiveQuery<R> delegate;
@@ -35,7 +35,7 @@ public class StageQueryImpl<R> implements Query<R> {
 	}
 
 	@Override
-	public CompletionStage<List<R>> getResultList() {
+	public InternalStage<List<R>> getResultList() {
 		return delegate.getReactiveResultList();
 	}
 
@@ -63,12 +63,12 @@ public class StageQueryImpl<R> implements Query<R> {
 	}
 
 	@Override
-	public CompletionStage<R> getSingleResult() {
+	public InternalStage<R> getSingleResult() {
 		return delegate.getReactiveSingleResult();
 	}
 
 	@Override
-	public CompletionStage<R> getSingleResultOrNull() {
+	public InternalStage<R> getSingleResultOrNull() {
 		return delegate.getReactiveSingleResultOrNull();
 	}
 
@@ -203,7 +203,7 @@ public class StageQueryImpl<R> implements Query<R> {
 	}
 
 	@Override
-	public CompletionStage<Integer> executeUpdate() {
+	public InternalStage<Integer> executeUpdate() {
 		return delegate.executeReactiveUpdate();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
@@ -20,7 +20,7 @@ import org.hibernate.reactive.query.ReactiveSelectionQuery;
 import org.hibernate.reactive.stage.Stage.SelectionQuery;
 
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	private final ReactiveSelectionQuery<T> delegate;
@@ -35,7 +35,7 @@ public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	}
 
 	@Override
-	public CompletionStage<List<T>> getResultList() {
+	public InternalStage<List<T>> getResultList() {
 		return delegate.getReactiveResultList();
 	}
 
@@ -63,12 +63,12 @@ public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	}
 
 	@Override
-	public CompletionStage<T> getSingleResult() {
+	public InternalStage<T> getSingleResult() {
 		return delegate.getReactiveSingleResult();
 	}
 
 	@Override
-	public CompletionStage<T> getSingleResultOrNull() {
+	public InternalStage<T> getSingleResultOrNull() {
 		return delegate.getReactiveSingleResultOrNull();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -40,7 +40,7 @@ import org.hibernate.reactive.stage.Stage.SelectionQuery;
 
 import java.lang.invoke.MethodHandles;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import java.util.function.Function;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.applyToAll;
@@ -61,23 +61,23 @@ public class StageSessionImpl implements Stage.Session {
 		this.delegate = session;
 	}
 	@Override
-	public CompletionStage<Void> flush() {
+	public InternalStage<Void> flush() {
 //		checkOpen();
 		return delegate.reactiveFlush();
 	}
 
 	@Override
-	public <T> CompletionStage<T> fetch(T association) {
+	public <T> InternalStage<T> fetch(T association) {
 		return delegate.reactiveFetch( association, false );
 	}
 
 	@Override
-	public <E,T> CompletionStage<T> fetch(E entity, Attribute<E,T> field) {
+	public <E,T> InternalStage<T> fetch(E entity, Attribute<E,T> field) {
 		return delegate.reactiveFetch( entity, field );
 	}
 
 	@Override
-	public <T> CompletionStage<T> unproxy(T association) {
+	public <T> InternalStage<T> unproxy(T association) {
 		return delegate.reactiveFetch( association, true );
 	}
 
@@ -118,109 +118,109 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
-	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey) {
+	public <T> InternalStage<T> find(Class<T> entityClass, Object primaryKey) {
 		return delegate.reactiveFind( entityClass, primaryKey, null, null );
 	}
 
 	@Override
-	public <T> CompletionStage<List<T>> find(Class<T> entityClass, Object... ids) {
+	public <T> InternalStage<List<T>> find(Class<T> entityClass, Object... ids) {
 		return delegate.reactiveFind( entityClass, ids );
 	}
 
 	@Override
-	public <T> CompletionStage<T> find(Class<T> entityClass, Identifier<T> id) {
+	public <T> InternalStage<T> find(Class<T> entityClass, Identifier<T> id) {
 		return delegate.reactiveFind( entityClass, id.namedValues() );
 	}
 
 	@Override
-	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey, LockMode lockMode) {
+	public <T> InternalStage<T> find(Class<T> entityClass, Object primaryKey, LockMode lockMode) {
 		return delegate.reactiveFind( entityClass, primaryKey, new LockOptions( lockMode ), null );
 	}
 
 	@Override
-	public <T> CompletionStage<T> find(Class<T> entityClass, Object id, LockModeType lockModeType) {
+	public <T> InternalStage<T> find(Class<T> entityClass, Object id, LockModeType lockModeType) {
 		return find( entityClass, id, LockModeTypeHelper.getLockMode( lockModeType ) );
 	}
 
 	// FIXME: Should I delete this?
 //	@Override
-	public <T> CompletionStage<T> find(Class<T> entityClass, Object primaryKey, LockOptions lockOptions) {
+	public <T> InternalStage<T> find(Class<T> entityClass, Object primaryKey, LockOptions lockOptions) {
 		return delegate.reactiveFind( entityClass, primaryKey, lockOptions, null );
 	}
 
 	@Override
-	public <T> CompletionStage<T> find(EntityGraph<T> entityGraph, Object id) {
+	public <T> InternalStage<T> find(EntityGraph<T> entityGraph, Object id) {
 		Class<T> entityClass = ( (RootGraph<T>) entityGraph ).getGraphedType().getJavaType();
 		return delegate.reactiveFind( entityClass, id, null, entityGraph );
 	}
 
 	@Override
-	public CompletionStage<Void> persist(Object entity) {
+	public InternalStage<Void> persist(Object entity) {
 		return delegate.reactivePersist( entity );
 	}
 
 	@Override
-	public CompletionStage<Void> persist(Object... entity) {
+	public InternalStage<Void> persist(Object... entity) {
 		return applyToAll( delegate::reactivePersist, entity );
 	}
 
 	@Override
-	public CompletionStage<Void> remove(Object entity) {
+	public InternalStage<Void> remove(Object entity) {
 		return delegate.reactiveRemove( entity );
 	}
 
 	@Override
-	public CompletionStage<Void> remove(Object... entity) {
+	public InternalStage<Void> remove(Object... entity) {
 		return applyToAll( delegate::reactiveRemove, entity );
 	}
 
 	@Override
-	public <T> CompletionStage<T> merge(T entity) {
+	public <T> InternalStage<T> merge(T entity) {
 		return delegate.reactiveMerge( entity );
 	}
 
 	@Override
-	public final CompletionStage<Void> merge(Object... entity) {
+	public final InternalStage<Void> merge(Object... entity) {
 		return applyToAll( delegate::reactiveMerge, entity );
 	}
 
 	@Override
-	public CompletionStage<Void> refresh(Object entity) {
+	public InternalStage<Void> refresh(Object entity) {
 		return delegate.reactiveRefresh( entity, LockOptions.NONE );
 	}
 
 	@Override
-	public CompletionStage<Void> refresh(Object entity, LockMode lockMode) {
+	public InternalStage<Void> refresh(Object entity, LockMode lockMode) {
 		return delegate.reactiveRefresh( entity, new LockOptions(lockMode) );
 	}
 
 	@Override
-	public CompletionStage<Void> refresh(Object entity, LockModeType lockModeType) {
+	public InternalStage<Void> refresh(Object entity, LockModeType lockModeType) {
 		return Stage.Session.super.refresh( entity, lockModeType );
 	}
 
 	//	@Override
-	public CompletionStage<Void> refresh(Object entity, LockOptions lockOptions) {
+	public InternalStage<Void> refresh(Object entity, LockOptions lockOptions) {
 		return delegate.reactiveRefresh( entity, lockOptions );
 	}
 
 	@Override
-	public CompletionStage<Void> refresh(Object... entity) {
+	public InternalStage<Void> refresh(Object... entity) {
 		return applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entity );
 	}
 
 	@Override
-	public CompletionStage<Void> lock(Object entity, LockMode lockMode) {
+	public InternalStage<Void> lock(Object entity, LockMode lockMode) {
 		return delegate.reactiveLock( entity, new LockOptions(lockMode) );
 	}
 
 	@Override
-	public CompletionStage<Void> lock(Object entity, LockModeType lockModeType) {
+	public InternalStage<Void> lock(Object entity, LockModeType lockModeType) {
 		return Stage.Session.super.lock( entity, lockModeType );
 	}
 
 	// @Override
-	public CompletionStage<Void> lock(Object entity, LockOptions lockOptions) {
+	public InternalStage<Void> lock(Object entity, LockOptions lockOptions) {
 		return delegate.reactiveLock( entity, lockOptions );
 	}
 
@@ -363,7 +363,7 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
-	public <T> CompletionStage<T> withTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
+	public <T> InternalStage<T> withTransaction(Function<Stage.Transaction, InternalStage<T>> work) {
 		return currentTransaction==null ? new Transaction<T>().execute(work) : work.apply(currentTransaction);
 	}
 
@@ -378,7 +378,7 @@ public class StageSessionImpl implements Stage.Session {
 		boolean rollback;
 		Throwable error;
 
-		CompletionStage<T> execute(Function<Stage.Transaction, CompletionStage<T>> work) {
+		InternalStage<T> execute(Function<Stage.Transaction, InternalStage<T>> work) {
 			currentTransaction = this;
 			return begin()
 					.thenCompose( v -> executeInTransaction( work ) )
@@ -390,7 +390,7 @@ public class StageSessionImpl implements Stage.Session {
 		 * differentiate an error starting a transaction (and therefore doesn't need to
 		 * roll back) and an error thrown by the work.
 		 */
-		CompletionStage<T> executeInTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
+		InternalStage<T> executeInTransaction(Function<Stage.Transaction, InternalStage<T>> work) {
 			return work.apply( this )
 					// only flush() if the work completed with no exception
 					.thenCompose( result -> flush().thenApply( v -> result ) )
@@ -410,15 +410,15 @@ public class StageSessionImpl implements Stage.Session {
 
 		}
 
-		CompletionStage<Void> flush() {
+		InternalStage<Void> flush() {
 			return delegate.reactiveAutoflush();
 		}
 
-		CompletionStage<Void> begin() {
+		InternalStage<Void> begin() {
 			return delegate.getReactiveConnection().beginTransaction();
 		}
 
-		CompletionStage<Void> end() {
+		InternalStage<Void> end() {
 			ReactiveActionQueue actionQueue = delegate.getReactiveActionQueue();
 			return actionQueue.beforeTransactionCompletion()
 					.thenApply( v -> delegate.getReactiveConnection() )
@@ -451,7 +451,7 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
-	public CompletionStage<Void> close() {
+	public InternalStage<Void> close() {
 		return delegate.reactiveClose();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/tuple/StageGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/tuple/StageGenerator.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.tuple;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 import org.hibernate.Incubating;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.generator.BeforeExecutionGenerator;
@@ -21,6 +21,6 @@ public abstract class StageGenerator implements BeforeExecutionGenerator {
         throw new UnsupportedOperationException( "Use generate(Stage.Session, Object, Object, EventType) instead" );
     }
 
-    public abstract CompletionStage<Object> generate(Stage.Session session, Object owner, Object currentValue,
+    public abstract InternalStage<Object> generate(Stage.Session session, Object owner, Object currentValue,
                                                      EventType eventType);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncCloseable.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/util/async/impl/AsyncCloseable.java
@@ -5,7 +5,7 @@
  */
 package org.hibernate.reactive.util.async.impl;
 
-import java.util.concurrent.CompletionStage;
+import org.hibernate.reactive.engine.impl.InternalStage;
 
 /**
  * Copy of com.ibm.asyncutil.util.AsyncClosable in com.ibm.async:asyncutil:0.1.0
@@ -32,6 +32,6 @@ public interface AsyncCloseable {
 	 * @return a {@link CompletionStage} that completes when all resources associated with this object
 	 * have been released, or with an exception if the resources cannot be released.
 	 */
-	CompletionStage<Void> close();
+	InternalStage<Void> close();
 
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BaseReactiveTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import org.hibernate.SessionFactory;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/BatchQueryOnConnectionTest.java
@@ -10,7 +10,6 @@ import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.pool.impl.OracleParameters;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedToOnesEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CascadeComplicatedToOnesEagerTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.Hibernate;
 import org.hibernate.cfg.Configuration;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompletionStagesTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompletionStagesTest.java
@@ -12,7 +12,6 @@ import java.util.LinkedHashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.CompletionStage;
 import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.Test;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CompositeIdTest.java
@@ -10,7 +10,6 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.reactive.stage.Stage;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CurrentUser.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CurrentUser.java
@@ -11,7 +11,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.util.EnumSet;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 import org.hibernate.annotations.ValueGenerationType;
 import org.hibernate.generator.EventType;
 import org.hibernate.generator.EventTypeSets;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomGeneratorTest.java
@@ -9,7 +9,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
 import java.util.Properties;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Parameter;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeListTest.java
@@ -9,7 +9,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeMapTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForBasicTypeSetTest.java
@@ -11,7 +11,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableEntityTypeMapTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddableTypeListTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Assertions;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableMapTest.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerElementCollectionForEmbeddedEmbeddableTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerOrderedElementCollectionForEmbeddableTypeListTest.java
@@ -10,7 +10,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/EagerTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.Hibernate;
 import org.hibernate.annotations.Fetch;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.cfg.Configuration;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.annotations.Filter;
 import org.hibernate.annotations.FilterDef;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorDynamicInsertTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorDynamicInsertTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.cfg.AvailableSettings;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.cfg.Configuration;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorWithColumnTransformerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/IdentityGeneratorWithColumnTransformerTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.annotations.ColumnTransformer;
 import org.hibernate.cfg.AvailableSettings;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InternalStateAssertionsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InternalStateAssertionsTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.Executor;
 
 import org.hibernate.reactive.mutiny.Mutiny;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultilineImportsTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import java.util.Collection;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedIdentityGenerationTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CountDownLatch;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/MultithreadedInsertionTest.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive;
 
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NoVertxContextTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NoVertxContextTest.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive;
 
-import java.util.concurrent.CompletionStage;
 import java.util.function.Function;
 
 import org.hibernate.SessionFactory;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveConstraintViolationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveConstraintViolationTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive;
 
 import java.util.Objects;
 import java.util.Set;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.exception.ConstraintViolationException;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveMultitenantNoResolverTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveMultitenantNoResolverTest.java
@@ -6,7 +6,6 @@
 package org.hibernate.reactive;
 
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.HibernateException;
 import org.hibernate.LockMode;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.LockMode;
 import org.hibernate.reactive.common.AffectedEntities;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReferenceTest.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.Hibernate;
 import org.hibernate.LockMode;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.configuration;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
 import org.hibernate.engine.jdbc.internal.JdbcServicesImpl;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateSqlServerTestBase.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.schema;
 
 import java.io.Serializable;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTestBase.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.schema;
 
-import java.util.concurrent.CompletionStage;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/ReactiveAssertions.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/ReactiveAssertions.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.testing;
 
 import java.time.Instant;
 import java.util.concurrent.CompletionException;
-import java.util.concurrent.CompletionStage;
 
 import io.smallrye.mutiny.Uni;
 import org.assertj.core.api.AbstractInstantAssert;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SessionFactoryManager.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SessionFactoryManager.java
@@ -7,7 +7,6 @@ package org.hibernate.reactive.testing;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
 
 import org.hibernate.SessionFactory;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/JsonTypeTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive.types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import org.hibernate.reactive.BaseReactiveTest;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/StringToJsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/StringToJsonTypeTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive.types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import org.hibernate.reactive.BaseReactiveTest;

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/UserJsonTypeTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/types/UserJsonTypeTest.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive.types;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
 
 import org.hibernate.annotations.Type;

--- a/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/BaseReactiveIT.java
+++ b/integration-tests/bytecode-enhancements-it/src/test/java/org/hibernate/reactive/it/BaseReactiveIT.java
@@ -8,7 +8,6 @@ package org.hibernate.reactive.it;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 


### PR DESCRIPTION

This is very rough and not fully compiling; needs some changes in Hibernate ORM core to be able to be finalized.

Leaving it here for the moment so we can discuss the approach before going too far.

The general idea would be that JDK's CompletionStage system is very feature rich, but so doing exposes several methods which are actively dangerous for our purposes, and it consumes more memory than a lighter version could; by having our own contract we can restrict what we use.
Also, we don't need (I thought? there's some evidence to the contrary) all the multi-threading capabilities the standard types offer: we just need to model a linear chain of events, with error propagation. The multi-threading safeguards are a performance drag, which we don't really need as long as we can verify correct design.

The additional benefit of using a custom interface would be that integration tests could replace the underlying implementation with something which more extensively traces the lifecycle of the events; for example we could verify that:
 - each chain is strictly tied to the expected threads exclusively (so to verify we really don't need the multi-threading capabilities)
 -  all stages are actually being completed, as we had cases for critical bugs in which some completion stage would get "lost" in the chain of operations.