### PR TITLE
Remove snapshots releases from main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,30 +212,6 @@ jobs:
         name: reports-java${{ matrix.java.name }}
         path: './**/build/reports/'
 
-  snapshot:
-    name: Create snapshot
-    if: github.event_name == 'push' && startsWith( github.ref, 'refs/heads/' )
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v2.2.0
-      with:
-        distribution: 'temurin'
-        java-version: 11
-    - name: Create artifacts
-      run: ./gradlew assemble
-    - name: Detect the version of Hibernate Reactive
-      id: detect-version
-      run: |
-        sed -E 's/^projectVersion( *= *| +)([^ ]+)/::set-output name=version::\2/g' gradle/version.properties
-    - name: Publish snapshot to JBoss Nexus
-      env:
-        ORG_GRADLE_PROJECT_jbossNexusUser: ${{ secrets.JBOSS_NEXUS_USER }}
-        ORG_GRADLE_PROJECT_jbossNexusPassword: ${{ secrets.JBOSS_NEXUS_PASSWORD }}
-      if: endsWith( steps.detect-version.outputs.version, '-SNAPSHOT' ) && env.ORG_GRADLE_PROJECT_jbossNexusUser
-      run: ./gradlew publishToJBossNexus closeAndReleaseJBossNexusStagingRepository
-
   release:
     name: Release
     if: github.event_name == 'push' && startsWith( github.ref, 'refs/tags/' )


### PR DESCRIPTION
Snapshot builds tend to fail quite often and sometimes we cannot even fix an issue until another project has been released.

I moved the build testing the snapshots under the branches `wip/*`. This way the failure of a build using snapshots won't affect the release of stable versions.

[Snapshot builds are here](https://github.com/hibernate/hibernate-reactive/branches).