### PR TITLE
Upgrade to Hibernate ORM 6.2.7.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '6.2.6.Final'
+        hibernateOrmVersion = '6.2.7.Final'
     }
     if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
         // Same as ORM as default

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -157,7 +157,7 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	 * @see org.hibernate.persister.collection.BasicCollectionPersister#recreate(PersistentCollection, Object, SharedSessionContractImplementor)
 	 */
 	@Override
-	public CompletionStage<Void> reactiveRecreate(PersistentCollection collection, Object id, SharedSessionContractImplementor session) {
+	public CompletionStage<Void> reactiveRecreate(PersistentCollection<?> collection, Object id, SharedSessionContractImplementor session) {
 		return getCreateEntryCoordinator().reactiveInsertRows( collection, id, collection::includeInRecreate, session );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -110,7 +110,12 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 			return new ReactiveDeleteRowsCoordinatorNoOp( this );
 		}
 
-		return new ReactiveDeleteRowsCoordinatorStandard( this, getRowMutationOperations(), hasPhysicalIndexColumn() );
+		return new ReactiveDeleteRowsCoordinatorStandard(
+				this,
+				getRowMutationOperations(),
+				hasPhysicalIndexColumn(),
+				getFactory().getServiceRegistry()
+		);
 	}
 
 	private ReactiveRemoveCoordinator buildDeleteAllCoordinator() {
@@ -121,7 +126,11 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 			return new ReactiveRemoveCoordinatorNoOp( this );
 		}
 
-		return new ReactiveRemoveCoordinatorStandard( this, this::buildDeleteAllOperation );
+		return new ReactiveRemoveCoordinatorStandard(
+				this,
+				this::buildDeleteAllOperation,
+				getFactory().getServiceRegistry()
+		);
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveOneToManyPersister.java
@@ -124,7 +124,12 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 			return new ReactiveDeleteRowsCoordinatorNoOp( this );
 		}
 		// never delete by index for one-to-many
-		return new ReactiveDeleteRowsCoordinatorStandard( this, getRowMutationOperations(), false );
+		return new ReactiveDeleteRowsCoordinatorStandard(
+				this,
+				getRowMutationOperations(),
+				false,
+				getFactory().getServiceRegistry()
+		);
 	}
 
 	private ReactiveRemoveCoordinator buildDeleteAllCoordinator() {
@@ -134,7 +139,11 @@ public class ReactiveOneToManyPersister extends OneToManyPersister
 			}
 			return new ReactiveRemoveCoordinatorNoOp( this );
 		}
-		return new ReactiveRemoveCoordinatorStandard( this, this::buildDeleteAllOperation );
+		return new ReactiveRemoveCoordinatorStandard(
+				this,
+				this::buildDeleteAllOperation,
+				getFactory().getServiceRegistry()
+		);
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
@@ -19,6 +19,7 @@ import org.hibernate.persister.collection.mutation.CollectionMutationTarget;
 import org.hibernate.persister.collection.mutation.DeleteRowsCoordinatorStandard;
 import org.hibernate.persister.collection.mutation.RowMutationOperations;
 import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.model.MutationOperationGroup;
 import org.hibernate.sql.model.MutationType;
 import org.hibernate.sql.model.internal.MutationOperationGroupSingle;
@@ -35,8 +36,12 @@ public class ReactiveDeleteRowsCoordinatorStandard extends DeleteRowsCoordinator
 	private MutationOperationGroupSingle operationGroup;
 	private final BasicBatchKey batchKey;
 
-	public ReactiveDeleteRowsCoordinatorStandard(CollectionMutationTarget mutationTarget, RowMutationOperations rowMutationOperations, boolean deleteByIndex) {
-		super( mutationTarget, rowMutationOperations, deleteByIndex );
+	public ReactiveDeleteRowsCoordinatorStandard(
+			CollectionMutationTarget mutationTarget,
+			RowMutationOperations rowMutationOperations,
+			boolean deleteByIndex,
+			ServiceRegistry serviceRegistry) {
+		super( mutationTarget, rowMutationOperations, deleteByIndex, serviceRegistry );
 		this.deleteByIndex = deleteByIndex;
 		this.rowMutationOperations = rowMutationOperations;
 		this.batchKey = new BasicBatchKey( mutationTarget.getRolePath() + "#DELETE" );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
@@ -21,6 +21,7 @@ import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.model.MutationOperationGroup;
 import org.hibernate.sql.model.MutationType;
 import org.hibernate.sql.model.ast.MutatingTableReference;
@@ -40,8 +41,11 @@ public class ReactiveRemoveCoordinatorStandard extends RemoveCoordinatorStandard
 	private final OperationProducer operationProducer;
 	private MutationOperationGroupSingle operationGroup;
 
-	public ReactiveRemoveCoordinatorStandard(CollectionMutationTarget mutationTarget, OperationProducer operationProducer) {
-		super( mutationTarget, operationProducer );
+	public ReactiveRemoveCoordinatorStandard(
+			CollectionMutationTarget mutationTarget,
+			OperationProducer operationProducer,
+			ServiceRegistry serviceRegistry) {
+		super( mutationTarget, operationProducer, serviceRegistry );
 		this.batchKey = new BasicBatchKey( mutationTarget.getRolePath() + "#REMOVE" );
 		this.operationProducer = operationProducer;
 	}


### PR DESCRIPTION
[I had to change one of the test](https://github.com/hibernate/hibernate-reactive/compare/main...DavideD:ORM-6.2.7?expand=1#diff-3e90f461f2350c2e82be9fad23b31da034848a9ed9eb2cf43a501c8c520e44fdR486) because now Hibernate ORM throw an exception if an associated entity has  `null` version (before it was treated as a transient entity).

I've added a fetch before removing the entity.
@gavinking, do you think this is acceptable or should we recognize the  use case and  do something smarter?

Basically, before the user was able to delete the entity without fetching it.