### PR TITLE
Enable GitHub workflows on different branches

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,12 +5,17 @@ on:
     branches:
       - 'main'
       - 'wip/**'
+      - '2.*'
+      - '3.*'
     tags:
       - '2.*'
+      - '3.*'
   pull_request:
     branches:
       - 'main'
       - 'wip/**'
+      - '2.*'
+      - '3.*'
   # For building snapshots
   workflow_call:
     inputs:


### PR DESCRIPTION
Fix #2044 

Include 2.* and 3.* branches and tags (before it was only the WIP ones)