### PR TITLE
Upgrade to hibernate-jenkins-pipeline-helpers 1.18 -- and configure the version on CI instead of in Jenkinsfile

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.17') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -9,7 +9,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 import org.hibernate.jenkins.pipeline.helpers.version.Version
 

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -1,7 +1,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.18') _
+@Library('hibernate-jenkins-pipeline-helpers') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -1,7 +1,7 @@
 /*
  * See https://github.com/hibernate/hibernate-jenkins-pipeline-helpers
  */
-@Library('hibernate-jenkins-pipeline-helpers@1.13') _
+@Library('hibernate-jenkins-pipeline-helpers@1.18') _
 
 // Avoid running the pipeline on branch indexing
 if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {


### PR DESCRIPTION
Upgrade to 1.18 to avoid buggy notifications.
See https://hibernate.zulipchat.com/#narrow/channel/132096-hibernate-user/topic/Jenkins.20Notifications
Full changeset:
https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.13..1.18
https://github.com/hibernate/hibernate-jenkins-pipeline-helpers/compare/1.17..1.18

Don't configure the version in Jenkinsfile so that it's easier to upgrade next time.
See https://ci.hibernate.org/manage/configure#global-untrusted-pipeline-libraries to change the (default) version globally for all projects.
