### PR TITLE
properly parse query string during native select query

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeSelectQueryPlanImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeSelectQueryPlanImpl.java
@@ -60,7 +60,7 @@ public class ReactiveNativeSelectQueryPlanImpl<R> extends NativeSelectQueryPlanI
 			resultSetMapping.addAffectedTableNames( affectedTableNames, sessionFactory );
 		}
 		this.affectedTableNames = affectedTableNames;
-		this.sql = sql;
+		this.sql = parser.process();
 		this.parameterList = parameterList;
 
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NativeQueryPlaceholderSubstitutionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/NativeQueryPlaceholderSubstitutionTest.java
@@ -1,0 +1,65 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+@Timeout(value = 10, timeUnit = MINUTES)
+public class NativeQueryPlaceholderSubstitutionTest extends BaseReactiveTest {
+
+  @Override
+  protected Collection<Class<?>> annotatedEntities() {
+    return List.of(Widget.class);
+  }
+
+  @Test
+  public void testThatSchemaGetsSubstitutedDuringNativeSelectQuery(VertxTestContext context) {
+
+    test(context, getSessionFactory().withSession(session ->
+      session.createNativeQuery("select count(*) from {h-schema}widgets", Integer.class)
+          .getSingleResult()
+          .thenAccept(result -> Assertions.assertEquals(0, result))
+    ));
+  }
+
+  @Test
+  public void testThatSchemaGetsSubstitutedDuringNativeNonSelectQuery(VertxTestContext context) {
+
+    test(context, getSessionFactory().withSession(session ->
+        session.createNativeQuery("update {h-schema}widgets set id = 1")
+            .executeUpdate()
+            .thenAccept(result -> Assertions.assertEquals(0, result))
+    ));
+  }
+
+  @Entity(name = "Widget")
+  @Table(name = "widgets")
+  public static class Widget {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Override
+    public String toString() {
+      return "Widget{" +
+          "id=" + id +
+          '}';
+    }
+  }
+
+}


### PR DESCRIPTION
This fixes a bug in `ReactiveNativeSelectQueryPlanImpl` where the sql query string was not getting processed by its `SQLQueryParser`. Before adding this code, any select query which had `{h-schema}`, `{h-domain}`, or `{h-catalog}` in the query string would throw an invalid sql grammar exception.