### PR TITLE
Use CodeRay highlighter in the documentation

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -108,7 +108,7 @@ task renderReferenceDocumentation(type: AsciidoctorTask, group: 'Documentation')
     outputDir = new File("$buildDir/asciidoc/reference/html_single")
     options logDocuments: true
 	attributes icons: 'font', experimental: true,
-			   'source-highlighter': 'prettify',
+			   'source-highlighter': 'coderay',
 			   linkcss: true,
 			   majorMinorVersion: project.version.family,
 			   fullVersion: project.version.toString(),


### PR DESCRIPTION
Hey @DavideD ,

I was looking into something for Search and noticed that opening reactive docs show some errors and tries to load CSS that is not there anymore ...
https://hibernate.org/reactive/documentation/2.2/reference/html_single/

```
run_prettify.min.js:1 Refused to load the stylesheet 'https://google-code-prettify.googlecode.com/svn/loader/prettify.css' because it violates the following Content Security Policy directive: "style-src 'unsafe-inline' 'self' https://cdn.jsdelivr.net https://cdnjs.cloudflare.com https://fonts.googleapis.com". Note that 'style-src-elem' was not explicitly set, so 'style-src' is used as a fallback.
```
From what I see https://docs.asciidoctor.org/asciidoc/latest/verbatim/source-highlighter/ `prettify` is not on the list of highlighters anymore (if it was).
I've tried `highlight.js`, but it also wants to load additional CSS, while `CodeRay`  generates a CSS file as part of the output.