### PR TITLE
Don't open multiple connections on schema update

### DIFF
--- a/hibernate-reactive-core/src/test/resources/log4j2.properties
+++ b/hibernate-reactive-core/src/test/resources/log4j2.properties
@@ -10,6 +10,10 @@ logger.hibernate-dialect.level = debug
 logger.hibernate.name = org.hibernate.SQL
 logger.hibernate.level = info
 
+# We want to log when a connection is opened/closed
+logger.sql-connection.name = org.hibernate.reactive.pool.impl
+logger.sql-connection.level = trace
+
 # Setting level to TRACE will show parameters values
 logger.sql-parameters-values.name = org.hibernate.type
 logger.sql-parameters-values.level = info


### PR DESCRIPTION
Fix #1909

This should prevent opening multiple connections during schema migration.
I need to figure out how to test it though (I've  only checked manually).