### PR TITLE
 Attempt to fix JDBCTimeZoneZonedTest sporadic failures probably due lack of database Timestamp precision

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/AutoZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/AutoZonedTest.java
@@ -19,6 +19,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,8 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
-import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
+import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecision;
 
+/**
+ * Test adapted from {@link org.hibernate.orm.test.timezones.AutoZonedTest}
+ */
 @Timeout(value = 10, timeUnit = MINUTES)
 @DisabledFor(value = DB2, reason = "Exception: IllegalStateException: Needed to have 6 in buffer but only had 0")
 public class AutoZonedTest extends BaseReactiveTest {
@@ -48,8 +52,16 @@ public class AutoZonedTest extends BaseReactiveTest {
 
 	@Test
 	public void test(VertxTestContext context) {
-		ZonedDateTime nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of( "CET" ) );
-		OffsetDateTime nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours( 3 ) );
+		final ZonedDateTime nowZoned;
+		final OffsetDateTime nowOffset;
+		if ( getDialect().getDefaultTimestampPrecision() == 6 ) {
+			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") ).truncatedTo( ChronoUnit.MICROS );
+			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) ).truncatedTo( ChronoUnit.MICROS );
+		}
+		else {
+			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") );
+			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) );
+		}
 		test( context, getSessionFactory()
 				.withTransaction( s -> {
 					Zoned z = new Zoned();
@@ -60,10 +72,10 @@ public class AutoZonedTest extends BaseReactiveTest {
 				.thenCompose( zid -> openSession()
 						.thenCompose( s -> s.find( Zoned.class, zid )
 								.thenAccept( z -> {
-									assertWithTruncationThat( roundToDefaultPrecision( z.zonedDateTime.toInstant(), getDialect() ) )
-											.isEqualTo( roundToDefaultPrecision( nowZoned.toInstant(), getDialect() ) );
-									assertWithTruncationThat( roundToDefaultPrecision( z.offsetDateTime.toInstant(), getDialect() ) )
-											.isEqualTo( roundToDefaultPrecision( nowOffset.toInstant(), getDialect() ) );
+									assertWithTruncationThat( adjustToDefaultPrecision( z.zonedDateTime.toInstant(), getDialect() ) )
+											.isEqualTo( adjustToDefaultPrecision( nowZoned.toInstant(), getDialect() ) );
+									assertWithTruncationThat( adjustToDefaultPrecision( z.offsetDateTime.toInstant(), getDialect() ) )
+											.isEqualTo( adjustToDefaultPrecision( nowOffset.toInstant(), getDialect() ) );
 									assertThat( z.zonedDateTime.toOffsetDateTime().getOffset() )
 											.isEqualTo( nowZoned.toOffsetDateTime().getOffset() );
 									assertThat( z.offsetDateTime.getOffset() )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/ColumnZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/ColumnZonedTest.java
@@ -9,6 +9,7 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 
@@ -29,8 +30,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.AvailableSettings.TIMEZONE_DEFAULT_STORAGE;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
-import static org.hibernate.type.descriptor.DateTimeUtils.roundToDefaultPrecision;
+import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecision;
 
+/**
+ * Test adapted from {@link org.hibernate.orm.test.timezones.ColumnZonedTest}
+ */
 @Timeout(value = 10, timeUnit = MINUTES)
 @DisabledFor(value = DB2, reason = "java.sql.SQLException: An error occurred with a DB2 operation, SQLCODE=-180  SQLSTATE=22007")
 public class ColumnZonedTest extends BaseReactiveTest {
@@ -48,8 +52,16 @@ public class ColumnZonedTest extends BaseReactiveTest {
 
 	@Test
 	public void test(VertxTestContext context) {
-		ZonedDateTime nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of( "CET" ) );
-		OffsetDateTime nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours( 3 ) );
+		final ZonedDateTime nowZoned;
+		final OffsetDateTime nowOffset;
+		if ( getDialect().getDefaultTimestampPrecision() == 6 ) {
+			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") ).truncatedTo( ChronoUnit.MICROS );
+			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) ).truncatedTo( ChronoUnit.MICROS );
+		}
+		else {
+			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") );
+			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) );
+		}
 		test( context, getSessionFactory()
 				.withTransaction( s -> {
 					Zoned z = new Zoned();
@@ -60,10 +72,10 @@ public class ColumnZonedTest extends BaseReactiveTest {
 				.thenCompose( zid -> openSession()
 						.thenCompose( s -> s.find( Zoned.class, zid )
 								.thenAccept( z -> {
-									assertWithTruncationThat( roundToDefaultPrecision( z.zonedDateTime.toInstant(), getDialect() ) )
-											.isEqualTo( roundToDefaultPrecision( nowZoned.toInstant(), getDialect() ) );
-									assertWithTruncationThat( roundToDefaultPrecision( z.offsetDateTime.toInstant(), getDialect() ) )
-											.isEqualTo( roundToDefaultPrecision( nowOffset.toInstant(), getDialect() ) );
+									assertWithTruncationThat( adjustToDefaultPrecision( z.zonedDateTime.toInstant(), getDialect() ) )
+											.isEqualTo( adjustToDefaultPrecision( nowZoned.toInstant(), getDialect() ) );
+									assertWithTruncationThat( adjustToDefaultPrecision( z.offsetDateTime.toInstant(), getDialect() ) )
+											.isEqualTo( adjustToDefaultPrecision( nowOffset.toInstant(), getDialect() ) );
 									assertThat( z.zonedDateTime.toOffsetDateTime().getOffset() )
 											.isEqualTo( nowZoned.toOffsetDateTime().getOffset() );
 									assertThat( z.offsetDateTime.getOffset() )

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/JDBCTimeZoneZonedTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/timezones/JDBCTimeZoneZonedTest.java
@@ -10,15 +10,11 @@ import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
 import java.util.Collection;
 import java.util.List;
 
 import org.hibernate.cfg.Configuration;
-import org.hibernate.dialect.Dialect;
-import org.hibernate.dialect.MySQLDialect;
-import org.hibernate.dialect.SybaseDialect;
 import org.hibernate.reactive.BaseReactiveTest;
 import org.hibernate.reactive.annotations.DisabledFor;
 
@@ -38,6 +34,9 @@ import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2
 import static org.hibernate.reactive.testing.ReactiveAssertions.assertWithTruncationThat;
 import static org.hibernate.type.descriptor.DateTimeUtils.adjustToDefaultPrecision;
 
+/**
+ * Test adapted from {@link org.hibernate.orm.test.timezones.JDBCTimeZoneZonedTest}
+ */
 @Timeout(value = 10, timeUnit = MINUTES)
 @DisabledFor(value = DB2, reason = "Exception: IllegalStateException: Needed to have 6 in buffer but only had 0")
 public class JDBCTimeZoneZonedTest extends BaseReactiveTest {
@@ -58,15 +57,7 @@ public class JDBCTimeZoneZonedTest extends BaseReactiveTest {
 	public void test(VertxTestContext context) {
 		final ZonedDateTime nowZoned;
 		final OffsetDateTime nowOffset;
-		final Dialect dialect = getDialect();
-		if ( dialect instanceof SybaseDialect || dialect instanceof MySQLDialect ) {
-			// Sybase has 1/300th sec precision
-			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") )
-					.with( ChronoField.NANO_OF_SECOND, 0L );
-			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) )
-					.with( ChronoField.NANO_OF_SECOND, 0L );
-		}
-		else if ( dialect.getDefaultTimestampPrecision() == 6 ) {
+		if ( getDialect().getDefaultTimestampPrecision() == 6 ) {
 			nowZoned = ZonedDateTime.now().withZoneSameInstant( ZoneId.of("CET") ).truncatedTo( ChronoUnit.MICROS );
 			nowOffset = OffsetDateTime.now().withOffsetSameInstant( ZoneOffset.ofHours(3) ).truncatedTo( ChronoUnit.MICROS );
 		}


### PR DESCRIPTION
Fix: https://github.com/hibernate/hibernate-reactive/issues/1724
Related: https://issues.redhat.com/browse/HREACT-56 