### PR TITLE
Adjust snapshot publishing to use the publish plugin instead of JReleaser

### DIFF
--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -41,19 +41,15 @@ pipeline {
 				script {
 					withCredentials([
 							// https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-ossrh
-							// TODO: Once we switch to maven-central publishing (from nexus2) we need to add a new credentials
-							//  to use the following env variable names to set the user/password:
-							//  - JRELEASER_MAVENCENTRAL_USERNAME
-							//  - JRELEASER_MAVENCENTRAL_TOKEN
-							//  Also use the new `credentialsId` for Maven Central, e.g.:
-							//  usernamePassword(credentialsId: '???????', passwordVariable: 'JRELEASER_MAVENCENTRAL_TOKEN', usernameVariable: 'JRELEASER_MAVENCENTRAL_USERNAME'),
-							usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'JRELEASER_NEXUS2_PASSWORD', usernameVariable: 'JRELEASER_NEXUS2_USERNAME'),
+							// TODO: Once we switch to maven-central publishing (from nexus2) we need to update credentialsId:
+							//  https://docs.gradle.org/current/samples/sample_publishing_credentials.html#:~:text=via%20environment%20variables
+							usernamePassword(credentialsId: 'ossrh.sonatype.org', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername'),
 							gitUsernamePassword(credentialsId: 'username-and-token.Hibernate-CI.github.com', gitToolName: 'Default'),
 							string(credentialsId: 'Hibernate-CI.github.com', variable: 'JRELEASER_GITHUB_TOKEN')
 					]) {
 						checkoutReleaseScripts()
 						def version = sh(
-								script: ".release/scripts/determine-current-version.sh orm",
+								script: ".release/scripts/determine-current-version.sh reactive",
 								returnStdout: true
 						).trim()
 						echo "Current version: '${version}'"

--- a/jreleaser.yml
+++ b/jreleaser.yml
@@ -27,16 +27,6 @@ deploy:
         releaseRepository: false
         stagingRepositories:
           - build/staging-deploy/maven
-      maven-central-snapshot:
-        active: SNAPSHOT
-        url: https://oss.sonatype.org/service/local
-        snapshotUrl: https://oss.sonatype.org/content/repositories/snapshots/
-        closeRepository: true
-        releaseRepository: true
-        javadocJar: false
-        sign: false
-        stagingRepositories:
-          - build/staging-deploy/maven
     mavenCentral:
       maven-central:
         # TODO: Change to RELEASE once switching to Maven-Central:
@@ -45,15 +35,5 @@ deploy:
         url: https://central.sonatype.com/api/v1/publisher
         snapshotSupported: false
         applyMavenCentralRules: true
-        stagingRepositories:
-          - build/staging-deploy/maven
-      maven-central-snapshot:
-        # TODO: Change to SNAPSHOT once switching to Maven-Central:
-        active: NEVER
-        url: https://central.sonatype.com/api/v1/publisher
-        snapshotSupported: true
-        applyMavenCentralRules: true
-        javadocJar: false
-        sign: false
         stagingRepositories:
           - build/staging-deploy/maven

--- a/publish.gradle
+++ b/publish.gradle
@@ -79,5 +79,12 @@ publishing {
             name = "staging"
             url = rootProject.layout.buildDirectory.dir("staging-deploy${File.separator}maven")
         }
+        maven {
+            name = 'snapshots'
+            url = "https://oss.sonatype.org/content/repositories/snapshots/"
+            // So that Gradle uses the `ORG_GRADLE_PROJECT_snapshotsPassword` / `ORG_GRADLE_PROJECT_snapshotsUsername`
+            //  env variables to read the username/password for the `snapshots` repository publishing:
+            credentials(PasswordCredentials)
+        }
     }
 }


### PR DESCRIPTION
Since JReleaser won't work with snapshot publishing to nexus3 and from the docs it's suggested to just use a regular publish plugin: https://central.sonatype.org/publish/publish-portal-snapshots/#publishing-via-other-methods

- https://github.com/hibernate/hibernate-orm/commit/f9164f289f2af6f0992b196d1b4799cfe5b27d28
- https://github.com/hibernate/hibernate-orm/commit/b58564dce380f62eee5e2dc618b0aa9fed6e4235