### PR TITLE
[#1501] Fix SubselectFetchTest

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/ReactiveAbstractEntityInitializer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/graph/entity/ReactiveAbstractEntityInitializer.java
@@ -26,10 +26,12 @@ import org.hibernate.sql.results.graph.AssemblerCreationState;
 import org.hibernate.sql.results.graph.DomainResult;
 import org.hibernate.sql.results.graph.DomainResultAssembler;
 import org.hibernate.sql.results.graph.Fetch;
+import org.hibernate.sql.results.graph.basic.BasicFetch;
 import org.hibernate.sql.results.graph.entity.AbstractEntityInitializer;
 import org.hibernate.sql.results.graph.entity.EntityLoadingLogging;
 import org.hibernate.sql.results.graph.entity.EntityResultGraphNode;
 import org.hibernate.sql.results.graph.entity.LoadingEntityEntry;
+import org.hibernate.sql.results.graph.entity.internal.EntityResultInitializer;
 import org.hibernate.sql.results.jdbc.spi.RowProcessingState;
 import org.hibernate.stat.spi.StatisticsImplementor;
 
@@ -41,7 +43,7 @@ import static org.hibernate.proxy.HibernateProxy.extractLazyInitializer;
 import static org.hibernate.reactive.util.impl.CompletionStages.loop;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
-public abstract class ReactiveAbstractEntityInitializer extends AbstractEntityInitializer implements ReactiveInitializer {
+public abstract class ReactiveAbstractEntityInitializer extends EntityResultInitializer implements ReactiveInitializer {
 
 	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
@@ -58,7 +60,7 @@ public abstract class ReactiveAbstractEntityInitializer extends AbstractEntityIn
 				navigablePath,
 				lockMode,
 				identifierFetch,
-				discriminatorFetch,
+				(BasicFetch<?>) discriminatorFetch,
 				rowIdResult,
 				creationState
 		);

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.Timeout;
@@ -43,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled // see https://github.com/hibernate/hibernate-reactive/issues/1502
 @Timeout(value = 10, timeUnit = MINUTES)
 public class SubselectFetchTest extends BaseReactiveTest {
 


### PR DESCRIPTION
fixes #1502 

- Follows ORM's [SubselectFetchTest.testSubselectFetchHql(...)](https://github.com/hibernate/hibernate-orm/blob/761ec951455eff85cd801473a97c7edb4976f717/hibernate-core/src/test/java/org/hibernate/orm/test/mapping/fetch/subselect/SubselectFetchTest.java#L100C22-L100C22)
- initialization on a collection is forced via a call to a collections `size()`