### PR TITLE
Create custom Vert.x contextual data storage

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/ContextualDataStorage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/ContextualDataStorage.java
@@ -1,0 +1,25 @@
+/* Hibernate, Relational Persistence for Idiomatic Java
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright: Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.context.impl;
+
+import java.util.concurrent.ConcurrentMap;
+
+import io.vertx.core.impl.VertxBuilder;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+/**
+ * SPI Implementation for {@link ContextLocal} storage.
+ */
+public class ContextualDataStorage implements VertxServiceProvider {
+
+	@SuppressWarnings("rawtypes")
+	static ContextLocal<ConcurrentMap> CONTEXTUAL_DATA_KEY = ContextLocal.registerLocal( ConcurrentMap.class );
+
+	@Override
+	public void init(VertxBuilder vertxBuilder) {
+	}
+}

--- a/hibernate-reactive-core/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/hibernate-reactive-core/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+org.hibernate.reactive.context.impl.ContextualDataStorage


### PR DESCRIPTION
Closes #2176

In Vert.x 5, the local context data map is deprecated.

Hibernate Reactive can have its own Vert.x contextual data storage (requires creating a io.vertx.core.spi.context.storage.ContextLocal key).