### PR TITLE
Change log4j.properties

### DIFF
--- a/hibernate-reactive-core/src/test/resources/log4j2.properties
+++ b/hibernate-reactive-core/src/test/resources/log4j2.properties
@@ -7,12 +7,14 @@ logger.hibernate-dialect.name = org.hibernate.orm.dialect
 logger.hibernate-dialect.level = debug
 
 # SQL logging disabled by default to speed test suite execution
+# It can also be enabled by setting the environment variable:
+# JAVA_TOOL_OPTIONS='-Dhibernate.show_sql=true'
 logger.hibernate.name = org.hibernate.SQL
 logger.hibernate.level = info
 
-# We want to log when a connection is opened/closed
+# Setting level TRACE will show when a connection is opened/closed
 logger.sql-connection.name = org.hibernate.reactive.pool.impl
-logger.sql-connection.level = trace
+logger.sql-connection.level = info
 
 # Setting level to TRACE will show parameters values
 logger.sql-parameters-values.name = org.hibernate.type
@@ -21,5 +23,5 @@ logger.sql-parameters-values.level = info
 appender.console.name = console
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{%p} %style{%c{1}}{Blue} [%t] %m%n
+appender.console.layout.pattern = %highlight{%p} %style{%c:%L}{Blue} [%t] %m%n
 

--- a/integration-tests/bytecode-enhancements-it/src/test/resources/log4j2.properties
+++ b/integration-tests/bytecode-enhancements-it/src/test/resources/log4j2.properties
@@ -7,14 +7,20 @@ logger.hibernate-dialect.name = org.hibernate.orm.dialect
 logger.hibernate-dialect.level = debug
 
 # SQL logging disabled by default to speed test suite execution
+# It can also be enabled by setting the environment variable:
+# JAVA_TOOL_OPTIONS='-Dhibernate.show_sql=true'
 logger.hibernate.name = org.hibernate.SQL
 logger.hibernate.level = info
 
+# Setting level TRACE will show when a connection is opened/closed
+logger.sql-connection.name = org.hibernate.reactive.pool.impl
+logger.sql-connection.level = info
+
 # Setting level to TRACE will show parameters values
 logger.sql-parameters-values.name = org.hibernate.type
-logger.sql-parameters-values.level = INFO
+logger.sql-parameters-values.level = info
 
 appender.console.name = console
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{[%p]} %m%n
+appender.console.layout.pattern = %highlight{%p} %style{%c:%L}{Blue} [%t] %m%n

--- a/integration-tests/hibernate-validator-postgres-it/src/test/resources/log4j2.properties
+++ b/integration-tests/hibernate-validator-postgres-it/src/test/resources/log4j2.properties
@@ -7,14 +7,20 @@ logger.hibernate-dialect.name = org.hibernate.orm.dialect
 logger.hibernate-dialect.level = debug
 
 # SQL logging disabled by default to speed test suite execution
+# It can also be enabled by setting the environment variable:
+# JAVA_TOOL_OPTIONS='-Dhibernate.show_sql=true'
 logger.hibernate.name = org.hibernate.SQL
 logger.hibernate.level = info
 
+# Setting level TRACE will show when a connection is opened/closed
+logger.sql-connection.name = org.hibernate.reactive.pool.impl
+logger.sql-connection.level = info
+
 # Setting level to TRACE will show parameters values
 logger.sql-parameters-values.name = org.hibernate.type
-logger.sql-parameters-values.level = INFO
+logger.sql-parameters-values.level = info
 
 appender.console.name = console
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{[%p]} %m%n
+appender.console.layout.pattern = %highlight{%p} %style{%c:%L}{Blue} [%t] %m%n

--- a/integration-tests/verticle-postgres-it/src/main/resources/log4j2.properties
+++ b/integration-tests/verticle-postgres-it/src/main/resources/log4j2.properties
@@ -2,14 +2,29 @@ rootLogger.level = info
 rootLogger.appenderRefs = console
 rootLogger.appenderRef.console.ref = console
 
-logger.hibernate.name = org.hibernate.SQL
-logger.hibernate.level = info
-
 # Integration tests
 logger.it.name = org.hibernate.reactive.it
 logger.it.level = info
 
+# Print the selected dialect information
+logger.hibernate-dialect.name = org.hibernate.orm.dialect
+logger.hibernate-dialect.level = debug
+
+# SQL logging disabled by default to speed test suite execution
+# It can also be enabled by setting the environment variable:
+# JAVA_TOOL_OPTIONS='-Dhibernate.show_sql=true'
+logger.hibernate.name = org.hibernate.SQL
+logger.hibernate.level = info
+
+# Setting level TRACE will show when a connection is opened/closed
+logger.sql-connection.name = org.hibernate.reactive.pool.impl
+logger.sql-connection.level = info
+
+# Setting level to TRACE will show parameters values
+logger.sql-parameters-values.name = org.hibernate.type
+logger.sql-parameters-values.level = info
+
 appender.console.name = console
 appender.console.type = Console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %highlight{[%p]} [%tid:%t] %m%n
+appender.console.layout.pattern = %highlight{%p} %style{%c:%L}{Blue} [%t] %m%n


### PR DESCRIPTION
Fix #1950 

* Print the full class path with the line number this way the IDE can link the message to the corresponding class

* Disable log related to the connection: it's useful only in certain situations and too verbose otherwise

* Uniform all log configurations in the different modules