### PR TITLE
[#1641] Tests for @Array and @Struct entity annotations

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/PostgreSqlReactiveInformationExtractorImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/PostgreSqlReactiveInformationExtractorImpl.java
@@ -141,7 +141,7 @@ public class PostgreSqlReactiveInformationExtractorImpl extends AbstractReactive
 
 	@Override
 	protected int dataTypeCode(String typeName) {
-		// Copied from PostgreSQLDialect.
+		// Copied from PostgreSQLDialect.resolveSqlTypeCode
 		// Not ideal, but it should work for now
 		// It would be nice to be able to get the correct code some way
 		switch ( typeName ) {
@@ -162,6 +162,11 @@ public class PostgreSqlReactiveInformationExtractorImpl extends AbstractReactive
 				return SqlTypes.TIMESTAMP_UTC;
 			case "bytea":
 				return Types.VARBINARY;
+			case "_numeric":
+			case "_bool":
+			case "_int8":
+			case "_varchar":
+				return Types.ARRAY;
 			default:
 				return 0;
 		}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StructComponentTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StructComponentTest.java
@@ -1,0 +1,131 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import java.util.List;
+
+import org.hibernate.annotations.Struct;
+import org.hibernate.reactive.annotations.DisabledFor;
+import org.hibernate.reactive.logging.impl.Log;
+import org.hibernate.reactive.logging.impl.LoggerFactory;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MYSQL;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Timeout(value = 10, timeUnit = MINUTES)
+@DisabledFor(value = ORACLE, reason = "see issue https://github.com/hibernate/hibernate-reactive/issues/1855")
+@DisabledFor(value = {SQLSERVER, MYSQL,	MARIA, COCKROACHDB}, reason = "ORM does not support @Struct for these databases")
+public class StructComponentTest extends BaseReactiveTest {
+
+	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	static Book book = createBook();
+	static Publisher ePublisher;
+	static Publisher pPublisher;
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Book.class );
+	}
+
+	private static Book createBook() {
+		ePublisher = new Publisher();
+		ePublisher.setName( "ebooks" );
+		ePublisher.setPubId( 5 );
+
+		pPublisher = new Publisher();
+		pPublisher.setName( "paperbooks" );
+		pPublisher.setPubId( 25 );
+
+		Book book = new Book();
+		book.title = "Hibernate";
+		book.author = "Steve";
+		book.ebookPublisher = ePublisher;
+		book.paperBackPublisher = pPublisher;
+		return book;
+	}
+
+	@BeforeEach
+	public void populateDB(VertxTestContext context) {
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( book )
+						.thenCompose( v -> session.flush() ) )
+		);
+	}
+
+	@Test
+	public void testStructComponent(VertxTestContext context) {
+		test( context, openSession()
+				.thenCompose( s2 -> s2.find( Book.class, book.id ) )
+				.thenAccept( resultBook -> {
+					assertNotNull( resultBook );
+					assertEquals( book.title, resultBook.title );
+					assertEquals( book.ebookPublisher.pubId, resultBook.ebookPublisher.pubId );
+					assertEquals( book.paperBackPublisher.pubId, resultBook.paperBackPublisher.pubId );
+				} )
+		);
+	}
+
+	@Entity(name = "Book")
+	public static class Book {
+
+		@Id
+		@GeneratedValue
+		private Long id;
+
+		private String title;
+
+		private String author;
+
+		@Column(name = "ebook_publisher")
+		private Publisher ebookPublisher;
+		private Publisher paperBackPublisher;
+	}
+
+	@Embeddable
+	@Struct( name = "publisher_type")
+	public static class Publisher {
+
+		private String name;
+
+		public String getName() {
+			return name;
+		}
+
+		public void setName(String name) {
+			this.name = name;
+		}
+
+		private Integer pubId;
+
+		public Integer getPubId() {
+			return pubId;
+		}
+
+		public void setPubId(Integer pubId) {
+			this.pubId = pubId;
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StructEmbeddableTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/StructEmbeddableTest.java
@@ -1,0 +1,180 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.awt.Point;
+import java.util.Collection;
+import java.util.List;
+
+import org.hibernate.annotations.Struct;
+import org.hibernate.reactive.annotations.DisabledFor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.COCKROACHDB;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MARIA;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.MYSQL;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.ORACLE;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+@Timeout(value = 10, timeUnit = MINUTES)
+@DisabledFor(value = ORACLE, reason = "see issue https://github.com/hibernate/hibernate-reactive/issues/1855")
+@DisabledFor(value = {SQLSERVER, MYSQL,	MARIA, COCKROACHDB}, reason = "ORM does not support @Struct for these databases")
+public class StructEmbeddableTest extends BaseReactiveTest {
+	static RecordStructHolder holder1;
+	static RecordStructHolder holder2;
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( RecordStructHolder.class );
+	}
+
+	@BeforeEach
+	public void populateDB(VertxTestContext context) {
+		holder1 = new RecordStructHolder( 1L, new NamedPoint( "first", 1, 1 ) );
+		holder2 = new RecordStructHolder( 2L, new NamedPoint( "second", 2, 2 ) );
+		holder1.simpleStringHolder = new SimpleStringHolder( "column a","column b","column c" );
+
+		test( context, getSessionFactory()
+				.withTransaction( session -> session.persist( holder1, holder2 )
+						.thenCompose( v -> session.flush() ) )
+		);
+	}
+
+	@Test
+	public void testFindAndUpdate(VertxTestContext context) {
+		test( context, openSession()
+				.thenCompose( s2 -> s2.find( RecordStructHolder.class, holder1.id )
+						.thenAccept( resultHolder -> {
+							assertNotNull( resultHolder );
+							assertEquals( holder1.getThePoint().getPoint(), resultHolder.getThePoint().getPoint() );
+							resultHolder.setThePoint( new NamedPoint( "third", 3, 3 ) );
+							assertEquals( "third", resultHolder.getThePoint().name );
+						} )
+						.thenCompose( vv -> s2.flush() )
+						.thenCompose( vv -> s2.find( RecordStructHolder.class, holder1.id )
+								.thenAccept( found -> assertEquals( "third", found.getThePoint().getName() ) ) )
+				)
+		);
+	}
+
+	@Test
+	public void testSelectionItems(VertxTestContext context) {
+		test( context, openSession()
+					  .thenCompose( s -> s.createSelectionQuery( "from RecordStructHolder where id = ?1", RecordStructHolder.class )
+						.setParameter( 1, holder1.getId() )
+						.getResultList() )
+						.thenAccept( holders -> {
+							assertNotNull( holders );
+							final RecordStructHolder holder = holders.get( 0 );
+							assertEquals( holder1.getThePoint().getPoint(), holder.getThePoint().getPoint() );
+						} )
+		);
+	}
+
+	@Test
+	public void testEmbeddedColumnOrder(VertxTestContext context) {
+		test( context, openSession()
+				.thenCompose( s2 -> s2.find( RecordStructHolder.class, holder1.id )
+						.thenAccept( resultHolder -> {
+							assertNotNull( resultHolder );
+							assertEquals( holder1.getThePoint().getPoint(), resultHolder.getThePoint().getPoint() );
+							assertEquals( "column a", holder1.simpleStringHolder.aColumn );
+							assertEquals( "column b", holder1.simpleStringHolder.bColumn );
+							assertEquals( "column c", holder1.simpleStringHolder.cColumn );
+						} )
+				)
+		);
+	}
+
+	@Entity(name = "RecordStructHolder")
+	public static class RecordStructHolder {
+		@Id
+		private Long id;
+		@Struct(name = "my_point_type")
+		private NamedPoint thePoint;
+
+		private SimpleStringHolder simpleStringHolder;
+
+		public RecordStructHolder() {
+		}
+
+		public RecordStructHolder(Long id, NamedPoint thePoint) {
+			this.id = id;
+			this.thePoint = thePoint;
+		}
+
+		public Long getId() {
+			return id;
+		}
+
+		public void setId(Long id) {
+			this.id = id;
+		}
+
+		public NamedPoint getThePoint() {
+			return thePoint;
+		}
+
+		public void setThePoint(NamedPoint point) {
+			this.thePoint = point;
+		}
+	}
+
+	@Embeddable
+	static class NamedPoint {
+		public String name;
+		public Point point;
+
+		public NamedPoint() {
+		}
+
+		public NamedPoint(String name, Integer x, Integer y) {
+			this.point = new Point( x, y );
+			this.name = name;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public Point getPoint() {
+			return point;
+		}
+	}
+
+	// By default, the order of columns is based on the alphabetical ordering of the embeddable type attribute names.
+	// This class has column names re-defined using @Column annotation "name" attribute and will reverse the column order
+	@Embeddable
+	@Struct(name = "simple_string_holder")
+	static class SimpleStringHolder {
+		@Column(name = "c")
+		public String aColumn;
+		@Column(name = "b")
+		public String bColumn;
+		@Column(name = "a")
+		public String cColumn;
+
+		public SimpleStringHolder() {}
+
+		public SimpleStringHolder(String aColumn, String bColumn, String cColumn) {
+			this.aColumn = aColumn;
+			this.bColumn = bColumn;
+			this.cColumn = cColumn;
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/DB2Database.java
@@ -73,6 +73,11 @@ class DB2Database implements TestableDatabase {
 		expectedDBTypeForClass.put( Character.class, "CHARACTER" );
 		expectedDBTypeForClass.put( char.class, "CHARACTER" );
 		expectedDBTypeForClass.put( String.class, "VARCHAR" );
+		expectedDBTypeForClass.put( String[].class, "VARBINARY" );
+		expectedDBTypeForClass.put( Long[].class, "VARBINARY" );
+		expectedDBTypeForClass.put( BigDecimal[].class, "VARBINARY" );
+		expectedDBTypeForClass.put( BigInteger[].class, "VARBINARY" );
+		expectedDBTypeForClass.put( Boolean[].class, "VARBINARY" );
 	}}
 
 	/**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MSSQLServerDatabase.java
@@ -82,6 +82,11 @@ class MSSQLServerDatabase implements TestableDatabase {
 		expectedDBTypeForClass.put( Character.class, "char" );
 		expectedDBTypeForClass.put( char.class, "char" );
 		expectedDBTypeForClass.put( String.class, "varchar" );
+		expectedDBTypeForClass.put( String[].class, "varbinary" );
+		expectedDBTypeForClass.put( Long[].class, "varbinary" );
+		expectedDBTypeForClass.put( BigDecimal[].class, "varbinary" );
+		expectedDBTypeForClass.put( BigInteger[].class, "varbinary" );
+		expectedDBTypeForClass.put( Boolean[].class, "varbinary" );
 	}}
 
 	/**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -73,6 +73,11 @@ class MySQLDatabase implements TestableDatabase {
 		expectedDBTypeForClass.put( Character.class, "char" );
 		expectedDBTypeForClass.put( char.class, "char" );
 		expectedDBTypeForClass.put( String.class, "varchar" );
+		expectedDBTypeForClass.put( String[].class, "varchar" );
+		expectedDBTypeForClass.put( Long[].class, "varbinary" );
+		expectedDBTypeForClass.put( BigDecimal[].class, "varbinary" );
+		expectedDBTypeForClass.put( BigInteger[].class, "varbinary" );
+		expectedDBTypeForClass.put( Boolean[].class, "varbinary" );
 	}};
 
 	/**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/OracleDatabase.java
@@ -81,6 +81,11 @@ class OracleDatabase implements TestableDatabase {
 			expectedDBTypeForClass.put( Character.class, "CHAR" );
 			expectedDBTypeForClass.put( char.class, "CHAR" );
 			expectedDBTypeForClass.put( String.class, "VARCHAR2" );
+			expectedDBTypeForClass.put( String[].class, "STRINGARRAY" );
+			expectedDBTypeForClass.put( Long[].class, "LONGARRAY" );
+			expectedDBTypeForClass.put( BigDecimal[].class, "BIGDECIMALARRAY" );
+			expectedDBTypeForClass.put( BigInteger[].class, "BIGINTEGERARRAY" );
+			expectedDBTypeForClass.put( Boolean[].class, "BOOLEANARRAY" );
 		}
 	}
 

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/PostgreSQLDatabase.java
@@ -73,6 +73,11 @@ class PostgreSQLDatabase implements TestableDatabase {
 			expectedDBTypeForClass.put( Character.class, "character" );
 			expectedDBTypeForClass.put( char.class, "character" );
 			expectedDBTypeForClass.put( String.class, "character varying" );
+			expectedDBTypeForClass.put( String[].class, "ARRAY" );
+			expectedDBTypeForClass.put( Long[].class, "ARRAY" );
+			expectedDBTypeForClass.put( BigDecimal[].class, "ARRAY" );
+			expectedDBTypeForClass.put( BigInteger[].class, "ARRAY" );
+			expectedDBTypeForClass.put( Boolean[].class, "ARRAY" );
 	}}
 
 	/**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/BasicTypesTestEntity.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/BasicTypesTestEntity.java
@@ -18,6 +18,9 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.TimeZone;
 import java.util.UUID;
+
+import org.hibernate.annotations.Array;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Convert;
 import jakarta.persistence.Entity;
@@ -103,6 +106,31 @@ public class BasicTypesTestEntity {
 	Duration duration;
 
 	Serializable serializable;
+
+	String[] stringArray;
+
+	@Array(length = 5)
+	String[] stringArrayAnnotated;
+
+	Long[] longArray;
+
+	@Array(length = 5)
+	Long[] longArrayAnnotated;
+
+	BigDecimal[] bigDecimalArray;
+
+	@Array(length = 5)
+	BigDecimal[] bigDecimalArrayAnnotated;
+
+	BigInteger[] bigIntegerArray;
+
+	@Array(length = 5)
+	BigInteger[] bigIntegerArrayAnnotated;
+
+	Boolean[] fieldBooleanArray;
+
+	@Array(length = 5)
+	Boolean[] fieldBooleanArrayAnnotated;
 
 	public BasicTypesTestEntity() {
 	}


### PR DESCRIPTION
[#1641] reactive tests for `@Array` and `@Struct` entity annotations

* Tests for `@Struct` currently work only for Postgres and DB2. 
* Oracle fails via `Not using JDBC... " error.
* Other DB's fail due to ORM limitations: `"Dialect does not support aggregateComponentAssignmentExpression:"`

* Tests with `@Array` annotations mostly work
* SchemaValidationTestBase is failing for PG & CockroachDB testing the **BigInteger[] bigIntegerArray** array element

Utilized *DisabledFor() reason = .....* to include info on the failed tests 