### PR TITLE
Start container only if requested

### DIFF
--- a/integration-tests/techempower-postgres-it/build.gradle
+++ b/integration-tests/techempower-postgres-it/build.gradle
@@ -58,7 +58,7 @@ tasks.withType( Test ).configureEach {
 
 	// We need a to use an instance of PostgreSQL with a specific configuration.
 	// So, for this particular integration-test module, we default to true unless docker is disabled.
-	systemProperty 'docker', project.properties['docker'] ?: true
+	systemProperty 'docker', project.hasProperty('docker')
 	systemProperty 'org.hibernate.reactive.common.InternalStateAssertions.ENFORCE', 'true'
 
 	if ( project.hasProperty( 'includeTests' ) ) {

--- a/integration-tests/techempower-postgres-it/src/main/java/org/hibernate/reactive/it/techempower/VertxServer.java
+++ b/integration-tests/techempower-postgres-it/src/main/java/org/hibernate/reactive/it/techempower/VertxServer.java
@@ -36,21 +36,12 @@ public class VertxServer {
 	private static final Log LOG = make( Log.class, lookup() );
 
 	// These properties are in DatabaseConfiguration in core
-	public static final boolean USE_DOCKER = isDockerEnabled();
-
-	// If not specify, default to enable docker
-	private static boolean isDockerEnabled() {
-		String enableDocker = System.getProperty( "docker" );
-		if ( enableDocker == null ) {
-			return true;
-		}
-		return Boolean.parseBoolean( enableDocker );
-	}
+	public static final boolean USE_DOCKER = Boolean.getBoolean( "docker" );
 
 	public static final String IMAGE_NAME = "postgres:15-bullseye";
-	public static final String USERNAME = "benchmarkdbuser";
-	public static final String PASSWORD = "benchmarkdbpass";
-	public static final String DB_NAME = "hello_world";
+	public static final String USERNAME = "hreact";
+	public static final String PASSWORD = "hreact";
+	public static final String DB_NAME = "hreact";
 
 	public static final int VERTICLE_INSTANCES = 10;
 

--- a/integration-tests/verticle-postgres-it/build.gradle
+++ b/integration-tests/verticle-postgres-it/build.gradle
@@ -55,7 +55,7 @@ tasks.withType( Test ).configureEach {
         displayGranularity = 1
         events = ['PASSED', 'FAILED', 'SKIPPED']
     }
-    systemProperty 'docker', project.hasProperty( 'docker' ) ? 'true' : 'false'
+    systemProperty 'docker', project.hasProperty( 'docker' )
     systemProperty 'org.hibernate.reactive.common.InternalStateAssertions.ENFORCE', 'true'
 
     if ( project.hasProperty( 'includeTests' ) ) {

--- a/integration-tests/verticle-postgres-it/src/main/java/org/hibernate/reactive/it/verticle/VertxServer.java
+++ b/integration-tests/verticle-postgres-it/src/main/java/org/hibernate/reactive/it/verticle/VertxServer.java
@@ -34,7 +34,7 @@ public class VertxServer {
 	private static final Log LOG = make( Log.class, lookup() );
 
 	// These properties are in DatabaseConfiguration in core
-	public static final boolean USE_DOCKER = true;
+	public static final boolean USE_DOCKER = Boolean.getBoolean( "docker" );
 
 	public static final String IMAGE_NAME = "postgres:15.2";
 	public static final String USERNAME = "hreact";


### PR DESCRIPTION
Not everybody has docker installed and we need to make sure that it's still  possible to run the full build when there is a remote database already started.

Fix #1711 