### PR TITLE
Remove workaround for HHH-19386

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -404,12 +404,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 		}
 		else if ( typedQueryReference instanceof MutationSpecificationImpl<?> specification ) {
 			final CommonAbstractCriteria query = specification.buildCriteria( getCriteriaBuilder() );
-			// Workaround for ORM, can be remove when this issue is solved: https://hibernate.atlassian.net/browse/HHH-19386
-			final Class<R> type =
-					specification.getResultType() == Void.class
-							? null
-							: (Class<R>) specification.getResultType();
-			return new ReactiveQuerySqmImpl<>( (SqmStatement<R>) query, type, this );
+			return new ReactiveQuerySqmImpl<>( (SqmStatement<R>) query, (Class<R>) specification.getResultType(), this );
 		}
 		else {
 			@SuppressWarnings("unchecked")

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -942,11 +942,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 		}
 		if ( typedQueryReference instanceof MutationSpecificationImpl<?> specification ) {
 			final CommonAbstractCriteria query = specification.buildCriteria( getCriteriaBuilder() );
-			// Workaround for ORM, can be remove when this issue is solved: https://hibernate.atlassian.net/browse/HHH-19386
-			Class<R> type = (Class<R>) specification.getResultType() == Void.class
-					? null
-					: (Class<R>) specification.getResultType();
-			return new ReactiveQuerySqmImpl<>( (SqmStatement<R>) query, type, this );
+			return new ReactiveQuerySqmImpl<>( (SqmStatement<R>) query, (Class<R>) specification.getResultType(), this );
 		}
 		@SuppressWarnings("unchecked")
 		// this cast is fine because of all our impls of TypedQueryReference return Class<R>


### PR DESCRIPTION
The method getResultType doesn't return Void.class anymore.

See https://hibernate.atlassian.net/browse/HHH-19386

Fix #2227 