### PR TITLE
add StatelessSession.getIdentifier() because repositories need it

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1878,6 +1878,17 @@ public interface Mutiny {
 		<T> Uni<T> fetch(T association);
 
 		/**
+		 * Return the identifier value of the given entity, which may be detached.
+		 *
+		 * @param entity a persistent instance associated with this session
+		 *
+		 * @return the identifier
+		 *
+		 * @since 3.0
+		 */
+		Object getIdentifier(Object entity);
+
+		/**
 		 * Obtain a native SQL result set mapping defined via the annotation
 		 * {@link jakarta.persistence.SqlResultSetMapping}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -193,6 +193,11 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 		return uni( () -> delegate.reactiveFetch( association, false ) );
 	}
 
+	@Override
+	public Object getIdentifier(Object entity) {
+		return delegate.getIdentifier(entity);
+	}
+
 //	@Override
 //	public <T> ResultSetMapping<T> getResultSetMapping(Class<T> resultType, String mappingName) {
 //		return delegate.getResultSetMapping( resultType, mappingName );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveStatelessSession.java
@@ -71,4 +71,6 @@ public interface ReactiveStatelessSession extends ReactiveQueryProducer, Reactiv
 	boolean isOpen();
 
 	void close(CompletableFuture<Void> closing);
+
+	Object getIdentifier(Object entity);
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1917,6 +1917,17 @@ public interface Stage {
 		<T> CompletionStage<T> fetch(T association);
 
 		/**
+		 * Return the identifier value of the given entity, which may be detached.
+		 *
+		 * @param entity a persistent instance associated with this session
+		 *
+		 * @return the identifier
+		 *
+		 * @since 3.0
+		 */
+		Object getIdentifier(Object entity);
+
+		/**
 		 * Obtain a native SQL result set mapping defined via the annotation
 		 * {@link jakarta.persistence.SqlResultSetMapping}.
 		 */

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -133,6 +133,11 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 	}
 
 	@Override
+	public Object getIdentifier(Object entity) {
+		return delegate.getIdentifier(entity);
+	}
+
+	@Override
 	public <T> CompletionStage<T> withTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
 		return currentTransaction == null
 				? new Transaction<T>().execute( work )


### PR DESCRIPTION
This was already added to ORM SS in 6.6. See #2040.