### PR TITLE
Add jdk 24 to the build on CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -154,6 +154,7 @@ jobs:
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
           - { name: "22-ea", java_version_numeric: 22, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "23-ea", java_version_numeric: 23, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "24-ea", java_version_numeric: 24, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:
     - uses: actions/checkout@v2
     - name: Get year/month for cache key

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,7 +152,7 @@ jobs:
           # and it's useful to test that.
           - { name: "20", java_version_numeric: 20, jvm_args: '--enable-preview' }
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
-          - { name: "22-ea", java_version_numeric: 22, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "22", java_version_numeric: 22, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "23-ea", java_version_numeric: 23, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "24-ea", java_version_numeric: 24, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:


### PR DESCRIPTION
fixes https://github.com/hibernate/hibernate-reactive/issues/1938

Hey @DavideD 😃 
I thought while I was at it (adding JDK builds to other projects) I'd create one for Reactive as well 😃 

22 is now GA, so I've removed the -ea from the version