### PR TITLE
Upgrade Hibernate ORM to 6.4.4.Final and Mutiny to 2.6.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Hibernate Reactive has been tested with:
 - CockroachDB 22.1
 - MS SQL Server 2019
 - Oracle 21.3
-- [Hibernate ORM][] 6.4.3.Final
+- [Hibernate ORM][] 6.4.4.Final
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5.2
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5.2
 - [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5.2

--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '6.4.3.Final'
+        hibernateOrmVersion = '6.4.4.Final'
     }
     if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
         // Same as ORM as default

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     api "org.hibernate.orm:hibernate-core:${hibernateOrmVersion}"
 
-    api 'io.smallrye.reactive:mutiny:2.5.3'
+    api 'io.smallrye.reactive:mutiny:2.5.6'
 
     //Logging
     implementation 'org.jboss.logging:jboss-logging:3.5.0.Final'


### PR DESCRIPTION
Fix #1861 and Fix #1863

Note that we need the upgrade to Mutiny 2.6.3 or we will have some race condition caused by https://github.com/smallrye/smallrye-mutiny/issues/1494