### PR TITLE
fix misspelling in Javadoc

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -846,14 +846,16 @@ public interface Mutiny {
 		Uni<Void> flush();
 
 		/**
-		 * Asynchronously fetch an association that's configured for lazy loading.
+		 * Asynchronously fetch an association configured for lazy loading.
 		 * <p>
 		 * <pre>
 		 * {@code session.fetch(author.getBook()).thenAccept(book -> print(book.getTitle()));}
 		 * </pre>
 		 * </p>
 		 * <p>
-		 * It can also initialize proxys. For example:
+		 * This operation may be even be used to initialize a reference returned by
+		 * {@link #getReference(Class, Object)}.
+		 * <p>
 		 * <pre>
 		 * {@code session.fetch(session.getReference(Author.class, authorId))}
 		 * </pre>

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -870,14 +870,16 @@ public interface Stage {
 		CompletionStage<Void> flush();
 
 		/**
-		 * Asynchronously fetch an association that's configured for lazy loading.
+		 * Asynchronously fetch an association configured for lazy loading.
 		 * <p>
 		 * <pre>
 		 * {@code session.fetch(author.getBook()).thenAccept(book -> print(book.getTitle()))}
 		 * </pre>
 		 * </p>
 		 * <p>
-		 * It can also initialize proxys. For example:
+		 * This operation may be even be used to initialize a reference returned by
+		 * {@link #getReference(Class, Object)}.
+		 * <p>
 		 * <pre>
 		 * {@code session.fetch(session.getReference(Author.class, authorId))}
 		 * </pre>


### PR DESCRIPTION
It should have been "proxies".

But anyway I rewrote the sentence.