### PR TITLE
Fix default Hibernate ORM version setting

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,7 +53,7 @@ version = projectVersion
 // ./gradlew clean build -PhibernateOrmVersion=5.6.15-SNAPSHOT
 ext {
     if ( !project.hasProperty('hibernateOrmVersion') ) {
-        hibernateOrmVersion = '6.4.4.Final'
+        hibernateOrmVersion = '6.5.0.CR2'
     }
     if ( !project.hasProperty( 'hibernateOrmGradlePluginVersion' ) ) {
         // Same as ORM as default

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,7 +35,7 @@ org.gradle.java.installations.auto-download=false
 #enableMavenLocalRepo = true
 
 # Override default Hibernate ORM version
-hibernateOrmVersion = 6.5.0.CR2
+#hibernateOrmVersion = 6.5.0.CR2
 
 # Override default Hibernate ORM Gradle plugin version
 # Using the stable version because I don't know how to configure the build to download the snapshot version from


### PR DESCRIPTION
It should be set in the default file and not the gradle.properties

Fix #1888 