### PR TITLE
Use specific Jenkins nodes for releases

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -58,7 +58,7 @@ def checkoutReleaseScripts() {
 
 pipeline {
 	agent {
-		label 'Worker&&Containers'
+		label 'Release'
 	}
 	tools {
 		jdk 'OpenJDK 17 Latest'

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -12,7 +12,7 @@ if (currentBuild.getBuildCauses().toString().contains('BranchIndexingCause')) {
 
 pipeline {
     agent {
-        label 'Fedora'
+        label 'Release'
     }
     tools {
         jdk 'OpenJDK 17 Latest'


### PR DESCRIPTION
This should be safer as these nodes are only used once.