### PR TITLE
Remove MutinyStatelessSessionDelegator#upsert(String entityName, Object entity) method

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/delegation/MutinyStatelessSessionDelegator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/delegation/MutinyStatelessSessionDelegator.java
@@ -212,11 +212,6 @@ public abstract class MutinyStatelessSessionDelegator implements Mutiny.Stateles
     }
 
     @Incubating
-    public Uni<Void> upsert(String entityName, Object entity) {
-        return delegate().upsert(entityName, entity);
-    }
-
-    @Incubating
     public Uni<Void> upsertAll(Object... entities) {
         return delegate().upsertAll(entities);
     }


### PR DESCRIPTION
The code was not compiling
```
delegate().upsert(entityName, entity);
```
has been removed so I think the aim was to get rid of this method.