### PR TITLE
[#1742] fix error in reactive SubselectFetchTest

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardRowReader.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/sql/results/internal/ReactiveStandardRowReader.java
@@ -129,6 +129,7 @@ public class ReactiveStandardRowReader<R> implements ReactiveRowReader<R> {
 	@Override
 	@SuppressWarnings("ForLoopReplaceableByForEach")
 	public void finishUp(JdbcValuesSourceProcessingState processingState) {
+		processingState.registerSubselect();
 		initializers.endLoading( processingState.getExecutionContext() );
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SubselectFetchTest.java
@@ -14,7 +14,6 @@ import org.hibernate.annotations.Fetch;
 import org.hibernate.annotations.FetchMode;
 
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.Timeout;
@@ -43,7 +42,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@Disabled // see https://github.com/hibernate/hibernate-reactive/issues/1502
 @Timeout(value = 10, timeUnit = MINUTES)
 public class SubselectFetchTest extends BaseReactiveTest {
 


### PR DESCRIPTION
fixes #1742 
 - added one line fix based on changes in ORM [#HHH-16624](https://hibernate.atlassian.net/browse/HHH-16624) in [StandardRowReader.finishUp()](https://github.com/hibernate/hibernate-orm/commit/f8275f1a70d48a6e655fa63e9e69e0055cc88222#)
 
 Tested this change on branch for this [PR](https://github.com/hibernate/hibernate-reactive/pull/1747) and it worked