### PR TITLE
Add support for StatelessSession#upsert

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hibernate Reactive has been tested with:
 - CockroachDB 22.1
 - MS SQL Server 2019
 - Oracle 21.3
-- [Hibernate ORM][] 6.3.0.Final
+- [Hibernate ORM][] 6.3.1.Final
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.4.5
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.4.5
 - [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.4.5

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '6.3.0.Final'
+        hibernateOrmVersion = '6.3.1.Final'
     }
     if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
         // Same as ORM as default

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityDeleteAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/ReactiveEntityDeleteAction.java
@@ -64,12 +64,14 @@ public class ReactiveEntityDeleteAction extends EntityDeleteAction implements Re
 		final boolean veto = isInstanceLoaded() && preDelete();
 
 		final Object ck = lockCacheItem();
-
-		final CompletionStage<Void> deleteStep = !isCascadeDeleteEnabled() && !veto
-				? ( (ReactiveEntityPersister) persister ).deleteReactive( id, version, instance, session )
-				: voidFuture();
-
-		return deleteStep.thenAccept( v -> {
+		return deleteStep(
+				veto,
+				(ReactiveEntityPersister) persister,
+				id,
+				version,
+				instance,
+				session
+		).thenAccept( v -> {
 			if ( isInstanceLoaded() ) {
 				postDeleteLoaded( id, persister, session, instance, ck );
 			}
@@ -83,5 +85,17 @@ public class ReactiveEntityDeleteAction extends EntityDeleteAction implements Re
 				statistics.deleteEntity( getPersister().getEntityName() );
 			}
 		} );
+	}
+
+	private CompletionStage<Void> deleteStep(
+			boolean veto,
+			ReactiveEntityPersister persister,
+			Object id,
+			Object version,
+			Object instance,
+			SharedSessionContractImplementor session) {
+		return !isCascadeDeleteEnabled() && !veto
+				? persister.deleteReactive( id, version, instance, session )
+				: voidFuture();
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1737,6 +1737,28 @@ public interface Mutiny {
 		Uni<Void> refresh(Object entity);
 
 		/**
+		 * Use a SQL {@code merge into} statement to perform an upsert.
+		 *
+		 * @param entity a detached entity instance
+		 *
+		 * @see org.hibernate.StatelessSession#upsert(Object)
+		 */
+		@Incubating
+		Uni<Void> upsert(Object entity);
+
+		/**
+		 * Use a SQL {@code merge into} statement to perform an upsert.
+		 *
+		 * @param entityName The entityName for the entity to be merged
+		 * @param entity a detached entity instance
+		 * @throws org.hibernate.TransientObjectException is the entity is transient
+		 *
+		 * @see org.hibernate.StatelessSession#upsert(String, Object)
+		 */
+		@Incubating
+		Uni<Void> upsert(String entityName, Object entity);
+
+		/**
 		 * Refresh the entity instance state from the database.
 		 *
 		 * @param entities The entities to be refreshed.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -164,6 +164,16 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 	}
 
 	@Override
+	public Uni<Void> upsert(Object entity) {
+		return uni( () -> delegate.reactiveUpsert( entity ) );
+	}
+
+	@Override
+	public Uni<Void> upsert(String entityName, Object entity) {
+		return uni( () -> delegate.reactiveUpsert( entityName, entity ) );
+	}
+
+	@Override
 	public Uni<Void> refreshAll(Object... entities) {
 		return uni( () -> delegate.reactiveRefreshAll( entities ) );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveCoordinatorFactory.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveCoordinatorFactory.java
@@ -44,4 +44,20 @@ public final class ReactiveCoordinatorFactory {
 			SessionFactoryImplementor factory) {
 		return new ReactiveDeleteCoordinator( entityPersister, factory );
 	}
+
+	public static ReactiveUpdateCoordinator buildMergeCoordinator(
+			AbstractEntityPersister entityPersister,
+			SessionFactoryImplementor factory) {
+		// we only have updates to issue for entities with one or more singular attributes
+		final AttributeMappingsList attributeMappings = entityPersister.getAttributeMappings();
+		for ( int i = 0; i < attributeMappings.size(); i++ ) {
+			AttributeMapping attributeMapping = attributeMappings.get( i );
+			if ( attributeMapping instanceof SingularAttributeMapping ) {
+				return new ReactiveMergeCoordinatorStandardScopeFactory( entityPersister, factory );
+			}
+		}
+
+		// otherwise, nothing to update
+		return new ReactiveUpdateCoordinatorNoOp( entityPersister );
+	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveEntityPersister.java
@@ -64,6 +64,22 @@ public interface ReactiveEntityPersister extends EntityPersister {
 			final SharedSessionContractImplementor session);
 
 	/**
+	 * Update the given instance state without blocking.
+	 *
+	 * @see EntityPersister#merge(Object, Object[], int[], boolean, Object[], Object, Object, Object, SharedSessionContractImplementor)
+	 */
+	CompletionStage<Void> mergeReactive(
+			final Object id,
+			final Object[] fields,
+			final int[] dirtyFields,
+			final boolean hasDirtyCollection,
+			final Object[] oldFields,
+			final Object oldVersion,
+			final Object object,
+			final Object rowId,
+			final SharedSessionContractImplementor session);
+
+	/**
 	 * Obtain a pessimistic lock without blocking
 	 */
 	CompletionStage<Void> reactiveLock(

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveMergeCoordinatorStandardScopeFactory.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveMergeCoordinatorStandardScopeFactory.java
@@ -1,0 +1,33 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.entity.impl;
+
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.persister.entity.mutation.MergeCoordinator;
+import org.hibernate.reactive.persister.entity.mutation.ReactiveMergeCoordinator;
+import org.hibernate.reactive.persister.entity.mutation.ReactiveScopedUpdateCoordinator;
+import org.hibernate.reactive.persister.entity.mutation.ReactiveUpdateCoordinator;
+
+public class ReactiveMergeCoordinatorStandardScopeFactory extends MergeCoordinator
+		implements ReactiveUpdateCoordinator {
+
+	public ReactiveMergeCoordinatorStandardScopeFactory(AbstractEntityPersister entityPersister, SessionFactoryImplementor factory) {
+		super( entityPersister, factory );
+	}
+
+	@Override
+	public ReactiveScopedUpdateCoordinator makeScopedCoordinator() {
+		return new ReactiveMergeCoordinator(
+				entityPersister(),
+				factory(),
+				this.getStaticUpdateGroup(),
+				this.getBatchKey(),
+				this.getVersionUpdateGroup(),
+				this.getVersionUpdateBatchkey()
+		);
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveUnionSubclassEntityPersister.java
@@ -246,6 +246,23 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 	}
 
 	/**
+	 * @see #mergeReactive(Object, Object[], int[], boolean, Object[], Object, Object, Object, SharedSessionContractImplementor)
+	 */
+	@Override
+	public void merge(
+			Object id,
+			Object[] values,
+			int[] dirtyAttributeIndexes,
+			boolean hasDirtyCollection,
+			Object[] oldValues,
+			Object oldVersion,
+			Object object,
+			Object rowId,
+			SharedSessionContractImplementor session) throws HibernateException {
+		throw LOG.nonReactiveMethodCall( "mergeReactive" );
+	}
+
+	/**
 	 * Process properties generated with an insert
 	 *
 	 * @see AbstractEntityPersister#processInsertGeneratedProperties(Object, Object, Object[], SharedSessionContractImplementor)
@@ -334,6 +351,27 @@ public class ReactiveUnionSubclassEntityPersister extends UnionSubclassEntityPer
 		return ( (ReactiveUpdateCoordinator) getUpdateCoordinator() )
 				// This is different from Hibernate ORM because our reactive update coordinator cannot be share among
 				// multiple update operations
+				.makeScopedCoordinator()
+				.coordinateReactiveUpdate( object, id, rowId, values, oldVersion, oldValues, dirtyAttributeIndexes, hasDirtyCollection, session );
+	}
+
+	/**
+	 * @see #merge(Object, Object[], int[], boolean, Object[], Object, Object, Object, SharedSessionContractImplementor)
+	 */
+	@Override
+	public CompletionStage<Void> mergeReactive(
+			Object id,
+			Object[] values,
+			int[] dirtyAttributeIndexes,
+			boolean hasDirtyCollection,
+			Object[] oldValues,
+			Object oldVersion,
+			Object object,
+			Object rowId,
+			SharedSessionContractImplementor session) {
+		// This is different from Hibernate ORM because our reactive update coordinator cannot be share among
+		// multiple update operations
+		return ( (ReactiveUpdateCoordinator) getMergeCoordinator() )
 				.makeScopedCoordinator()
 				.coordinateReactiveUpdate( object, id, rowId, values, oldVersion, oldValues, dirtyAttributeIndexes, hasDirtyCollection, session );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveDeleteCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveDeleteCoordinator.java
@@ -11,12 +11,10 @@ import java.util.concurrent.CompletionStage;
 
 import org.hibernate.engine.jdbc.mutation.JdbcValueBindings;
 import org.hibernate.engine.jdbc.mutation.MutationExecutor;
-import org.hibernate.engine.jdbc.mutation.ParameterUsage;
 import org.hibernate.engine.jdbc.mutation.group.PreparedStatementDetails;
 import org.hibernate.engine.jdbc.mutation.spi.MutationExecutorService;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
-import org.hibernate.metamodel.mapping.EntityRowIdMapping;
 import org.hibernate.persister.entity.AbstractEntityPersister;
 import org.hibernate.persister.entity.mutation.DeleteCoordinator;
 import org.hibernate.persister.entity.mutation.EntityTableMapping;
@@ -25,6 +23,7 @@ import org.hibernate.reactive.adaptor.impl.PreparedStatementAdaptor;
 import org.hibernate.reactive.engine.jdbc.env.internal.ReactiveMutationExecutor;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
+import org.hibernate.sql.model.MutationOperation;
 import org.hibernate.sql.model.MutationOperationGroup;
 
 import static org.hibernate.engine.jdbc.mutation.internal.ModelMutationHelper.identifiedResultsCheck;
@@ -61,17 +60,18 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 	}
 
 	@Override
-	protected void doDynamicDelete(Object entity, Object id, Object rowId, Object[] loadedState, SharedSessionContractImplementor session) {
+	protected void doDynamicDelete(Object entity, Object id, Object[] loadedState, SharedSessionContractImplementor session) {
 		stage = new CompletableFuture<>();
-		final MutationOperationGroup operationGroup = generateOperationGroup( loadedState, true, session );
+		final MutationOperationGroup operationGroup = generateOperationGroup( null, loadedState, true, session );
 		final ReactiveMutationExecutor mutationExecutor = mutationExecutor( session, operationGroup );
 
-		operationGroup.forEachOperation( (position, mutation) -> {
+		for ( int i = 0; i < operationGroup.getNumberOfOperations(); i++ ) {
+			final MutationOperation mutation = operationGroup.getOperation( i );
 			if ( mutation != null ) {
 				final String tableName = mutation.getTableDetails().getTableName();
 				mutationExecutor.getPreparedStatementDetails( tableName );
 			}
-		} );
+		}
 
 		applyLocking( null, loadedState, mutationExecutor, session );
 		applyId( id, null, mutationExecutor, getStaticDeleteGroup(), session );
@@ -102,25 +102,29 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 			MutationOperationGroup operationGroup,
 			SharedSessionContractImplementor session) {
 		final JdbcValueBindings jdbcValueBindings = mutationExecutor.getJdbcValueBindings();
-		final EntityRowIdMapping rowIdMapping = entityPersister().getRowIdMapping();
 
-		operationGroup.forEachOperation( (position, jdbcMutation) -> {
+		for ( int position = 0; position < operationGroup.getNumberOfOperations(); position++ ) {
+			final MutationOperation jdbcMutation = operationGroup.getOperation( position );
 			final EntityTableMapping tableDetails = (EntityTableMapping) jdbcMutation.getTableDetails();
-			breakDownIdJdbcValues( id, rowId, session, jdbcValueBindings, rowIdMapping, tableDetails );
+			breakDownKeyJdbcValues( id, rowId, session, jdbcValueBindings, tableDetails );
 			final PreparedStatementDetails statementDetails = mutationExecutor.getPreparedStatementDetails( tableDetails.getTableName() );
 			if ( statementDetails != null ) {
 				PreparedStatementAdaptor.bind( statement -> {
-					PrepareStatementDetailsAdaptor detailsAdaptor = new PrepareStatementDetailsAdaptor( statementDetails, statement, session.getJdbcServices() );
+					PrepareStatementDetailsAdaptor detailsAdaptor = new PrepareStatementDetailsAdaptor(
+							statementDetails,
+							statement,
+							session.getJdbcServices()
+					);
 					// force creation of the PreparedStatement
 					//noinspection resource
 					detailsAdaptor.resolveStatement();
 				} );
 			}
-		} );
+		}
 	}
 
 	@Override
-	protected void doStaticDelete(Object entity, Object id, Object[] loadedState, Object version, SharedSessionContractImplementor session) {
+	protected void doStaticDelete(Object entity, Object id, Object rowId, Object[] loadedState, Object version, SharedSessionContractImplementor session) {
 		stage = new CompletableFuture<>();
 		final boolean applyVersion = entity != null;
 		final MutationOperationGroup operationGroupToUse = entity == null
@@ -128,18 +132,19 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 				: getStaticDeleteGroup();
 
 		final ReactiveMutationExecutor mutationExecutor = mutationExecutor( session, operationGroupToUse );
-		getStaticDeleteGroup().forEachOperation( (position, mutation) -> {
+		for ( int position = 0; position < getStaticDeleteGroup().getNumberOfOperations(); position++ ) {
+			final MutationOperation mutation = getStaticDeleteGroup().getOperation( position );
 			if ( mutation != null ) {
 				mutationExecutor.getPreparedStatementDetails( mutation.getTableDetails().getTableName() );
 			}
-		} );
+		}
 
 		if ( applyVersion ) {
 			applyLocking( version, null, mutationExecutor, session );
 		}
 		final JdbcValueBindings jdbcValueBindings = mutationExecutor.getJdbcValueBindings();
 		bindPartitionColumnValueBindings( loadedState, session, jdbcValueBindings );
-		applyId( id, null, mutationExecutor, getStaticDeleteGroup(), session );
+		applyId( id, rowId, mutationExecutor, getStaticDeleteGroup(), session );
 		mutationExecutor.executeReactive(
 						entity,
 						null,
@@ -156,38 +161,6 @@ public class ReactiveDeleteCoordinator extends DeleteCoordinator {
 				)
 				.thenAccept( v -> mutationExecutor.release() )
 				.whenComplete( this::complete );
-	}
-
-	/**
-	 * Copy and paste of the on in ORM
-	 */
-	private static void breakDownIdJdbcValues(
-			Object id,
-			Object rowId,
-			SharedSessionContractImplementor session,
-			JdbcValueBindings jdbcValueBindings,
-			EntityRowIdMapping rowIdMapping,
-			EntityTableMapping tableDetails) {
-		if ( rowId != null && rowIdMapping != null && tableDetails.isIdentifierTable() ) {
-			jdbcValueBindings.bindValue(
-					rowId,
-					tableDetails.getTableName(),
-					rowIdMapping.getRowIdName(),
-					ParameterUsage.RESTRICT
-			);
-		}
-		else {
-			tableDetails.getKeyMapping().breakDownKeyJdbcValues(
-					id,
-					(jdbcValue, columnMapping) -> jdbcValueBindings.bindValue(
-							jdbcValue,
-							tableDetails.getTableName(),
-							columnMapping.getColumnName(),
-							ParameterUsage.RESTRICT
-					),
-					session
-			);
-		}
 	}
 
 	private void complete(Object o, Throwable throwable) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveMergeCoordinator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/mutation/ReactiveMergeCoordinator.java
@@ -1,0 +1,36 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.persister.entity.mutation;
+
+import org.hibernate.engine.jdbc.batch.spi.BatchKey;
+import org.hibernate.engine.spi.SessionFactoryImplementor;
+import org.hibernate.persister.entity.AbstractEntityPersister;
+import org.hibernate.persister.entity.mutation.EntityTableMapping;
+import org.hibernate.sql.model.MutationOperation;
+import org.hibernate.sql.model.MutationOperationGroup;
+import org.hibernate.sql.model.ast.builder.AbstractTableUpdateBuilder;
+import org.hibernate.sql.model.ast.builder.TableMergeBuilder;
+
+/**
+ * @see org.hibernate.persister.entity.mutation.MergeCoordinator
+ * @see org.hibernate.reactive.persister.entity.impl.ReactiveMergeCoordinatorStandardScopeFactory
+ */
+public class ReactiveMergeCoordinator extends ReactiveUpdateCoordinatorStandard {
+	public ReactiveMergeCoordinator(
+			AbstractEntityPersister entityPersister,
+			SessionFactoryImplementor factory,
+			MutationOperationGroup staticUpdateGroup,
+			BatchKey batchKey,
+			MutationOperationGroup versionUpdateGroup,
+			BatchKey versionUpdateBatchkey) {
+		super( entityPersister, factory, staticUpdateGroup, batchKey, versionUpdateGroup, versionUpdateBatchkey );
+	}
+
+	@Override
+	protected <O extends MutationOperation> AbstractTableUpdateBuilder<O> newTableUpdateBuilder(EntityTableMapping tableMapping) {
+		return new TableMergeBuilder<>( entityPersister(), tableMapping, factory() );
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -184,7 +184,7 @@ public class SqlClientConnection implements ReactiveConnection {
 
 			int i = 0;
 			RowSet<Row> resultNext = result;
-			if ( parametersBatch.size() > 0 ) {
+			if ( !parametersBatch.isEmpty() ) {
 				final RowIterator<Row> iterator = resultNext.iterator();
 				if ( iterator.hasNext() ) {
 					while ( iterator.hasNext() ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
@@ -40,6 +40,10 @@ public interface ReactiveStatelessSession extends ReactiveQueryProducer, Reactiv
 
 	CompletionStage<Void> reactiveUpdate(Object entity);
 
+	CompletionStage<Void> reactiveUpsert(Object entity);
+
+	CompletionStage<Void> reactiveUpsert(String entityName, Object entity);
+
 	CompletionStage<Void> reactiveRefresh(Object entity);
 
 	CompletionStage<Void> reactiveRefresh(Object entity, LockMode lockMode);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1815,6 +1815,23 @@ public interface Stage {
 		}
 
 		/**
+		 *
+		 * @param entity a detached entity instance
+		 *
+		 * @see org.hibernate.StatelessSession#upsert(Object)
+		 */
+		CompletionStage<Void> upsert(Object entity);
+
+		/**
+		 *
+		 * @param entityName The entityName for the entity to be merged
+		 * @param entity a detached entity instance
+		 *
+		 * @see org.hibernate.StatelessSession#upsert(String, Object)
+		 */
+		CompletionStage<Void> upsert(String entityName, Object entity);
+
+		/**
 		 * Asynchronously fetch an association that's configured for lazy loading.
 		 *
 		 * <pre>

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -118,6 +118,16 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 	}
 
 	@Override
+	public CompletionStage<Void> upsert(Object entity) {
+		return delegate.reactiveUpsert( entity );
+	}
+
+	@Override
+	public CompletionStage<Void> upsert(String entityName, Object entity) {
+		return delegate.reactiveUpsert( entityName, entity );
+	}
+
+	@Override
 	public <T> CompletionStage<T> fetch(T association) {
 		return delegate.reactiveFetch( association, false );
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UpsertTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/UpsertTest.java
@@ -1,0 +1,203 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Objects;
+
+import org.hibernate.reactive.testing.DBSelectionExtension;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MYSQL;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
+import static org.hibernate.reactive.testing.DBSelectionExtension.skipTestsFor;
+
+/**
+ * Same as Hibernate ORM org.hibernate.orm.test.stateless.UpsertTest
+ * <p>
+ *     These tests are in a separate class because we need to skip the execution on some databases,
+ *     but once this has been resolved, they could be in {@link ReactiveStatelessSessionTest}.
+ * </p>
+ */
+@Timeout(value = 10, timeUnit = MINUTES)
+public class UpsertTest extends BaseReactiveTest {
+
+	/**
+	 * Something is missing in HR to make it work for these databases.
+ 	 */
+	@RegisterExtension
+	public DBSelectionExtension dbSelection = skipTestsFor( COCKROACHDB, DB2, MARIA, MYSQL, ORACLE );
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Record.class );
+	}
+
+	@Test
+	public void testMutinyUpsert(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( new Record( 123L, "hello earth" ) )
+							  .call( () -> ss.upsert( new Record( 456L, "hello mars" ) ) )
+					  )
+					  .call( v -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .invoke( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "hello earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+					  .call( () -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( new Record( 123L, "goodbye earth" ) )
+					  ) )
+					  .call( v -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .invoke( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "goodbye earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+		);
+	}
+
+	@Test
+	public void testMutinyUpsertWithEntityName(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( Record.class.getName(), new Record( 123L, "hello earth" ) )
+							  .call( () -> ss.upsert( Record.class.getName(), new Record( 456L, "hello mars" ) ) )
+					  )
+					  .call( v -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .invoke( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "hello earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+					  .call( () -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( Record.class.getName(), new Record( 123L, "goodbye earth" ) )
+					  ) )
+					  .call( v -> getMutinySessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .invoke( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "goodbye earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+		);
+	}
+
+	@Test
+	public void testStageUpsert(VertxTestContext context) {
+		test( context, getSessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( new Record( 123L, "hello earth" ) )
+							  .thenCompose( v -> ss.upsert( new Record( 456L, "hello mars" ) ) )
+					  )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .thenAccept( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "hello earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( new Record( 123L, "goodbye earth" ) )
+					  ) )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .thenAccept( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "goodbye earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+		);
+	}
+
+	@Test
+	public void testStageUpsertWithEntityName(VertxTestContext context) {
+		test( context, getSessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( Record.class.getName(), new Record( 123L, "hello earth" ) )
+							  .thenCompose( v -> ss.upsert( Record.class.getName(), new Record( 456L, "hello mars" ) ) )
+					  )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .thenAccept( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "hello earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+							  .upsert( Record.class.getName(), new Record( 123L, "goodbye earth" ) )
+					  ) )
+					  .thenCompose( v -> getSessionFactory().withStatelessTransaction( ss -> ss
+									  .createQuery( "from Record order by id", Record.class ).getResultList() )
+							  .thenAccept( results -> assertThat( results ).containsExactly(
+									  new Record( 123L, "goodbye earth" ),
+									  new Record( 456L, "hello mars" )
+							  ) )
+					  )
+		);
+	}
+
+	@Entity(name = "Record")
+	@Table(name = "Record")
+	public static class Record {
+		@Id
+		public Long id;
+		public String message;
+
+		Record(Long id, String message) {
+			this.id = id;
+			this.message = message;
+		}
+
+		Record() {
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public String getMessage() {
+			return message;
+		}
+
+		public void setMessage(String msg) {
+			message = msg;
+		}
+
+		// Equals and HashCode for simplifying the test assertions,
+		// not to be taken as an example or for production.
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			Record record = (Record) o;
+			return Objects.equals( id, record.id ) && Objects.equals( message, record.message );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( id, message );
+		}
+	}
+}


### PR DESCRIPTION
Fix #1702 
Requires the latest `main` in Hibernate ORM
Built on top of https://github.com/hibernate/hibernate-reactive/pull/1764 because it fixes some compilation errors

Supersedes #1757:
* It seems to only work for PostgreSQL 
* Implements and add tests for `upsert( String, Object )`
* Minor fixes to some classes
* Fix the test case
* Remove unnecessary classes