### PR TITLE
Update GitHub workflow cache action to v4

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
           echo "::set-output name=yearmonth::$(/bin/date -u "+%Y-%m")"
         shell: bash
       - name: Cache Gradle downloads
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-gradle
         with:
           path: |
@@ -139,7 +139,7 @@ jobs:
           echo "::set-output name=yearmonth::$(/bin/date -u "+%Y-%m")"
         shell: bash
       - name: Cache Gradle downloads
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         id: cache-gradle
         with:
           path: |


### PR DESCRIPTION
Fix #2049

v2 has been deprecated for a while:
https://github.blog/changelog/2024-09-16-notice-of-upcoming-deprecations-and-changes-in-github-actions-services/