### PR TITLE
Upgrade Hibernate ORM to 6.3.0.Final

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '6.2.8.Final'
+        hibernateOrmVersion = '6.3.0.Final'
     }
     if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
         // Same as ORM as default

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/Identifier.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/common/Identifier.java
@@ -8,6 +8,7 @@ package org.hibernate.reactive.common;
 import org.hibernate.Incubating;
 
 import jakarta.persistence.metamodel.SingularAttribute;
+
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -16,90 +17,89 @@ import java.util.Map;
  * Represents a value of an attribute that forms part of the
  * natural key of an entity.
  *
- * @see org.hibernate.annotations.NaturalId
- *
  * @param <T> the owning entity class
+ * @see org.hibernate.annotations.NaturalId
  */
 @Incubating
 public abstract class Identifier<T> {
 
-    public abstract Id<T>[] ids();
+	public abstract Id<T>[] ids();
 
-    public abstract Map<String,Object> namedValues();
+	public abstract Map<String, Object> namedValues();
 
-    public static class Id<T> extends Identifier<T> {
-        private <I> Id(SingularAttribute<T,I> attribute, I id) {
-            this.id = id;
-            this.attributeName = attribute.getName();
-        }
+	public static class Id<T> extends Identifier<T> {
+		private <I> Id(SingularAttribute<T, I> attribute, I id) {
+			this.id = id;
+			this.attributeName = attribute.getName();
+		}
 
-        private Id(String attributeName, Object id) {
-            this.attributeName = attributeName;
-            this.id = id;
-        }
+		private Id(String attributeName, Object id) {
+			this.attributeName = attributeName;
+			this.id = id;
+		}
 
-        private final String attributeName;
-        private final Object id;
+		private final String attributeName;
+		private final Object id;
 
-        public Object getId() {
-            return id;
-        }
+		public Object getId() {
+			return id;
+		}
 
-        public String getAttributeName() {
-            return attributeName;
-        }
+		public String getAttributeName() {
+			return attributeName;
+		}
 
-        @Override
-        public Id<T>[] ids() {
-            return new Id[]{this};
-        }
+		@Override
+		public Id<T>[] ids() {
+			return new Id[] {this};
+		}
 
-        @Override
-        public Map<String, Object> namedValues() {
-            return Collections.singletonMap(attributeName, id);
-        }
-    }
+		@Override
+		public Map<String, Object> namedValues() {
+			return Collections.singletonMap( attributeName, id );
+		}
+	}
 
-    public static class Composite<T> extends Identifier<T> {
-        Id<T>[] ids;
+	public static class Composite<T> extends Identifier<T> {
+		Id<T>[] ids;
 
-        public Composite(Id<T>[] ids) {
-            this.ids = ids;
-        }
+		public Composite(Id<T>[] ids) {
+			this.ids = ids;
+		}
 
-        public Id<T>[] getValues() {
-            return ids;
-        }
+		public Id<T>[] getValues() {
+			return ids;
+		}
 
-        @Override
-        public Id<T>[] ids() {
-            return ids;
-        }
+		@Override
+		public Id<T>[] ids() {
+			return ids;
+		}
 
-        @Override
-        public Map<String, Object> namedValues() {
-            Map<String, Object> namedValues = new HashMap<>();
-            for (Id<T> id : ids) {
-                namedValues.put( id.getAttributeName(), id.getId() );
-            }
-            return namedValues;
-        }
-    }
+		@Override
+		public Map<String, Object> namedValues() {
+			Map<String, Object> namedValues = new HashMap<>();
+			for ( Id<T> id : ids ) {
+				namedValues.put( id.getAttributeName(), id.getId() );
+			}
+			return namedValues;
+		}
+	}
 
-    public static <T,I> Id<T> id(SingularAttribute<T,I> attribute, I id) {
-        return new Id<>(attribute, id);
-    }
+	public static <T, I> Id<T> id(SingularAttribute<T, I> attribute, I id) {
+		return new Id<>( attribute, id );
+	}
 
-    public static <T> Id<T> id(String attributeName, Object id) {
-        return new Id<>(attributeName, id);
-    }
+	public static <T> Id<T> id(String attributeName, Object id) {
+		return new Id<>( attributeName, id );
+	}
 
-    public static <T> Id<T> id(Class<T> entityClass, String attributeName, Object id) {
-        return new Id<>(attributeName, id);
-    }
+	public static <T> Id<T> id(Class<T> entityClass, String attributeName, Object id) {
+		return new Id<>( attributeName, id );
+	}
 
-    @SafeVarargs
-    public static <T> Identifier<T> composite(Id<T>... ids) {
-        return new Composite<>(ids);
-    }
+	@SafeVarargs
+	public static <T> Identifier<T> composite(Id<T>... ids) {
+		return new Composite<>( ids );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityInsertActionHolder.java
@@ -28,7 +28,7 @@ public final class ReactiveEntityInsertActionHolder implements Executable, React
 	}
 
 	@Override
-	public Serializable[] getPropertySpaces() {
+	public String[] getPropertySpaces() {
 		return delegate.getPropertySpaces();
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityRegularInsertAction.java
@@ -84,7 +84,7 @@ public class ReactiveEntityRegularInsertAction extends EntityInsertAction implem
 						postInsert();
 
 						final StatisticsImplementor statistics = session.getFactory().getStatistics();
-						if ( statistics.isStatisticsEnabled() && !veto ) {
+						if ( statistics.isStatisticsEnabled() ) {
 							statistics.insertEntity( getPersister().getEntityName() );
 						}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityUpdateAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityUpdateAction.java
@@ -95,7 +95,7 @@ public class ReactiveEntityUpdateAction extends EntityUpdateAction implements Re
 				} )
 				.thenCompose( this::handleGeneratedProperties )
 				.thenAccept( entry -> {
-					handleDeleted( entry, persister, instance );
+					handleDeleted( entry );
 					updateCacheItem( persister, ck, entry );
 					handleNaturalIdResolutions( persister, session, id );
 					postUpdate();
@@ -136,16 +136,16 @@ public class ReactiveEntityUpdateAction extends EntityUpdateAction implements Re
 	}
 
 	// TODO: copy/paste from superclass (make it protected)
-	private void handleDeleted(EntityEntry entry, EntityPersister persister, Object instance) {
+	private void handleDeleted(EntityEntry entry) {
 		if ( entry.getStatus() == Status.DELETED ) {
-			final EntityMetamodel entityMetamodel = persister.getEntityMetamodel();
+			final EntityMetamodel entityMetamodel = getPersister().getEntityMetamodel();
 			final boolean isImpliedOptimisticLocking = !entityMetamodel.isVersioned()
 					&& entityMetamodel.getOptimisticLockStyle().isAllOrDirty();
 			if ( isImpliedOptimisticLocking && entry.getLoadedState() != null ) {
 				// The entity will be deleted and because we are going to create a delete statement
 				// that uses all the state values in the where clause, the entry state needs to be
 				// updated otherwise the statement execution will not delete any row (see HHH-15218).
-				entry.postUpdate(instance, getState(), getNextVersion() );
+				entry.postUpdate( getInstance(), getState(), getNextVersion() );
 			}
 		}
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/env/internal/ReactiveMutationExecutor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/env/internal/ReactiveMutationExecutor.java
@@ -115,7 +115,7 @@ public interface ReactiveMutationExecutor extends MutationExecutor {
 						// the optional table did not have a row
 						return voidFuture();
 					}
-					checkResults( session, statementDetails, resultChecker, affectedRowCount, -1);
+					checkResults( session, statementDetails, resultChecker, affectedRowCount, -1 );
 					return voidFuture();
 				} )
 				.whenComplete( (o, throwable) -> {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsert.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsert.java
@@ -21,7 +21,7 @@ import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
 import org.hibernate.reactive.id.insert.ReactiveInsertGeneratedIdentifierDelegate;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
-import org.hibernate.sql.model.MutationOperationGroup;
+import org.hibernate.sql.model.EntityMutationOperationGroup;
 import org.hibernate.sql.model.ValuesAnalysis;
 
 import static org.hibernate.reactive.engine.jdbc.ResultsCheckerUtil.checkResults;
@@ -31,7 +31,7 @@ import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER
 public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInsert implements ReactiveMutationExecutor {
 
 	public ReactiveMutationExecutorPostInsert(
-			MutationOperationGroup mutationOperationGroup,
+			EntityMutationOperationGroup mutationOperationGroup,
 			SharedSessionContractImplementor session) {
 		super( mutationOperationGroup, session );
 	}
@@ -49,17 +49,16 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 						session
 				)
 				.thenApply( this::logId )
-				.thenCompose(id -> {
-					if (secondaryTablesStatementGroup == null) {
-						return completedFuture(id);
+				.thenCompose( id -> {
+					if ( secondaryTablesStatementGroup == null ) {
+						return completedFuture( id );
 					}
-					AtomicReference<CompletionStage<Object>>  res = new AtomicReference<>(completedFuture(id));
-					secondaryTablesStatementGroup
-							.forEachStatement( (tableName, statementDetails) -> res
-									.set( res.get().thenCompose( i -> reactiveExecuteWithId( i, tableName, statementDetails, inclusionChecker, resultChecker, session ) ) )
-							);
+					AtomicReference<CompletionStage<Object>> res = new AtomicReference<>( completedFuture( id ) );
+					secondaryTablesStatementGroup.forEachStatement( (tableName, statementDetails) -> {
+						res.set( res.get().thenCompose( i -> reactiveExecuteWithId( i, tableName, statementDetails, inclusionChecker, resultChecker, session ) ) );
+					} );
 					return res.get();
-				});
+				} );
 	}
 
 	private Object logId(Object identifier) {
@@ -91,8 +90,10 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 
 		if ( inclusionChecker != null && !inclusionChecker.include( tableDetails ) ) {
 			if ( MODEL_MUTATION_LOGGER.isTraceEnabled() ) {
-				MODEL_MUTATION_LOGGER
-						.tracef( "Skipping execution of secondary insert : %s", tableDetails.getTableName() );
+				MODEL_MUTATION_LOGGER.tracef(
+						"Skipping execution of secondary insert : %s",
+						tableDetails.getTableName()
+				);
 			}
 			return completedFuture( id );
 		}
@@ -137,6 +138,4 @@ public class ReactiveMutationExecutorPostInsert extends MutationExecutorPostInse
 					valueBindings.afterStatement( tableDetails );
 				} );
 	}
-
-
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsertSingleTable.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/jdbc/mutation/internal/ReactiveMutationExecutorPostInsertSingleTable.java
@@ -15,7 +15,7 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.mutation.EntityMutationTarget;
 import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
 import org.hibernate.reactive.id.insert.ReactiveInsertGeneratedIdentifierDelegate;
-import org.hibernate.sql.model.MutationOperationGroup;
+import org.hibernate.sql.model.EntityMutationOperationGroup;
 import org.hibernate.sql.model.PreparableMutationOperation;
 import org.hibernate.sql.model.ValuesAnalysis;
 
@@ -28,10 +28,11 @@ public class ReactiveMutationExecutorPostInsertSingleTable extends MutationExecu
 	private final EntityMutationTarget mutationTarget;
 	private final PreparedStatementDetails identityInsertStatementDetails;
 
-	public ReactiveMutationExecutorPostInsertSingleTable(MutationOperationGroup mutationOperationGroup, SharedSessionContractImplementor session) {
+	public ReactiveMutationExecutorPostInsertSingleTable(EntityMutationOperationGroup mutationOperationGroup, SharedSessionContractImplementor session) {
 		super( mutationOperationGroup, session );
-		this.mutationTarget = (EntityMutationTarget) mutationOperationGroup.getMutationTarget();
-		final PreparableMutationOperation operation = mutationOperationGroup.getOperation( mutationTarget.getIdentifierTableName() );
+		this.mutationTarget = mutationOperationGroup.getMutationTarget();
+		final PreparableMutationOperation operation = (PreparableMutationOperation) mutationOperationGroup
+				.getOperation( mutationTarget.getIdentifierTableName() );
 		this.identityInsertStatementDetails = identityPreparation( operation, session );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
@@ -128,8 +128,8 @@ public class DefaultReactiveDeleteEventListener
 			final EventSource source = event.getSession();
 			Object object = event.getObject();
 			if ( object instanceof CompletionStage ) {
-				final CompletionStage<Object> objectStage = (CompletionStage<Object>) object;
-				return objectStage.thenCompose( objectEvent -> fetchAndDelete( event, transientEntities, source, objectEvent ) );
+				final CompletionStage<?> stage = (CompletionStage<?>) object;
+				return stage.thenCompose( objectEvent -> fetchAndDelete( event, transientEntities, source, objectEvent ) );
 			}
 			else {
 				return fetchAndDelete( event, transientEntities, source, object);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
@@ -421,7 +421,7 @@ public class DefaultReactiveLoadEventListener implements LoadEventListener, Reac
 			EntityPersister persister,
 			EntityKey keyToLoad,
 			EventSource session) {
-		if ( keyToLoad.isBatchLoadable() ) {
+		if ( keyToLoad.isBatchLoadable( session.getLoadQueryInfluencers() ) ) {
 			// Add a batch-fetch entry into the queue for this entity
 			session.getPersistenceContextInternal().getBatchFetchQueue().addBatchLoadableEntityKey( keyToLoad );
 		}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveAbstractMultiIdEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveAbstractMultiIdEntityLoader.java
@@ -11,7 +11,6 @@ import java.util.concurrent.CompletionStage;
 
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.loader.ast.internal.Preparable;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.metamodel.mapping.EntityIdentifierMapping;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -20,7 +19,7 @@ import org.hibernate.reactive.loader.ast.spi.ReactiveMultiIdEntityLoader;
 /**
  * @see org.hibernate.loader.ast.internal.AbstractMultiIdEntityLoader
  */
-public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements ReactiveMultiIdEntityLoader<T>, Preparable {
+public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements ReactiveMultiIdEntityLoader<T> {
 
 	private final EntityMappingType entityDescriptor;
 	private final SessionFactoryImplementor sessionFactory;
@@ -30,11 +29,7 @@ public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements Reactive
 	public ReactiveAbstractMultiIdEntityLoader(EntityMappingType entityDescriptor, SessionFactoryImplementor sessionFactory) {
 		this.entityDescriptor = entityDescriptor;
 		this.sessionFactory = sessionFactory;
-	}
-
-	@Override
-	public void prepare() {
-		identifierMapping = getLoadable().getIdentifierMapping();
+		this.identifierMapping = getLoadable().getIdentifierMapping();
 	}
 
 	protected EntityMappingType getEntityDescriptor() {
@@ -55,7 +50,7 @@ public abstract class ReactiveAbstractMultiIdEntityLoader<T> implements Reactive
 	}
 
 	@Override
-	public final <K> CompletionStage<List<T>> load(K[] ids, MultiIdLoadOptions loadOptions, EventSource session) {
+	public final <K> CompletionStage<List<T>> reactiveLoad(K[] ids, MultiIdLoadOptions loadOptions, EventSource session) {
 		Objects.requireNonNull( ids );
 
 		return loadOptions.isOrderReturnEnabled()

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderNamedQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveCollectionLoaderNamedQuery.java
@@ -10,11 +10,21 @@ import java.util.concurrent.CompletionStage;
 import org.hibernate.collection.spi.PersistentCollection;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.PluralAttributeMapping;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.query.named.NamedQueryMemento;
 
 /**
  * @see org.hibernate.loader.ast.internal.CollectionLoaderNamedQuery
  */
 public class ReactiveCollectionLoaderNamedQuery implements ReactiveCollectionLoader {
+
+	private final CollectionPersister persister;
+	private final NamedQueryMemento namedQueryMemento;
+
+	public ReactiveCollectionLoaderNamedQuery(CollectionPersister persister, NamedQueryMemento namedQueryMemento) {
+		this.persister = persister;
+		this.namedQueryMemento = namedQueryMemento;
+	}
 
 	@Override
 	public PluralAttributeMapping getLoadable() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveEntityBatchLoaderArrayParam.java
@@ -18,7 +18,6 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.internal.EntityBatchLoaderArrayParam;
 import org.hibernate.loader.ast.internal.LoaderSelectBuilder;
 import org.hibernate.loader.ast.internal.MultiKeyLoadHelper;
-import org.hibernate.loader.ast.internal.Preparable;
 import org.hibernate.loader.ast.spi.EntityBatchLoader;
 import org.hibernate.loader.ast.spi.SqlArrayMultiKeyLoader;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
@@ -31,8 +30,6 @@ import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.internal.JdbcParameterImpl;
 import org.hibernate.sql.exec.spi.JdbcOperationQuerySelect;
 import org.hibernate.sql.exec.spi.JdbcParameterBindings;
-import org.hibernate.type.BasicType;
-import org.hibernate.type.BasicTypeRegistry;
 
 import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LOAD_LOGGER;
 
@@ -40,7 +37,7 @@ import static org.hibernate.loader.ast.internal.MultiKeyLoadLogging.MULTI_KEY_LO
  * @see EntityBatchLoaderArrayParam
  */
 public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEntityLoaderSupport<T>
-		implements EntityBatchLoader<CompletionStage<T>>, ReactiveSingleIdEntityLoader<T>, SqlArrayMultiKeyLoader, Preparable {
+		implements EntityBatchLoader<CompletionStage<T>>, ReactiveSingleIdEntityLoader<T>, SqlArrayMultiKeyLoader {
 
 	private final int domainBatchSize;
 
@@ -64,6 +61,32 @@ public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEnti
 					domainBatchSize
 			);
 		}
+
+		identifierMapping = (BasicEntityIdentifierMapping) getLoadable().getIdentifierMapping();
+		final Class<?> arrayClass =
+				Array.newInstance( identifierMapping.getJavaType().getJavaTypeClass(), 0 ).getClass();
+		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
+				sessionFactory.getTypeConfiguration().getBasicTypeRegistry().getRegisteredType( arrayClass ),
+				identifierMapping.getJdbcMapping(),
+				arrayClass,
+				sessionFactory
+		);
+
+		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );
+		sqlAst = LoaderSelectBuilder.createSelectBySingleArrayParameter(
+				getLoadable(),
+				identifierMapping,
+				new LoadQueryInfluencers( sessionFactory ),
+				LockOptions.NONE,
+				jdbcParameter,
+				sessionFactory
+		);
+
+		jdbcSelectOperation = sessionFactory.getJdbcServices()
+				.getJdbcEnvironment()
+				.getSqlAstTranslatorFactory()
+				.buildSelectTranslator( sessionFactory, sqlAst )
+				.translate( JdbcParameterBindings.NO_BINDINGS, QueryOptions.NONE );
 	}
 
 	@Override
@@ -142,39 +165,6 @@ public class ReactiveEntityBatchLoaderArrayParam<T> extends ReactiveSingleIdEnti
 						BatchFetchQueueHelper.removeBatchLoadableEntityKey( id, getLoadable(), session );
 					}
 				} );
-	}
-
-	@Override
-	public void prepare() {
-		identifierMapping = (BasicEntityIdentifierMapping) getLoadable().getIdentifierMapping();
-		final Class<?> arrayClass = Array.newInstance( identifierMapping.getJavaType().getJavaTypeClass(), 0 )
-				.getClass();
-
-		final BasicTypeRegistry basicTypeRegistry = sessionFactory.getTypeConfiguration().getBasicTypeRegistry();
-		final BasicType<?> arrayBasicType = basicTypeRegistry.getRegisteredType( arrayClass );
-
-		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
-				arrayBasicType,
-				identifierMapping.getJdbcMapping(),
-				arrayClass,
-				sessionFactory
-		);
-
-		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );
-		sqlAst = LoaderSelectBuilder.createSelectBySingleArrayParameter(
-				getLoadable(),
-				identifierMapping,
-				LoadQueryInfluencers.NONE,
-				LockOptions.NONE,
-				jdbcParameter,
-				sessionFactory
-		);
-
-		jdbcSelectOperation = sessionFactory.getJdbcServices()
-				.getJdbcEnvironment()
-				.getSqlAstTranslatorFactory()
-				.buildSelectTranslator( sessionFactory, sqlAst )
-				.translate( JdbcParameterBindings.NO_BINDINGS, QueryOptions.NONE );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveMultiIdEntityLoaderArrayParam.java
@@ -27,7 +27,6 @@ import org.hibernate.loader.ast.internal.CacheEntityLoaderHelper;
 import org.hibernate.loader.ast.internal.LoaderHelper;
 import org.hibernate.loader.ast.internal.LoaderSelectBuilder;
 import org.hibernate.loader.ast.internal.MultiIdEntityLoaderArrayParam;
-import org.hibernate.loader.ast.internal.MultiKeyLoadHelper;
 import org.hibernate.loader.ast.internal.MultiKeyLoadLogging;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
 import org.hibernate.metamodel.mapping.BasicEntityIdentifierMapping;
@@ -46,10 +45,10 @@ import org.hibernate.sql.exec.spi.JdbcParameterBindings;
 import org.hibernate.sql.exec.spi.JdbcParametersList;
 import org.hibernate.sql.results.internal.RowTransformerStandardImpl;
 import org.hibernate.type.BasicType;
-import org.hibernate.type.BasicTypeRegistry;
 
 import static org.hibernate.internal.util.collections.CollectionHelper.arrayList;
 import static org.hibernate.internal.util.collections.CollectionHelper.isEmpty;
+import static org.hibernate.loader.ast.internal.MultiKeyLoadHelper.resolveArrayJdbcMapping;
 import static org.hibernate.reactive.loader.ast.internal.ReactiveLoaderHelper.loadByArrayParameter;
 import static org.hibernate.reactive.util.impl.CompletionStages.completedFuture;
 import static org.hibernate.reactive.util.impl.CompletionStages.loop;
@@ -60,13 +59,24 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
  */
 public class ReactiveMultiIdEntityLoaderArrayParam<E> extends ReactiveAbstractMultiIdEntityLoader<E> {
 
-	private JdbcMapping arrayJdbcMapping;
-	private JdbcParameter jdbcParameter;
+	private final JdbcMapping arrayJdbcMapping;
+	private final JdbcParameter jdbcParameter;
 
 	public ReactiveMultiIdEntityLoaderArrayParam(
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
 		super( entityDescriptor, sessionFactory );
+		final Class<?> arrayClass = createTypedArray( 0 ).getClass();
+		JdbcMapping jdbcMapping = getIdentifierMapping().getJdbcMapping();
+		BasicType<?> registeredType = getSessionFactory().getTypeConfiguration()
+				.getBasicTypeRegistry()
+				.getRegisteredType( arrayClass );
+		JdbcMapping arrayJdbcMapping1 = resolveArrayJdbcMapping( registeredType, jdbcMapping, arrayClass, getSessionFactory() );
+//		JavaType<Object> objectJavaType = getSessionFactory().getTypeConfiguration()
+//				.getJavaTypeRegistry()
+//				.resolveDescriptor( ReactiveArrayJdbcType.class );
+		arrayJdbcMapping = arrayJdbcMapping1;
+		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );
 	}
 
 	@Override
@@ -402,23 +412,4 @@ public class ReactiveMultiIdEntityLoaderArrayParam<E> extends ReactiveAbstractMu
 		//noinspection unchecked
 		return (X[]) Array.newInstance( getIdentifierMapping().getJavaType().getJavaTypeClass(), length );
 	}
-
-	@Override
-	public void prepare() {
-		super.prepare();
-
-		final Class<?> arrayClass = createTypedArray( 0 ).getClass();
-
-		final BasicTypeRegistry basicTypeRegistry = getSessionFactory().getTypeConfiguration().getBasicTypeRegistry();
-		final BasicType<?> arrayBasicType = basicTypeRegistry.getRegisteredType( arrayClass );
-
-		arrayJdbcMapping = MultiKeyLoadHelper.resolveArrayJdbcMapping(
-				arrayBasicType,
-				getIdentifierMapping().getJdbcMapping(),
-				arrayClass,
-				getSessionFactory()
-		);
-		jdbcParameter = new JdbcParameterImpl( arrayJdbcMapping );
-	}
-
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveNaturalIdLoaderDelegate.java
@@ -118,11 +118,10 @@ public abstract class ReactiveNaturalIdLoaderDelegate<T> extends AbstractNatural
                 naturalIdMapping().normalizeInput( naturalIdValue ),
                 NaturalIdLoadOptions.NONE,
                 (tableGroup, creationState) -> entityDescriptor().getIdentifierMapping().createDomainResult(
-                        tableGroup.getNavigablePath().append( EntityIdentifierMapping.ROLE_LOCAL_NAME ),
+                        tableGroup.getNavigablePath().append( EntityIdentifierMapping.ID_ROLE_NAME ),
                         tableGroup,
                         null,
-                        creationState
-                ),
+                        creationState ),
                 ReactiveNaturalIdLoaderDelegate::visitFetches,
                 ReactiveNaturalIdLoaderDelegate::statsEnabled,
                 (result, startToken) -> {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdEntityLoaderStandardImpl.java
@@ -5,21 +5,15 @@
  */
 package org.hibernate.reactive.loader.ast.internal;
 
-import java.util.EnumMap;
 import java.util.concurrent.CompletionStage;
-import java.util.concurrent.atomic.AtomicInteger;
 
-import org.hibernate.Internal;
-import org.hibernate.LockMode;
 import org.hibernate.LockOptions;
 import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.internal.LoaderSelectBuilder;
 import org.hibernate.loader.ast.internal.SingleIdEntityLoaderStandardImpl;
-import org.hibernate.loader.ast.spi.CascadingFetchProfile;
 import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.persister.entity.Loadable;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.sql.ast.tree.select.SelectStatement;
 import org.hibernate.sql.exec.spi.JdbcParametersList;
@@ -29,80 +23,41 @@ import org.hibernate.sql.exec.spi.JdbcParametersList;
  *
  * @see SingleIdEntityLoaderStandardImpl
  */
-public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderStandardImpl<CompletionStage<T>> implements ReactiveSingleIdEntityLoader<T> {
-
-	private EnumMap<LockMode, ReactiveSingleIdLoadPlan> selectByLockMode = new EnumMap<>( LockMode.class );
-	private EnumMap<CascadingFetchProfile, ReactiveSingleIdLoadPlan> selectByInternalCascadeProfile;
-
-	private AtomicInteger nonReusablePlansGenerated = new AtomicInteger();
-
-	@Override
-	public AtomicInteger getNonReusablePlansGenerated() {
-		return nonReusablePlansGenerated;
-	}
+public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityLoaderStandardImpl<CompletionStage<T>>
+		implements ReactiveSingleIdEntityLoader<T> {
 
 	private DatabaseSnapshotExecutor databaseSnapshotExecutor;
-
-	private final EntityMappingType entityDescriptor;
 
 	public ReactiveSingleIdEntityLoaderStandardImpl(
 			EntityMappingType entityDescriptor,
 			SessionFactoryImplementor sessionFactory) {
-		super( entityDescriptor, sessionFactory );
-		// todo (6.0) : consider creating a base AST and "cloning" it
-		this.entityDescriptor = entityDescriptor;
-	}
-
-	@Override
-	public EntityMappingType getLoadable() {
-		return entityDescriptor;
+		super(
+				entityDescriptor,
+				sessionFactory,
+				(lockOptions, influencers) -> createLoadPlan( entityDescriptor, lockOptions, influencers, sessionFactory )
+		);
 	}
 
 	@Override
 	public CompletionStage<Object[]> reactiveLoadDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
 		if ( databaseSnapshotExecutor == null ) {
-			databaseSnapshotExecutor = new DatabaseSnapshotExecutor( entityDescriptor, sessionFactory );
+			databaseSnapshotExecutor = new DatabaseSnapshotExecutor( getLoadable(), sessionFactory );
 		}
 
 		return databaseSnapshotExecutor.loadDatabaseSnapshot( id, session );
 	}
 
 	@Override
-	public void prepare() {
-		// see `org.hibernate.persister.entity.AbstractEntityPersister#createLoaders`
-		//		we should pre-load a few - maybe LockMode.NONE and LockMode.READ
-		final LockOptions lockOptions = LockOptions.NONE;
-		final LoadQueryInfluencers queryInfluencers = new LoadQueryInfluencers( sessionFactory );
-		final ReactiveSingleIdLoadPlan<T> plan = createLoadPlan(
+	public CompletionStage<T> load(
+			Object key,
+			LockOptions lockOptions,
+			Boolean readOnly,
+			SharedSessionContractImplementor session) {
+		final ReactiveSingleIdLoadPlan<T> loadPlan = (ReactiveSingleIdLoadPlan<T>) resolveLoadPlan(
 				lockOptions,
-				queryInfluencers,
-				sessionFactory
+				session.getLoadQueryInfluencers(),
+				session.getFactory()
 		);
-		if ( determineIfReusable( lockOptions, queryInfluencers ) ) {
-			selectByLockMode.put( lockOptions.getLockMode(), plan );
-		}
-	}
-
-	private boolean determineIfReusable(LockOptions lockOptions, LoadQueryInfluencers loadQueryInfluencers) {
-		if ( getLoadable().isAffectedByEntityGraph( loadQueryInfluencers ) ) {
-			return false;
-		}
-
-		if ( getLoadable().isAffectedByEnabledFetchProfiles( loadQueryInfluencers ) ) {
-			return false;
-		}
-
-		//noinspection RedundantIfStatement
-		if ( lockOptions.getTimeOut() != LockOptions.WAIT_FOREVER ) {
-			return false;
-		}
-
-		return true;
-	}
-
-	@Override
-	public CompletionStage<T> load(Object key, LockOptions lockOptions, Boolean readOnly, SharedSessionContractImplementor session) {
-		final ReactiveSingleIdLoadPlan<T> loadPlan = resolveLoadPlan( lockOptions, session.getLoadQueryInfluencers(), session.getFactory() );
 		return loadPlan.load( key, readOnly, true, session );
 	}
 
@@ -113,93 +68,21 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 			LockOptions lockOptions,
 			Boolean readOnly,
 			SharedSessionContractImplementor session) {
-		final ReactiveSingleIdLoadPlan<T> loadPlan = resolveLoadPlan(
-				lockOptions,
-				session.getLoadQueryInfluencers(),
-				session.getFactory()
-		);
-
+		final ReactiveSingleIdLoadPlan<T> loadPlan = (ReactiveSingleIdLoadPlan<T>) resolveLoadPlan( lockOptions, session.getLoadQueryInfluencers(), session.getFactory() );
 		return loadPlan.load( key, entityInstance, readOnly, false, session );
 	}
 
-	@Internal
-	@Override
-	public ReactiveSingleIdLoadPlan<T> resolveLoadPlan(
-			LockOptions lockOptions,
-			LoadQueryInfluencers loadQueryInfluencers,
-			SessionFactoryImplementor sessionFactory) {
-		if ( getLoadable().isAffectedByEnabledFilters( loadQueryInfluencers ) ) {
-			// special case of not-cacheable based on enabled filters effecting this load.
-			//
-			// This case is special because the filters need to be applied in order to
-			// 		properly restrict the SQL/JDBC results.  For this reason it has higher
-			// 		precedence than even "internal" fetch profiles.
-			nonReusablePlansGenerated.incrementAndGet();
-			return createLoadPlan( lockOptions, loadQueryInfluencers, sessionFactory );
-		}
-
-		final CascadingFetchProfile enabledCascadingFetchProfile = loadQueryInfluencers.getEnabledCascadingFetchProfile();
-		if ( enabledCascadingFetchProfile != null ) {
-			if ( LockMode.WRITE.greaterThan( lockOptions.getLockMode() ) ) {
-				if ( selectByInternalCascadeProfile == null ) {
-					selectByInternalCascadeProfile = new EnumMap<>( CascadingFetchProfile.class );
-				}
-				else {
-					final ReactiveSingleIdLoadPlan existing = selectByInternalCascadeProfile.get( enabledCascadingFetchProfile );
-					if ( existing != null ) {
-						//noinspection unchecked
-						return existing;
-					}
-				}
-
-				final ReactiveSingleIdLoadPlan<T> plan = createLoadPlan(
-						lockOptions,
-						loadQueryInfluencers,
-						sessionFactory
-				);
-				selectByInternalCascadeProfile.put( enabledCascadingFetchProfile, plan );
-				return plan;
-			}
-		}
-
-		// otherwise see if the loader for the requested load can be cached - which
-		// 		also means we should look in the cache for an existing one
-
-		final boolean reusable = determineIfReusable( lockOptions, loadQueryInfluencers );
-
-		if ( reusable ) {
-			final ReactiveSingleIdLoadPlan<T> existing = selectByLockMode.get( lockOptions.getLockMode() );
-			if ( existing != null ) {
-				//noinspection unchecked
-				return existing;
-			}
-
-			final ReactiveSingleIdLoadPlan<T> plan = createLoadPlan(
-					lockOptions,
-					loadQueryInfluencers,
-					sessionFactory
-			);
-			selectByLockMode.put( lockOptions.getLockMode(), plan );
-
-			return plan;
-		}
-
-		nonReusablePlansGenerated.incrementAndGet();
-		return createLoadPlan( lockOptions, loadQueryInfluencers, sessionFactory );
-	}
-
-	private ReactiveSingleIdLoadPlan<T> createLoadPlan(
+	private static <T> ReactiveSingleIdLoadPlan<T> createLoadPlan(
+			EntityMappingType loadable,
 			LockOptions lockOptions,
 			LoadQueryInfluencers queryInfluencers,
 			SessionFactoryImplementor sessionFactory) {
-
-
 		final JdbcParametersList.Builder jdbcParametersListBuilder = JdbcParametersList.newBuilder();
 		final SelectStatement sqlAst = LoaderSelectBuilder.createSelect(
-				getLoadable(),
+				loadable,
 				// null here means to select everything
 				null,
-				getLoadable().getIdentifierMapping(),
+				loadable.getIdentifierMapping(),
 				null,
 				1,
 				queryInfluencers,
@@ -210,8 +93,8 @@ public class ReactiveSingleIdEntityLoaderStandardImpl<T> extends SingleIdEntityL
 		final JdbcParametersList jdbcParameters = jdbcParametersListBuilder.build();
 
 		return new ReactiveSingleIdLoadPlan<>(
-				(Loadable) getLoadable(),
-				getLoadable().getIdentifierMapping(),
+				loadable,
+				loadable.getIdentifierMapping(),
 				sqlAst,
 				jdbcParameters,
 				lockOptions,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/internal/ReactiveSingleIdLoadPlan.java
@@ -15,6 +15,7 @@ import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.loader.ast.internal.SingleIdLoadPlan;
+import org.hibernate.metamodel.mapping.EntityMappingType;
 import org.hibernate.metamodel.mapping.ModelPart;
 import org.hibernate.persister.entity.Loadable;
 import org.hibernate.query.internal.SimpleQueryOptions;
@@ -35,7 +36,7 @@ import org.hibernate.sql.results.graph.entity.LoadingEntityEntry;
 public class ReactiveSingleIdLoadPlan<T> extends SingleIdLoadPlan<CompletionStage<T>> {
 
 	public ReactiveSingleIdLoadPlan(
-			Loadable persister,
+			EntityMappingType persister,
 			ModelPart restrictivePart,
 			SelectStatement sqlAst,
 			JdbcParametersList jdbcParameters,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveMultiIdEntityLoader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/loader/ast/spi/ReactiveMultiIdEntityLoader.java
@@ -9,13 +9,22 @@ import java.util.List;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.event.spi.EventSource;
-import org.hibernate.loader.ast.spi.EntityMultiLoader;
+import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
+import org.hibernate.reactive.logging.impl.Log;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.hibernate.reactive.logging.impl.LoggerFactory.make;
 
 /**
  * @see org.hibernate.loader.ast.spi.MultiIdEntityLoader
  */
-public interface ReactiveMultiIdEntityLoader<T> extends EntityMultiLoader<CompletionStage<T>> {
+public interface ReactiveMultiIdEntityLoader<T> extends MultiIdEntityLoader<T> {
 
-	<K> CompletionStage<List<T>> load(K[] ids, MultiIdLoadOptions options, EventSource session);
+	@Override
+	default <K> List<T> load(K[] ids, MultiIdLoadOptions options, EventSource session) {
+		throw make( Log.class, lookup() ).nonReactiveMethodCall( "reactiveLoad" );
+	}
+
+	<K> CompletionStage<List<T>> reactiveLoad(K[] ids, MultiIdLoadOptions options, EventSource session);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -5,19 +5,11 @@
  */
 package org.hibernate.reactive.mutiny;
 
-import io.smallrye.mutiny.Uni;
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.EntityGraph;
-import jakarta.persistence.FlushModeType;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.Parameter;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaDelete;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.CriteriaUpdate;
-import jakarta.persistence.metamodel.Attribute;
-import jakarta.persistence.metamodel.Metamodel;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Function;
+
 import org.hibernate.Cache;
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
@@ -32,6 +24,7 @@ import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.query.Page;
 import org.hibernate.reactive.common.AffectedEntities;
 import org.hibernate.reactive.common.Identifier;
 import org.hibernate.reactive.common.ResultSetMapping;
@@ -40,10 +33,19 @@ import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.stat.Statistics;
 
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.function.BiFunction;
-import java.util.function.Function;
+import io.smallrye.mutiny.Uni;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityGraph;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.Parameter;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.Metamodel;
 
 import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
 import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttributeInterceptable;
@@ -140,6 +142,16 @@ public interface Mutiny {
 		 * 0.
 		 */
 		SelectionQuery<R> setFirstResult(int firstResult);
+
+		/**
+		 * Set the {@linkplain Page page} of results to return.
+		 *
+		 * @see Page
+		 *
+		 * @since 2.1
+		 */
+		@Incubating
+		SelectionQuery<R> setPage(Page page);
 
 		/**
 		 * @return the maximum number results, or {@link Integer#MAX_VALUE}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -347,6 +347,12 @@ public interface Mutiny {
 		 */
 		SelectionQuery<R> setPlan(EntityGraph<R> entityGraph);
 
+		/**
+		 * Enable a {@linkplain org.hibernate.annotations.FetchProfile fetch
+		 * profile} which will be in effect during execution of this query.
+		 */
+		SelectionQuery<R> enableFetchProfile(String profileName);
+
 		@Override
 		SelectionQuery<R> setParameter(int parameter, Object argument);
 
@@ -456,6 +462,9 @@ public interface Mutiny {
 
 		@Override
 		Query<R> setComment(String comment);
+
+		@Override
+		Query<R> enableFetchProfile(String profileName);
 	}
 
 
@@ -863,7 +872,7 @@ public interface Mutiny {
 		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
 		 */
-		<R> SelectionQuery<R> createSelectionQuery(String queryString);
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
 
 		/**
 		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -896,8 +896,12 @@ public interface Mutiny {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1461,8 +1465,12 @@ public interface Mutiny {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see Session#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1477,6 +1485,30 @@ public interface Mutiny {
 		 * @see Session#createQuery(String, Class)
 		 */
 		<R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
+		 * query string.
+		 *
+		 * @param queryString The HQL/JPQL query
+		 *
+		 * @return The {@link SelectionQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
+		 */
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL
+		 * update or delete statement.
+		 *
+		 * @param queryString The HQL/JPQL query, update or delete statement
+		 *
+		 * @return The {@link MutationQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String)
+		 */
+		MutationQuery createMutationQuery(String queryString);
 
 		/**
 		 * Create an instance of {@link Query} for the named query.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyMutationQueryImpl.java
@@ -8,7 +8,7 @@ package org.hibernate.reactive.mutiny.impl;
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.Parameter;
 import org.hibernate.reactive.mutiny.Mutiny.MutationQuery;
-import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.query.ReactiveMutationQuery;
 
 import java.util.concurrent.CompletionStage;
 import java.util.function.Supplier;
@@ -16,9 +16,9 @@ import java.util.function.Supplier;
 public class MutinyMutationQueryImpl<R> implements MutationQuery {
 
 	private final MutinySessionFactoryImpl factory;
-	private final ReactiveQuery<R> delegate;
+	private final ReactiveMutationQuery<R> delegate;
 
-	public MutinyMutationQueryImpl(ReactiveQuery<R> delegate, MutinySessionFactoryImpl factory) {
+	public MutinyMutationQueryImpl(ReactiveMutationQuery<R> delegate, MutinySessionFactoryImpl factory) {
 		this.delegate = delegate;
 		this.factory = factory;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -72,6 +72,12 @@ public class MutinyQueryImpl<R> implements Query<R> {
 	}
 
 	@Override
+	public Query<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
 	public Uni<R> getSingleResult() {
 		return uni( delegate::getReactiveSingleResult );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyQueryImpl.java
@@ -5,6 +5,20 @@
  */
 package org.hibernate.reactive.mutiny.impl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.LockMode;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.query.Page;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.Mutiny.Query;
+import org.hibernate.reactive.query.ReactiveQuery;
+
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
@@ -12,17 +26,6 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.LockMode;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.reactive.mutiny.Mutiny.Query;
-import org.hibernate.reactive.query.ReactiveQuery;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 public class MutinyQueryImpl<R> implements Query<R> {
 
@@ -118,6 +121,13 @@ public class MutinyQueryImpl<R> implements Query<R> {
 	@Override
 	public Query<R> setFirstResult(int startPosition) {
 		delegate.setFirstResult( startPosition );
+		return this;
+	}
+
+	@Override
+	public Mutiny.SelectionQuery<R> setPage(Page page) {
+		setFirstResult( page.getFirstResult() );
+		setMaxResults( page.getMaxResults() );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
@@ -5,6 +5,20 @@
  */
 package org.hibernate.reactive.mutiny.impl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
+
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.LockMode;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.query.Page;
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
+import org.hibernate.reactive.query.ReactiveSelectionQuery;
+
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
@@ -12,17 +26,6 @@ import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.LockMode;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
-import org.hibernate.reactive.query.ReactiveSelectionQuery;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.function.Supplier;
 
 public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	private final MutinySessionFactoryImpl factory;
@@ -111,6 +114,13 @@ public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	@Override
 	public SelectionQuery<R> setFirstResult(int startPosition) {
 		delegate.setFirstResult( startPosition );
+		return this;
+	}
+
+	@Override
+	public Mutiny.SelectionQuery<R> setPage(Page page) {
+		setMaxResults( page.getMaxResults() );
+		setFirstResult( page.getFirstResult() );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySelectionQueryImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.LockMode;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
-import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.query.ReactiveSelectionQuery;
 
 import java.util.List;
 import java.util.concurrent.CompletionStage;
@@ -26,9 +26,9 @@ import java.util.function.Supplier;
 
 public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	private final MutinySessionFactoryImpl factory;
-	private final ReactiveQuery<R> delegate;
+	private final ReactiveSelectionQuery<R> delegate;
 
-	public MutinySelectionQueryImpl(ReactiveQuery<R> delegate, MutinySessionFactoryImpl factory) {
+	public MutinySelectionQueryImpl(ReactiveSelectionQuery<R> delegate, MutinySessionFactoryImpl factory) {
 		this.delegate = delegate;
 		this.factory = factory;
 	}
@@ -207,6 +207,12 @@ public class MutinySelectionQueryImpl<R> implements SelectionQuery<R> {
 	@Override
 	public SelectionQuery<R> setComment(String comment) {
 		delegate.setComment( comment );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
 		return this;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -33,7 +33,6 @@ import org.hibernate.reactive.mutiny.Mutiny.MutationQuery;
 import org.hibernate.reactive.mutiny.Mutiny.Query;
 import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
 import org.hibernate.reactive.pool.ReactiveConnection;
-import org.hibernate.reactive.query.sqm.internal.ReactiveQuerySqmImpl;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.reactive.session.ReactiveQueryProducer;
 import org.hibernate.reactive.session.ReactiveSession;
@@ -125,7 +124,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 		return new MutinyMutationQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new MutinyQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
@@ -143,7 +142,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 	@Override
 	public <R> MutationQuery createQuery(CriteriaUpdate<R> criteriaUpdate) {
 		return new MutinyMutationQueryImpl<>(
-				(ReactiveQuerySqmImpl<R>) delegate.createReactiveMutationQuery( criteriaUpdate ),
+				delegate.createReactiveMutationQuery( criteriaUpdate ),
 				factory
 		);
 	}
@@ -151,7 +150,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 	@Override
 	public <R> MutationQuery createQuery(CriteriaDelete<R> criteriaDelete) {
 		return new MutinyMutationQueryImpl<>(
-				(ReactiveQuerySqmImpl<R>) delegate.createReactiveMutationQuery( criteriaDelete ),
+				delegate.createReactiveMutationQuery( criteriaDelete ),
 				factory
 		);
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -116,8 +116,8 @@ public class MutinySessionImpl implements Mutiny.Session {
 	}
 
 	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(String queryString) {
-		return new MutinySelectionQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new MutinySelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ), factory );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -68,9 +68,19 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 		return new MutinyQueryImpl<>( delegate.createReactiveQuery( queryString ), factory );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType) {
 		return new MutinySelectionQueryImpl<>( delegate.createReactiveQuery( queryString, resultType ), factory );
+	}
+
+	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new MutinySelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType), factory );
+	}
+
+	@Override
+	public Mutiny.MutationQuery createMutationQuery(String queryString) {
+		return new MutinyMutationQueryImpl<>( delegate.createReactiveMutationQuery( queryString), factory );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/impl/ReactiveBasicCollectionPersister.java
@@ -19,6 +19,8 @@ import org.hibernate.loader.ast.spi.CollectionLoader;
 import org.hibernate.mapping.Collection;
 import org.hibernate.metamodel.spi.RuntimeModelCreationContext;
 import org.hibernate.persister.collection.BasicCollectionPersister;
+import org.hibernate.persister.collection.CollectionPersister;
+import org.hibernate.query.named.NamedQueryMemento;
 import org.hibernate.reactive.loader.ast.internal.ReactiveCollectionLoader;
 import org.hibernate.reactive.loader.ast.internal.ReactiveCollectionLoaderSubSelectFetch;
 import org.hibernate.reactive.persister.collection.mutation.ReactiveDeleteRowsCoordinator;
@@ -47,8 +49,6 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	private final ReactiveDeleteRowsCoordinator deleteRowsCoordinator;
 	private final ReactiveRemoveCoordinator removeCoordinator;
 
-	private CollectionLoader reusableCollectionLoader;
-
 	public ReactiveBasicCollectionPersister(
 			Collection collectionBinding,
 			CollectionDataAccess cacheAccessStrategy,
@@ -62,17 +62,13 @@ public class ReactiveBasicCollectionPersister extends BasicCollectionPersister i
 	}
 
 	@Override
-	protected CollectionLoader createCollectionLoader(LoadQueryInfluencers loadQueryInfluencers) {
-		if ( isCollectionLoaderReusable( loadQueryInfluencers ) ) {
-			if ( reusableCollectionLoader == null ) {
-				reusableCollectionLoader = ReactiveAbstractCollectionPersister.super
-						.generateCollectionLoader( LoadQueryInfluencers.NONE );
-			}
-			return reusableCollectionLoader;
-		}
+	public CollectionLoader createNamedQueryCollectionLoader(CollectionPersister persister, NamedQueryMemento namedQueryMemento) {
+		return ReactiveAbstractCollectionPersister.super.createNamedQueryCollectionLoader( persister, namedQueryMemento );
+	}
 
-		// create a one-off
-		return ReactiveAbstractCollectionPersister.super.generateCollectionLoader( loadQueryInfluencers );
+	@Override
+	public CollectionLoader createSingleKeyCollectionLoader(LoadQueryInfluencers loadQueryInfluencers) {
+		return ReactiveAbstractCollectionPersister.super.createSingleKeyCollectionLoader( loadQueryInfluencers );
 	}
 
 	private ReactiveUpdateRowsCoordinator buildUpdateRowCoordinator() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveDeleteRowsCoordinatorStandard.java
@@ -22,7 +22,7 @@ import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.model.MutationOperationGroup;
 import org.hibernate.sql.model.MutationType;
-import org.hibernate.sql.model.internal.MutationOperationGroupSingle;
+import org.hibernate.sql.model.internal.MutationOperationGroupFactory;
 import org.hibernate.sql.model.jdbc.JdbcMutationOperation;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.loop;
@@ -32,7 +32,7 @@ import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER
 public class ReactiveDeleteRowsCoordinatorStandard extends DeleteRowsCoordinatorStandard implements ReactiveDeleteRowsCoordinator {
 	private final RowMutationOperations rowMutationOperations;
 	private final boolean deleteByIndex;
-	private MutationOperationGroupSingle operationGroup;
+	private MutationOperationGroup operationGroup;
 	private final BasicBatchKey batchKey;
 
 	public ReactiveDeleteRowsCoordinatorStandard(
@@ -101,12 +101,12 @@ public class ReactiveDeleteRowsCoordinatorStandard extends DeleteRowsCoordinator
 				.createExecutor( this::getBatchKey, operationGroup, session );
 	}
 
-	private MutationOperationGroupSingle createOperationGroup() {
+	private MutationOperationGroup createOperationGroup() {
 		assert getMutationTarget().getTargetPart() != null;
 		assert getMutationTarget().getTargetPart().getKeyDescriptor() != null;
 
 		final JdbcMutationOperation operation = rowMutationOperations.getDeleteRowOperation();
-		return new MutationOperationGroupSingle( MutationType.DELETE, getMutationTarget(), operation );
+		return MutationOperationGroupFactory.singleOperation( MutationType.DELETE, getMutationTarget(), operation );
 	}
 
 	private BasicBatchKey getBatchKey() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/collection/mutation/ReactiveRemoveCoordinatorStandard.java
@@ -5,7 +5,6 @@
  */
 package org.hibernate.reactive.persister.collection.mutation;
 
-import java.lang.invoke.MethodHandles;
 import java.util.concurrent.CompletionStage;
 
 import org.hibernate.engine.jdbc.batch.internal.BasicBatchKey;
@@ -18,34 +17,30 @@ import org.hibernate.persister.collection.mutation.CollectionTableMapping;
 import org.hibernate.persister.collection.mutation.OperationProducer;
 import org.hibernate.persister.collection.mutation.RemoveCoordinatorStandard;
 import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
-import org.hibernate.reactive.logging.impl.Log;
-import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.service.ServiceRegistry;
 import org.hibernate.sql.model.MutationOperationGroup;
-import org.hibernate.sql.model.MutationType;
 import org.hibernate.sql.model.ast.MutatingTableReference;
-import org.hibernate.sql.model.internal.MutationOperationGroupSingle;
 
 import static org.hibernate.persister.collection.mutation.RowMutationOperations.DEFAULT_RESTRICTOR;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 import static org.hibernate.sql.model.ModelMutationLogging.MODEL_MUTATION_LOGGER;
+import static org.hibernate.sql.model.MutationType.DELETE;
+import static org.hibernate.sql.model.internal.MutationOperationGroupFactory.singleOperation;
 
 public class ReactiveRemoveCoordinatorStandard extends RemoveCoordinatorStandard implements ReactiveRemoveCoordinator {
 
-	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
-
 	private final BasicBatchKey batchKey;
 	private final OperationProducer operationProducer;
-	private MutationOperationGroupSingle operationGroup;
+	private MutationOperationGroup operationGroup;
 
 	public ReactiveRemoveCoordinatorStandard(
 			CollectionMutationTarget mutationTarget,
 			OperationProducer operationProducer,
 			ServiceRegistry serviceRegistry) {
 		super( mutationTarget, operationProducer, serviceRegistry );
-		this.batchKey = new BasicBatchKey( mutationTarget.getRolePath() + "#REMOVE" );
 		this.operationProducer = operationProducer;
+		this.batchKey = new BasicBatchKey( mutationTarget.getRolePath() + "#REMOVE" );
 	}
 
 	private BasicBatchKey getBatchKey() {
@@ -92,7 +87,7 @@ public class ReactiveRemoveCoordinatorStandard extends RemoveCoordinatorStandard
 	}
 
 	// FIXME: Update ORM and inherit this
-	protected MutationOperationGroupSingle buildOperationGroup() {
+	private MutationOperationGroup buildOperationGroup() {
 		assert getMutationTarget().getTargetPart() != null;
 		assert getMutationTarget().getTargetPart().getKeyDescriptor() != null;
 
@@ -103,10 +98,6 @@ public class ReactiveRemoveCoordinatorStandard extends RemoveCoordinatorStandard
 		final CollectionTableMapping tableMapping = getMutationTarget().getCollectionTableMapping();
 		final MutatingTableReference tableReference = new MutatingTableReference( tableMapping );
 
-		return new MutationOperationGroupSingle(
-				MutationType.DELETE,
-				getMutationTarget(),
-				operationProducer.createOperation( tableReference )
-		);
+		return singleOperation( DELETE, getMutationTarget(), operationProducer.createOperation( tableReference ) );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveAbstractEntityPersister.java
@@ -261,10 +261,14 @@ public interface ReactiveAbstractEntityPersister extends ReactiveEntityPersister
 
 	@Override
 	default CompletionStage<Object[]> reactiveGetDatabaseSnapshot(Object id, SharedSessionContractImplementor session) {
-		return getReactiveSingleIdEntityLoader().reactiveLoadDatabaseSnapshot( id, session );
+		ReactiveSingleIdEntityLoader<?> reactiveSingleIdEntityLoader = getReactiveSingleIdEntityLoader();
+		return reactiveSingleIdEntityLoader.reactiveLoadDatabaseSnapshot( id, session );
 	}
 
-	ReactiveSingleIdEntityLoader<?> getReactiveSingleIdEntityLoader();
+	default ReactiveSingleIdEntityLoader<?> getReactiveSingleIdEntityLoader() {
+		AbstractEntityPersister delegate = delegate();
+		return (ReactiveSingleIdEntityLoader<?>) delegate.getSingleIdLoader();
+	}
 
 	/**
 	 * @see AbstractEntityPersister#getCurrentVersion(Object, SharedSessionContractImplementor)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveJoinedSubclassEntityPersister.java
@@ -17,7 +17,9 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.jdbc.Expectation;
+import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
+import org.hibernate.loader.ast.spi.SingleIdEntityLoader;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -36,7 +38,6 @@ import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
 import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
 import org.hibernate.property.access.spi.PropertyAccess;
-import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveDeleteCoordinator;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveInsertCoordinator;
@@ -73,6 +74,15 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 		reactiveDelegate = new ReactiveAbstractPersisterDelegate( this, persistentClass, creationContext );
 	}
 
+	@Override
+	protected SingleIdEntityLoader<?> buildSingleIdEntityLoader() {
+		return reactiveDelegate.buildSingleIdEntityLoader();
+	}
+
+	@Override
+	protected MultiIdEntityLoader<Object> buildMultiIdLoader() {
+		return reactiveDelegate.buildMultiIdEntityLoader();
+	}
 
 	@Override
 	protected AttributeMapping buildSingularAssociationAttributeMapping(
@@ -150,11 +160,6 @@ public class ReactiveJoinedSubclassEntityPersister extends JoinedSubclassEntityP
 	@Override
 	public Generator getGenerator() throws HibernateException {
 		return reactiveDelegate.reactive( super.getGenerator() );
-	}
-
-	@Override
-	public ReactiveSingleIdEntityLoader<?> getReactiveSingleIdEntityLoader() {
-		return reactiveDelegate.getSingleIdEntityLoader();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveSingleTableEntityPersister.java
@@ -21,7 +21,9 @@ import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.jdbc.Expectation;
+import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
+import org.hibernate.loader.ast.spi.SingleIdEntityLoader;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -40,7 +42,6 @@ import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
-import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveDeleteCoordinator;
 import org.hibernate.reactive.persister.entity.mutation.ReactiveInsertCoordinator;
@@ -59,7 +60,7 @@ import org.hibernate.type.EntityType;
  */
 public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersister implements ReactiveAbstractEntityPersister {
 
-	private final ReactiveAbstractPersisterDelegate reactiveDelegate;
+	private ReactiveAbstractPersisterDelegate reactiveDelegate;
 
 	public ReactiveSingleTableEntityPersister(
 			final PersistentClass persistentClass,
@@ -68,6 +69,16 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 		reactiveDelegate = new ReactiveAbstractPersisterDelegate( this, persistentClass, creationContext );
+	}
+
+	@Override
+	protected SingleIdEntityLoader<?> buildSingleIdEntityLoader() {
+		return reactiveDelegate.buildSingleIdEntityLoader();
+	}
+
+	@Override
+	protected MultiIdEntityLoader<Object> buildMultiIdLoader() {
+		return reactiveDelegate.buildMultiIdEntityLoader();
 	}
 
 	@Override
@@ -175,11 +186,6 @@ public class ReactiveSingleTableEntityPersister extends SingleTableEntityPersist
 	@Override
 	public String[][] getLazyPropertyColumnAliases() {
 		return super.getLazyPropertyColumnAliases();
-	}
-
-	@Override
-	public ReactiveSingleIdEntityLoader<?> getReactiveSingleIdEntityLoader() {
-		return reactiveDelegate.getSingleIdEntityLoader();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
@@ -24,7 +24,9 @@ import org.hibernate.event.spi.EventSource;
 import org.hibernate.generator.Generator;
 import org.hibernate.id.IdentityGenerator;
 import org.hibernate.jdbc.Expectation;
+import org.hibernate.loader.ast.spi.MultiIdEntityLoader;
 import org.hibernate.loader.ast.spi.MultiIdLoadOptions;
+import org.hibernate.loader.ast.spi.SingleIdEntityLoader;
 import org.hibernate.loader.ast.spi.SingleUniqueKeyEntityLoader;
 import org.hibernate.mapping.PersistentClass;
 import org.hibernate.mapping.Property;
@@ -43,7 +45,6 @@ import org.hibernate.persister.entity.mutation.InsertCoordinator;
 import org.hibernate.persister.entity.mutation.UpdateCoordinator;
 import org.hibernate.property.access.spi.PropertyAccess;
 import org.hibernate.reactive.loader.ast.internal.ReactiveSingleIdArrayLoadPlan;
-import org.hibernate.reactive.loader.ast.spi.ReactiveSingleIdEntityLoader;
 import org.hibernate.reactive.loader.ast.spi.ReactiveSingleUniqueKeyEntityLoader;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
@@ -74,6 +75,16 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 			final RuntimeModelCreationContext creationContext) throws HibernateException {
 		super( persistentClass, cacheAccessStrategy, naturalIdRegionAccessStrategy, creationContext );
 		reactiveDelegate = new ReactiveAbstractPersisterDelegate( this, persistentClass, creationContext );
+	}
+
+	@Override
+	protected SingleIdEntityLoader<?> buildSingleIdEntityLoader() {
+		return reactiveDelegate.buildSingleIdEntityLoader();
+	}
+
+	@Override
+	protected MultiIdEntityLoader<Object> buildMultiIdLoader() {
+		return reactiveDelegate.buildMultiIdEntityLoader();
 	}
 
 	@Override
@@ -173,11 +184,6 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	@Override
 	public Generator getGenerator() throws HibernateException {
 		return reactiveDelegate.reactive( super.getGenerator() );
-	}
-
-	@Override
-	public ReactiveSingleIdEntityLoader<?> getReactiveSingleIdEntityLoader() {
-		return reactiveDelegate.getSingleIdEntityLoader();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveTypeContributor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/impl/ReactiveTypeContributor.java
@@ -44,6 +44,7 @@ import org.hibernate.type.descriptor.jdbc.ClobJdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcType;
 import org.hibernate.type.descriptor.jdbc.JdbcTypeIndicators;
 import org.hibernate.type.descriptor.jdbc.ObjectJdbcType;
+import org.hibernate.type.descriptor.jdbc.ReactiveArrayJdbcTypeConstructor;
 import org.hibernate.type.descriptor.jdbc.TimestampJdbcType;
 import org.hibernate.type.descriptor.jdbc.TimestampUtcAsJdbcTimestampJdbcType;
 import org.hibernate.type.descriptor.jdbc.spi.JdbcTypeRegistry;
@@ -82,6 +83,7 @@ public class ReactiveTypeContributor implements TypeContributor {
 
 		JdbcTypeRegistry jdbcTypeRegistry = typeConfiguration.getJdbcTypeRegistry();
 		jdbcTypeRegistry.addDescriptor( ReactiveArrayJdbcType.INSTANCE );
+		jdbcTypeRegistry.addTypeConstructor( ReactiveArrayJdbcTypeConstructor.INSTANCE );
 
 		if ( dialect instanceof MySQLDialect || dialect instanceof DB2Dialect || dialect instanceof OracleDialect ) {
 			jdbcTypeRegistry.addDescriptor( TimestampAsLocalDateTimeJdbcType.INSTANCE );
@@ -186,11 +188,6 @@ public class ReactiveTypeContributor implements TypeContributor {
 		@Override
 		public String getRawTypeName() {
 			return "json";
-		}
-
-		@Override
-		public String getTypeNamePattern() {
-			return "";
 		}
 
 		@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
@@ -64,6 +64,7 @@ public interface ReactiveSelectionQuery<R> extends CommonQueryContract {
 
 	@Override
 	ReactiveSelectionQuery<R> setTimeout(int timeout);
+
 	Integer getFetchSize();
 
 	ReactiveSelectionQuery<R> setFetchSize(int fetchSize);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/ReactiveSelectionQuery.java
@@ -115,11 +115,14 @@ public interface ReactiveSelectionQuery<R> extends CommonQueryContract {
 
 	ReactiveSelectionQuery<R> setLockMode(String alias, LockMode lockMode);
 
+	@Deprecated
 	ReactiveSelectionQuery<R> setAliasSpecificLockMode(String alias, LockMode lockMode);
 
 	ReactiveSelectionQuery<R> setFollowOnLocking(boolean enable);
 
 	void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic);
+
+	ReactiveSelectionQuery<R> enableFetchProfile(String profileName);
 
 	@Override
 	ReactiveSelectionQuery<R> setParameter(String name, Object value);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
@@ -60,7 +60,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 
 	private final Supplier<DomainParameterXref> getDomainParameterXref;
 
-	private final Supplier<Class<R>> getResultType;
+	private final Supplier<Class<?>> getResultType;
 	private final Supplier<String> getQueryString;
 
 	private final Runnable beforeQuery;
@@ -78,7 +78,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 			Supplier<SqmStatement<?>> getStatement,
 			Supplier<TupleMetadata> getTupleMetadata,
 			Supplier<DomainParameterXref> getDomainParameterXref,
-			Supplier<Class<R>> getResultType,
+			Supplier<Class<?>> getResultType,
 			Supplier<String> getQueryString,
 			Runnable beforeQuery,
 			Consumer<Boolean> afterQuery,
@@ -106,7 +106,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 			Supplier<SqmStatement<?>> getStatement,
 			Supplier<TupleMetadata> getTupleMetadata,
 			Supplier<DomainParameterXref> getDomainParameterXref,
-			Supplier<Class<R>> getResultType,
+			Supplier<Class<?>> getResultType,
 			Supplier<String> getQueryString,
 			Runnable beforeQuery,
 			Consumer<Boolean> afterQuery,
@@ -264,8 +264,8 @@ public class ReactiveAbstractSelectionQuery<R> {
 		return doList.get();
 	}
 
-	public SqmStatement<?> getSqmStatement() {
-		return getStatement.get();
+	public SqmStatement<R> getSqmStatement() {
+		return (SqmStatement<R>) getStatement.get();
 	}
 
 	public TupleMetadata getTupleMetadata() {
@@ -273,7 +273,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 	}
 
 	public Class<R> getResultType() {
-		return getResultType.get();
+		return (Class<R>) getResultType.get();
 	}
 
 	public DomainParameterXref getDomainParameterXref() {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
@@ -6,8 +6,7 @@
 package org.hibernate.reactive.query.spi;
 
 import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.CompletionStage;
 import java.util.function.Consumer;
@@ -18,6 +17,7 @@ import java.util.stream.Stream;
 import org.hibernate.HibernateException;
 import org.hibernate.LockOptions;
 import org.hibernate.TypeMismatchException;
+import org.hibernate.engine.spi.LoadQueryInfluencers;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.IllegalQueryOperationException;
 import org.hibernate.query.hql.internal.QuerySplitter;
@@ -36,6 +36,8 @@ import org.hibernate.reactive.query.sqm.spi.ReactiveSelectQueryPlan;
 import org.hibernate.sql.results.internal.TupleMetadata;
 
 import jakarta.persistence.NoResultException;
+
+import static java.util.Collections.emptySet;
 
 /**
  * Emulate {@link org.hibernate.query.spi.AbstractSelectionQuery}.
@@ -62,6 +64,8 @@ public class ReactiveAbstractSelectionQuery<R> {
 
 	private final Supplier<Class<?>> getResultType;
 	private final Supplier<String> getQueryString;
+
+	private Set<String> fetchProfiles;
 
 	private final Runnable beforeQuery;
 
@@ -175,13 +179,40 @@ public class ReactiveAbstractSelectionQuery<R> {
 	}
 
 	public CompletionStage<List<R>> reactiveList() {
+		final Set<String> profiles = applyProfiles();
 		beforeQuery.run();
 		return doReactiveList()
 				.handle( (list, error) -> {
 					handleException( error );
 					return list;
 				} )
-				.whenComplete( (rs, throwable) -> afterQuery.accept( throwable == null ) );
+				.whenComplete( (rs, throwable) -> {
+					afterQuery.accept( throwable == null );
+					unapplyProfiles( profiles );
+				} );
+	}
+
+	private void unapplyProfiles(Set<String> profiles) {
+		for ( String profile : profiles) {
+			session.getLoadQueryInfluencers().disableFetchProfile( profile );
+		}
+	}
+
+	private Set<String> applyProfiles() {
+		final LoadQueryInfluencers loadQueryInfluencers = session.getLoadQueryInfluencers();
+		if ( fetchProfiles != null ) {
+			final Set<String> profiles = new HashSet<>( fetchProfiles.size() );
+			for ( String profile : fetchProfiles ) {
+				if ( !loadQueryInfluencers.isFetchProfileEnabled( profile ) ) {
+					loadQueryInfluencers.enableFetchProfile( profile );
+					profiles.add( profile );
+				}
+			}
+			return profiles;
+		}
+		else {
+			return emptySet();
+		}
 	}
 
 	private void handleException(Throwable e) {
@@ -312,4 +343,10 @@ public class ReactiveAbstractSelectionQuery<R> {
 		throw LOG.nonReactiveMethodCall( "reactiveUniqueResultOptional" );
 	}
 
+	public void enableFetchProfile(String profileName) {
+		if ( fetchProfiles == null ) {
+			fetchProfiles = new HashSet<>();
+		}
+		fetchProfiles.add( profileName );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeQueryImpl.java
@@ -741,4 +741,9 @@ public class ReactiveNativeQueryImpl<R> extends NativeQueryImpl<R>
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		super.applyGraph( graph, semantic );
 	}
+
+	@Override
+	public ReactiveNativeQueryImpl<R> enableFetchProfile(String profileName) {
+		throw new UnsupportedOperationException("A native SQL query cannot use fetch profiles");
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
@@ -7,7 +7,12 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
-import java.util.*;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
@@ -210,7 +215,7 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 			final int toIndex = max != -1
 					? first + max
 					: resultSize;
-			return list.subList( first, toIndex > resultSize ? resultSize : toIndex );
+			return list.subList( first, Math.min( toIndex, resultSize ) );
 		}
 		return list;
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
@@ -7,12 +7,7 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.lang.invoke.MethodHandles;
 import java.time.Instant;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.concurrent.CompletionStage;
 import java.util.stream.Stream;
 
@@ -830,5 +825,11 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 	@Override
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		super.applyGraph( graph, semantic );
+	}
+
+	@Override
+	public ReactiveQuerySqmImpl<R> enableFetchProfile(String profileName) {
+		selectionQueryDelegate.enableFetchProfile( profileName );
+		return this;
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveQuerySqmImpl.java
@@ -193,7 +193,7 @@ public class ReactiveQuerySqmImpl<R> extends QuerySqmImpl<R> implements Reactive
 		final boolean needsDistinct = containsCollectionFetches
 				&& ( sqmStatement.usesDistinct() || hasAppliedGraph( getQueryOptions() ) || hasLimit );
 
-		final DomainQueryExecutionContext executionContextToUse = executionContextFordoList( containsCollectionFetches, hasLimit, needsDistinct );
+		final DomainQueryExecutionContext executionContextToUse = executionContextForDoList( containsCollectionFetches, hasLimit, needsDistinct );
 
 		return resolveSelectReactiveQueryPlan()
 				.reactivePerformList( executionContextToUse )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
@@ -93,7 +93,7 @@ public class ReactiveSqmSelectionQueryImpl<R> extends SqmSelectionQueryImpl<R> i
 		getSession().prepareForQueryExecution( requiresTxn( getQueryOptions().getLockOptions()
 																	.findGreatestLockMode() ) );
 
-		final SqmSelectStatement<?> sqmStatement = (SqmSelectStatement<?>) getSqmStatement();
+		final SqmSelectStatement<?> sqmStatement = getSqmStatement();
 		final boolean containsCollectionFetches = sqmStatement.containsCollectionFetches();
 		final boolean hasLimit = hasLimit( sqmStatement, getQueryOptions() );
 		final boolean needsDistinct = containsCollectionFetches

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSqmSelectionQueryImpl.java
@@ -588,4 +588,10 @@ public class ReactiveSqmSelectionQueryImpl<R> extends SqmSelectionQueryImpl<R> i
 	public void applyGraph(RootGraphImplementor<?> graph, GraphSemantic semantic) {
 		getQueryOptions().applyGraph( graph, semantic );
 	}
+
+	@Override
+	public ReactiveSqmSelectionQueryImpl<R> enableFetchProfile(String profileName) {
+		selectionQueryDelegate.enableFetchProfile( profileName );
+		return this;
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveAbstractCteMutationHandler.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/cte/ReactiveAbstractCteMutationHandler.java
@@ -209,7 +209,7 @@ public interface ReactiveAbstractCteMutationHandler extends ReactiveAbstractMuta
 		return factory.getQueryEngine()
 				.getSqmFunctionRegistry()
 				.findFunctionDescriptor( "count" )
-				.generateSqmExpression( arg, null, factory.getQueryEngine(), typeConfiguration )
+				.generateSqmExpression( arg, null, factory.getQueryEngine() )
 				.convertToSqlAst( sqmConverter );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
@@ -69,8 +69,6 @@ public interface ReactiveQueryProducer extends ReactiveConnectionSupplier {
 
 	<R> ReactiveNativeQuery<R> createReactiveNativeQuery(String sqlString, String resultSetMappingName, Class<R> resultClass);
 
-	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString);
-
 	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType);
 
 	<R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(CriteriaQuery<R> criteria);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionFactoryImpl.java
@@ -5,8 +5,6 @@
  */
 package org.hibernate.reactive.session.impl;
 
-
-
 import org.hibernate.boot.spi.BootstrapContext;
 import org.hibernate.boot.spi.MetadataImplementor;
 import org.hibernate.boot.spi.SessionFactoryOptions;
@@ -18,8 +16,6 @@ import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.mutiny.impl.MutinySessionFactoryImpl;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.impl.StageSessionFactoryImpl;
-
-
 
 /**
  * A Hibernate {@link org.hibernate.SessionFactory} that can be

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -231,7 +231,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 		final GraphSemantic semantic = effectiveEntityGraph.getSemantic();
 		final RootGraphImplementor<?> graph = effectiveEntityGraph.getGraph();
 		boolean clearedEffectiveGraph;
-		if ( semantic == null || graph.appliesTo( entityName ) ) {
+		if ( semantic == null || graph.appliesTo( getFactory().getJpaMetamodel().entity( entityName ) ) ) {
 			clearedEffectiveGraph = false;
 		}
 		else {
@@ -1585,8 +1585,8 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 			}
 		}
 
-		protected final ReactiveIdentifierLoadAccessImpl getIdentifierLoadAccess() {
-			final ReactiveIdentifierLoadAccessImpl identifierLoadAccess = new ReactiveIdentifierLoadAccessImpl(
+		protected final ReactiveIdentifierLoadAccessImpl<T> getIdentifierLoadAccess() {
+			final ReactiveIdentifierLoadAccessImpl<T> identifierLoadAccess = new ReactiveIdentifierLoadAccessImpl<>(
 					entityPersister );
 			if ( this.lockOptions != null ) {
 				identifierLoadAccess.with( lockOptions );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -468,11 +468,6 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	}
 
 	@Override
-	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString) {
-		return interpretAndCreateSelectionQuery( hqlString, null );
-	}
-
-	@Override
 	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType) {
 		return interpretAndCreateSelectionQuery( hqlString, resultType );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -608,12 +608,9 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 		}
 	}
 
-
 	@Override
 	public <T> RootGraphImplementor<T> createEntityGraph(Class<T> entity) {
-		return new RootGraphImpl<>( null,
-									getFactory().getJpaMetamodel().entity( entity ),
-									getSessionFactory().getJpaMetamodel() );
+		return new RootGraphImpl<>( null, getFactory().getJpaMetamodel().entity( entity ) );
 	}
 
 	@Override
@@ -626,14 +623,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 		return (RootGraphImplementor<T>) entityGraph;
 	}
 
-	private RootGraphImplementor<?> createEntityGraph(String graphName) {
-		checkOpen();
-		final RootGraphImplementor<?> named = getFactory().findEntityGraphByName( graphName );
-		return named != null
-				? named.makeRootGraph( graphName, true )
-				: null;
-	}
-
 	@Override
 	@SuppressWarnings("unchecked")
 	public <T> RootGraphImplementor<T> getEntityGraph(Class<T> entity, String name) {
@@ -642,15 +631,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 			throw LOG.wrongEntityType();
 		}
 		return (RootGraphImplementor<T>) entityGraph;
-	}
-
-	private RootGraphImplementor<?> getEntityGraph(String graphName) {
-		checkOpen();
-		final RootGraphImplementor<?> named = getFactory().findEntityGraphByName( graphName );
-		if ( named == null ) {
-			throw new IllegalArgumentException( "Could not locate EntityGraph with given name : " + graphName );
-		}
-		return named;
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -792,11 +792,6 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 	}
 
 	@Override
-	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString) {
-		return interpretAndCreateSelectionQuery( hqlString, null );
-	}
-
-	@Override
 	public <R> ReactiveSelectionQuery<R> createReactiveSelectionQuery(String hqlString, Class<R> resultType) {
 		return interpretAndCreateSelectionQuery( hqlString, resultType );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/ReactiveStandardMutationExecutorService.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/exec/internal/ReactiveStandardMutationExecutorService.java
@@ -14,17 +14,15 @@ import org.hibernate.engine.jdbc.mutation.spi.BatchKeyAccess;
 import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.internal.util.config.ConfigurationHelper;
-import org.hibernate.metamodel.mapping.EntityMappingType;
-import org.hibernate.persister.entity.mutation.EntityMutationTarget;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorPostInsert;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorPostInsertSingleTable;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorSingleBatched;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorSingleNonBatched;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorSingleSelfExecuting;
 import org.hibernate.reactive.engine.jdbc.mutation.internal.ReactiveMutationExecutorStandard;
+import org.hibernate.sql.model.EntityMutationOperationGroup;
 import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.MutationOperationGroup;
-import org.hibernate.sql.model.MutationTarget;
 import org.hibernate.sql.model.MutationType;
 import org.hibernate.sql.model.PreparableMutationOperation;
 import org.hibernate.sql.model.SelfExecutingUpdateOperation;
@@ -60,18 +58,16 @@ public class ReactiveStandardMutationExecutorService implements MutationExecutor
 
 		final int numberOfOperations = operationGroup.getNumberOfOperations();
 		final MutationType mutationType = operationGroup.getMutationType();
-		final MutationTarget<?> mutationTarget = operationGroup.getMutationTarget();
+		final EntityMutationOperationGroup entityMutationOperationGroup = operationGroup.asEntityMutationOperationGroup();
 
 		if ( mutationType == MutationType.INSERT
-				&& mutationTarget instanceof EntityMutationTarget
-				&& ( (EntityMutationTarget) mutationTarget ).getIdentityInsertDelegate() != null ) {
-			assert mutationTarget instanceof EntityMappingType;
-
+				&& entityMutationOperationGroup != null
+				&& entityMutationOperationGroup.getMutationTarget().getIdentityInsertDelegate() != null ) {
 			if ( numberOfOperations > 1 ) {
-				return new ReactiveMutationExecutorPostInsert( operationGroup, session );
+				return new ReactiveMutationExecutorPostInsert( entityMutationOperationGroup, session );
 			}
 
-			return new ReactiveMutationExecutorPostInsertSingleTable( operationGroup, session );
+			return new ReactiveMutationExecutorPostInsertSingleTable( entityMutationOperationGroup, session );
 		}
 
 		if ( numberOfOperations == 1 ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveResultsHelper.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveResultsHelper.java
@@ -102,6 +102,11 @@ public class ReactiveResultsHelper {
 			public SqlAstCreationContext getSqlAstCreationContext() {
 				return sessionFactory;
 			}
+
+			@Override
+			public ExecutionContext getExecutionContext() {
+				return executionContext;
+			}
 		};
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -349,6 +349,12 @@ public interface Stage {
 		 */
 		SelectionQuery<R> setPlan(EntityGraph<R> entityGraph);
 
+		/**
+		 * Enable a {@linkplain org.hibernate.annotations.FetchProfile fetch
+		 * profile} which will be in effect during execution of this query.
+		 */
+		SelectionQuery<R> enableFetchProfile(String profileName);
+
 		@Override
 		SelectionQuery<R> setParameter(int parameter, Object argument);
 
@@ -903,7 +909,7 @@ public interface Stage {
 		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
 		 */
-		<R> SelectionQuery<R> createSelectionQuery(String queryString);
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
 
 		/**
 		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -933,8 +933,12 @@ public interface Stage {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see jakarta.persistence.EntityManager#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1496,8 +1500,12 @@ public interface Stage {
 		 *
 		 * @return The {@link Query} instance for manipulation and execution
 		 *
+		 * @deprecated See explanation in
+		 * {@link org.hibernate.query.QueryProducer#createSelectionQuery(String)}
+		 *
 		 * @see org.hibernate.Session#createQuery(String)
 		 */
+		@Deprecated
 		<R> Query<R> createQuery(String queryString);
 
 		/**
@@ -1512,6 +1520,30 @@ public interface Stage {
 		 * @see org.hibernate.Session#createQuery(String, Class)
 		 */
 		<R> SelectionQuery<R> createQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
+		 * query string.
+		 *
+		 * @param queryString The HQL/JPQL query
+		 *
+		 * @return The {@link SelectionQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String, Class)
+		 */
+		<R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType);
+
+		/**
+		 * Create an instance of {@link MutationQuery} for the given HQL/JPQL
+		 * update or delete statement.
+		 *
+		 * @param queryString The HQL/JPQL query, update or delete statement
+		 *
+		 * @return The {@link MutationQuery} instance for manipulation and execution
+		 *
+		 * @see jakarta.persistence.EntityManager#createQuery(String)
+		 */
+		MutationQuery createMutationQuery(String queryString);
 
 		/**
 		 * Create an instance of {@link Query} for the given SQL query string,

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -5,18 +5,15 @@
  */
 package org.hibernate.reactive.stage;
 
-import java.lang.invoke.MethodHandles;
-import java.util.List;
-import java.util.concurrent.CompletionStage;
-import java.util.function.BiFunction;
-import java.util.function.Function;
-
+import jakarta.persistence.*;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaDelete;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.CriteriaUpdate;
+import jakarta.persistence.metamodel.Attribute;
+import jakarta.persistence.metamodel.Metamodel;
 import org.hibernate.Cache;
-import org.hibernate.CacheMode;
-import org.hibernate.Filter;
-import org.hibernate.FlushMode;
-import org.hibernate.Incubating;
-import org.hibernate.LockMode;
+import org.hibernate.*;
 import org.hibernate.bytecode.enhance.spi.interceptor.EnhancementAsProxyLazinessInterceptor;
 import org.hibernate.collection.spi.AbstractPersistentCollection;
 import org.hibernate.collection.spi.PersistentCollection;
@@ -25,6 +22,7 @@ import org.hibernate.engine.spi.PersistentAttributeInterceptor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.jpa.internal.util.FlushModeTypeHelper;
 import org.hibernate.proxy.HibernateProxy;
+import org.hibernate.query.Page;
 import org.hibernate.reactive.common.AffectedEntities;
 import org.hibernate.reactive.common.Identifier;
 import org.hibernate.reactive.common.ResultSetMapping;
@@ -34,25 +32,16 @@ import org.hibernate.reactive.session.impl.ReactiveQueryExecutorLookup;
 import org.hibernate.reactive.util.impl.CompletionStages;
 import org.hibernate.stat.Statistics;
 
-import jakarta.persistence.CacheRetrieveMode;
-import jakarta.persistence.CacheStoreMode;
-import jakarta.persistence.EntityGraph;
-import jakarta.persistence.FlushModeType;
-import jakarta.persistence.LockModeType;
-import jakarta.persistence.Parameter;
-import jakarta.persistence.criteria.CriteriaBuilder;
-import jakarta.persistence.criteria.CriteriaDelete;
-import jakarta.persistence.criteria.CriteriaQuery;
-import jakarta.persistence.criteria.CriteriaUpdate;
-import jakarta.persistence.metamodel.Attribute;
-import jakarta.persistence.metamodel.Metamodel;
+import java.lang.invoke.MethodHandles;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.hibernate.engine.internal.ManagedTypeHelper.asPersistentAttributeInterceptable;
 import static org.hibernate.engine.internal.ManagedTypeHelper.isPersistentAttributeInterceptable;
 import static org.hibernate.internal.util.LockModeConverter.convertToLockMode;
-import static org.hibernate.jpa.internal.util.CacheModeHelper.interpretCacheMode;
-import static org.hibernate.jpa.internal.util.CacheModeHelper.interpretCacheRetrieveMode;
-import static org.hibernate.jpa.internal.util.CacheModeHelper.interpretCacheStoreMode;
+import static org.hibernate.jpa.internal.util.CacheModeHelper.*;
 
 /**
  * An API for Hibernate Reactive where non-blocking operations are
@@ -142,6 +131,16 @@ public interface Stage {
 		 * 0.
 		 */
 		SelectionQuery<R> setFirstResult(int firstResult);
+
+		/**
+		 * Set the {@linkplain Page page} of results to return.
+		 *
+		 * @see Page
+		 *
+		 * @since 2.1
+		 */
+		@Incubating
+		SelectionQuery<R> setPage(Page page);
 
 		/**
 		 * @return the maximum number results, or {@link Integer#MAX_VALUE}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -5,23 +5,25 @@
  */
 package org.hibernate.reactive.stage.impl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.LockMode;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.query.Page;
+import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.stage.Stage.Query;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.LockMode;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.reactive.query.ReactiveQuery;
-import org.hibernate.reactive.stage.Stage;
-import org.hibernate.reactive.stage.Stage.Query;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 public class StageQueryImpl<R> implements Query<R> {
 	private final ReactiveQuery<R> delegate;
@@ -110,6 +112,13 @@ public class StageQueryImpl<R> implements Query<R> {
 	@Override
 	public Query<R> setFirstResult(int startPosition) {
 		delegate.setFirstResult( startPosition );
+		return this;
+	}
+
+	@Override
+	public Stage.SelectionQuery<R> setPage(Page page) {
+		setFirstResult( page.getFirstResult() );
+		setMaxResults( page.getMaxResults() );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageQueryImpl.java
@@ -17,6 +17,7 @@ import org.hibernate.LockMode;
 import org.hibernate.graph.GraphSemantic;
 import org.hibernate.graph.spi.RootGraphImplementor;
 import org.hibernate.reactive.query.ReactiveQuery;
+import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.Stage.Query;
 
 import java.util.List;
@@ -59,6 +60,12 @@ public class StageQueryImpl<R> implements Query<R> {
 	@Override
 	public Query<R> setPlan(EntityGraph<R> entityGraph) {
 		delegate.applyGraph( (RootGraphImplementor<?>) entityGraph, GraphSemantic.FETCH );
+		return this;
+	}
+
+	@Override
+	public Stage.SelectionQuery<R> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
@@ -63,6 +63,12 @@ public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	}
 
 	@Override
+	public SelectionQuery<T> enableFetchProfile(String profileName) {
+		delegate.enableFetchProfile( profileName );
+		return this;
+	}
+
+	@Override
 	public CompletionStage<T> getSingleResult() {
 		return delegate.getReactiveSingleResult();
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSelectionQueryImpl.java
@@ -5,22 +5,24 @@
  */
 package org.hibernate.reactive.stage.impl;
 
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+
+import org.hibernate.CacheMode;
+import org.hibernate.FlushMode;
+import org.hibernate.LockMode;
+import org.hibernate.graph.GraphSemantic;
+import org.hibernate.graph.spi.RootGraphImplementor;
+import org.hibernate.query.Page;
+import org.hibernate.reactive.query.ReactiveSelectionQuery;
+import org.hibernate.reactive.stage.Stage.SelectionQuery;
+
 import jakarta.persistence.CacheRetrieveMode;
 import jakarta.persistence.CacheStoreMode;
 import jakarta.persistence.EntityGraph;
 import jakarta.persistence.FlushModeType;
 import jakarta.persistence.LockModeType;
 import jakarta.persistence.Parameter;
-import org.hibernate.CacheMode;
-import org.hibernate.FlushMode;
-import org.hibernate.LockMode;
-import org.hibernate.graph.GraphSemantic;
-import org.hibernate.graph.spi.RootGraphImplementor;
-import org.hibernate.reactive.query.ReactiveSelectionQuery;
-import org.hibernate.reactive.stage.Stage.SelectionQuery;
-
-import java.util.List;
-import java.util.concurrent.CompletionStage;
 
 public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	private final ReactiveSelectionQuery<T> delegate;
@@ -109,6 +111,13 @@ public class StageSelectionQueryImpl<T> implements SelectionQuery<T> {
 	@Override
 	public SelectionQuery<T> setFirstResult(int startPosition) {
 		delegate.setFirstResult( startPosition );
+		return this;
+	}
+
+	@Override
+	public SelectionQuery<T> setPage(Page page) {
+		setMaxResults( page.getMaxResults() );
+		setFirstResult( page.getFirstResult() );
 		return this;
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -485,7 +485,7 @@ public class StageSessionImpl implements Stage.Session {
 		return delegate.createEntityGraph( rootType, graphName );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new StageQueryImpl<>( delegate.createReactiveQuery( queryString ) );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -108,8 +108,8 @@ public class StageSessionImpl implements Stage.Session {
 	}
 
 	@Override
-	public <R> SelectionQuery<R> createSelectionQuery(String queryString) {
-		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString ) );
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ) );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -225,9 +225,19 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 		return delegate.reactiveGet( entityClass, id, null, entityGraph );
 	}
 
-	@Override
+	@Override @Deprecated
 	public <R> Query<R> createQuery(String queryString) {
 		return new StageQueryImpl<>( delegate.createReactiveQuery( queryString ) );
+	}
+
+	@Override
+	public <R> SelectionQuery<R> createSelectionQuery(String queryString, Class<R> resultType) {
+		return new StageSelectionQueryImpl<>( delegate.createReactiveSelectionQuery( queryString, resultType ) );
+	}
+
+	@Override
+	public MutationQuery createMutationQuery(String queryString) {
+		return new StageMutationQueryImpl<>( delegate.createReactiveMutationQuery( queryString ) );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/type/descriptor/jdbc/ReactiveArrayJdbcTypeConstructor.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/type/descriptor/jdbc/ReactiveArrayJdbcTypeConstructor.java
@@ -1,0 +1,43 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.type.descriptor.jdbc;
+
+import java.sql.Types;
+
+import org.hibernate.dialect.Dialect;
+import org.hibernate.reactive.type.descriptor.jdbc.ReactiveArrayJdbcType;
+import org.hibernate.tool.schema.extract.spi.ColumnTypeInformation;
+import org.hibernate.type.BasicType;
+import org.hibernate.type.spi.TypeConfiguration;
+
+/**
+ * Factory for {@link ReactiveArrayJdbcType}.
+ */
+public class ReactiveArrayJdbcTypeConstructor implements JdbcTypeConstructor {
+	public static final ReactiveArrayJdbcTypeConstructor INSTANCE = new ReactiveArrayJdbcTypeConstructor();
+
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			BasicType<?> elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return resolveType( typeConfiguration, dialect, elementType.getJdbcType(), columnTypeInformation );
+	}
+
+	@Override
+	public JdbcType resolveType(
+			TypeConfiguration typeConfiguration,
+			Dialect dialect,
+			JdbcType elementType,
+			ColumnTypeInformation columnTypeInformation) {
+		return new ReactiveArrayJdbcType( elementType );
+	}
+
+	@Override
+	public int getDefaultSqlTypeCode() {
+		return Types.ARRAY;
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FilterWithPaginationTest.java
@@ -15,10 +15,12 @@ import org.hibernate.annotations.FilterDef;
 import org.hibernate.annotations.ParamDef;
 import org.hibernate.reactive.mutiny.Mutiny;
 import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 import org.hibernate.type.descriptor.java.StringJavaType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.smallrye.mutiny.Uni;
 import io.vertx.junit5.Timeout;
@@ -33,6 +35,8 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.query.Page.first;
 import static org.hibernate.query.Page.page;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.reactive.testing.DBSelectionExtension.skipTestsFor;
 
 /**
  * Test the combination of filters, max results, first result, and {@link org.hibernate.query.Page}.
@@ -40,6 +44,10 @@ import static org.hibernate.query.Page.page;
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class FilterWithPaginationTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = skipTestsFor( DB2 );
 
 	FamousPerson margaret = new FamousPerson( 1L, "Margaret Howe Lovatt", Status.LIVING, "the woman who lived in a half-flooded home with a dolphin." );
 	FamousPerson nellie = new FamousPerson( 2L, "Nellie Bly", Status.DECEASED, "In 1888, she traveled around the world in 72 days." );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyReplaceOrphanedEntityTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/LazyReplaceOrphanedEntityTest.java
@@ -11,8 +11,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 
+import org.hibernate.reactive.testing.DBSelectionExtension;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
@@ -32,10 +35,15 @@ import jakarta.persistence.OneToOne;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class LazyReplaceOrphanedEntityTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	private Campaign theCampaign;
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ReactiveSessionTest.java
@@ -886,7 +886,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						)
 						.thenCompose( v -> openSession() )
 						.thenCompose( session -> session
-								.createSelectionQuery( "from GuineaPig" )
+								.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 								.getResultList()
 								.thenAccept( resultList -> assertThat( resultList ).containsExactlyInAnyOrder( aloiPig, bloiPig ) ) ) )
 		);
@@ -903,7 +903,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 								.getSingleResult()
 								.thenAccept( actualPig -> assertThatPigsAreEqual( expectedPig, actualPig ) ) )
 						.thenCompose( v -> openSession() )
-						.thenCompose( session -> session.createSelectionQuery( "from GuineaPig" )
+						.thenCompose( session -> session.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 								.getSingleResult()
 								.thenAccept( actualPig -> assertThatPigsAreEqual( expectedPig, (GuineaPig) actualPig ) ) )
 				)
@@ -917,7 +917,7 @@ public class ReactiveSessionTest extends BaseReactiveTest {
 						.getSingleResultOrNull()
 						.thenAccept( Assertions::assertNull ) )
 				.thenCompose( v -> openSession() )
-				.thenCompose( session -> session.createSelectionQuery( "from GuineaPig" )
+				.thenCompose( session -> session.createSelectionQuery( "from GuineaPig", GuineaPig.class )
 						.getSingleResultOrNull()
 						.thenAccept( Assertions::assertNull ) )
 		);

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
@@ -14,6 +14,7 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.Timeout;
@@ -42,6 +43,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+@Disabled // see https://github.com/hibernate/hibernate-reactive/issues/1502
 @Timeout(value = 10, timeUnit = MINUTES)
 public class SubselectFetchTest extends BaseReactiveTest {
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -41,8 +41,8 @@ class MySQLDatabase implements TestableDatabase {
 		expectedDBTypeForClass.put( Boolean.class, "bit" );
 
 		expectedDBTypeForClass.put( NumericBooleanConverter.class, "int" );
-		expectedDBTypeForClass.put( YesNoConverter.class, "enum" );
-		expectedDBTypeForClass.put( TrueFalseConverter.class, "enum" );
+		expectedDBTypeForClass.put( YesNoConverter.class, "char" );
+		expectedDBTypeForClass.put( TrueFalseConverter.class, "char" );
 	 	expectedDBTypeForClass.put( byte[].class, "varbinary" );
 		// expectedDBTypeForClass.put( TextType.class, "text" );
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SqlStatementTracker.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/SqlStatementTracker.java
@@ -24,6 +24,7 @@ import org.hibernate.service.spi.ServiceRegistryImplementor;
  * Check {@link #registerService(StandardServiceRegistryBuilder)} to register an instance of this class.
  * It's not thread-safe.
  * </p>
+ * @see #registerService(StandardServiceRegistryBuilder)
  */
 public class SqlStatementTracker extends SqlStatementLogger {
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/AutoZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/AutoZonedTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -22,16 +23,22 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class AutoZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/ColumnZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/ColumnZonedTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -22,16 +23,22 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class ColumnZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/DefaultZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/DefaultZonedTest.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 
 import org.hibernate.dialect.TimeZoneSupport;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -22,15 +23,21 @@ import java.util.Collection;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class DefaultZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/JDBCTimeZoneZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/JDBCTimeZoneZonedTest.java
@@ -15,8 +15,10 @@ import java.util.List;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
@@ -28,12 +30,18 @@ import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.JDBC_TIME_ZONE;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class JDBCTimeZoneZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
+
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
 		return List.of( Zoned.class );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/PassThruZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/PassThruZonedTest.java
@@ -5,15 +5,6 @@
  */
 package org.hibernate.reactive.timezones;
 
-import io.vertx.junit5.Timeout;
-import io.vertx.junit5.VertxTestContext;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-
-import org.hibernate.cfg.Configuration;
-import org.hibernate.reactive.BaseReactiveTest;
-
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneId;
@@ -22,17 +13,34 @@ import java.time.ZonedDateTime;
 import java.util.Collection;
 import java.util.List;
 
+import org.hibernate.cfg.Configuration;
+import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
+
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class PassThruZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
+
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
 		return List.of( Zoned.class );

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/UTCNormalizedInstantTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/UTCNormalizedInstantTest.java
@@ -12,8 +12,10 @@ import java.util.TimeZone;
 
 import org.hibernate.annotations.JdbcTypeCode;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
@@ -23,11 +25,16 @@ import jakarta.persistence.Id;
 
 import static java.sql.Types.TIMESTAMP;
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class UTCNormalizedInstantTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/UTCNormalizedZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/UTCNormalizedZonedTest.java
@@ -14,8 +14,10 @@ import java.util.List;
 
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.BaseReactiveTest;
+import org.hibernate.reactive.testing.DBSelectionExtension;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
@@ -26,12 +28,17 @@ import jakarta.persistence.Id;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
 
 @Timeout(value = 10, timeUnit = MINUTES)
 
 public class UTCNormalizedZonedTest extends BaseReactiveTest {
+
+	// Db2: Exception: IllegalStateException: Needed to have 6 in buffer but only had 0
+	@RegisterExtension
+	public final DBSelectionExtension skip = DBSelectionExtension.skipTestsFor( DB2 );
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {


### PR DESCRIPTION
Supersedes https://github.com/hibernate/hibernate-reactive/pull/1726

This branch will be merged to `main` after the next Hibernate ORM 6.3 release (we will need to update the properties before releasing it)

I've already merged the existing PRs in it, but it needs the latest ORM snapshot to work and it might not be available remotely at the moment (should be available soon).

Fix #1718 
Fix #1703 
Fix #1706 
