### PR TITLE
[2.4] Upgrade Vert.x SQL client to 4.5.15 (from 4.5.14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,11 +38,11 @@ Hibernate Reactive has been tested with:
 - MS SQL Server 2022
 - Oracle 23
 - [Hibernate ORM][] 6.6.15.Final
-- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5.14
-- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5.14
-- [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5.14
-- [Vert.x Reactive MS SQL Server Client](https://vertx.io/docs/vertx-mssql-client/java/) 4.5.14
-- [Vert.x Reactive Oracle Client](https://vertx.io/docs/vertx-oracle-client/java/) 4.5.14
+- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5.15
+- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5.15
+- [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5.15
+- [Vert.x Reactive MS SQL Server Client](https://vertx.io/docs/vertx-mssql-client/java/) 4.5.15
+- [Vert.x Reactive Oracle Client](https://vertx.io/docs/vertx-oracle-client/java/) 4.5.15
 - [Quarkus][Quarkus] via the Hibernate Reactive extension
 
 [PostgreSQL]: https://www.postgresql.org

--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ ext {
     // Example:
     // ./gradlew build -PvertxSqlClientVersion=4.0.0-SNAPSHOT
     if ( !project.hasProperty( 'vertxSqlClientVersion' ) ) {
-        vertxSqlClientVersion = '4.5.14'
+        vertxSqlClientVersion = '4.5.15'
     }
 
     testcontainersVersion = '1.20.6'

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,9 +47,9 @@ hibernateOrmVersion = 6.6.15.Final
 #skipOrmVersionParsing = true
 
 # Override default Vert.x Sql client version
-#vertxSqlClientVersion = 4.5.14-SNAPSHOT
+#vertxSqlClientVersion = 4.5.15-SNAPSHOT
 
 # Override default Vert.x Web client and server versions. For integration tests, both default to vertxSqlClientVersion
-#vertxWebVersion = 4.5.14
-#vertxWebtClientVersion = 4.5.14
+#vertxWebVersion = 4.5.15
+#vertxWebtClientVersion = 4.5.15
 

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -5,8 +5,8 @@
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-//DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
+//DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2

--- a/tooling/jbang/Db2ReactiveTest.java.qute
+++ b/tooling/jbang/Db2ReactiveTest.java.qute
@@ -5,8 +5,8 @@
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-//DEPS io.vertx:vertx-db2-client:$\{vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
+//DEPS io.vertx:vertx-db2-client:$\{vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2

--- a/tooling/jbang/Example.java
+++ b/tooling/jbang/Example.java
@@ -6,9 +6,9 @@
  */
 
 //DEPS com.ongres.scram:client:2.1
-//DEPS io.vertx:vertx-pg-client:${vertx.version:4.5.14}
-//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.14}
-//DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.14}
+//DEPS io.vertx:vertx-pg-client:${vertx.version:4.5.15}
+//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.15}
+//DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:2.4.0.Final}
 //DEPS org.slf4j:slf4j-simple:2.0.7
 //DESCRIPTION Allow authentication to PostgreSQL using SCRAM:

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -5,8 +5,8 @@
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-//DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
+//DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -5,8 +5,8 @@
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-//DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
+//DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -5,8 +5,8 @@
  * Copyright: Red Hat Inc. and Hibernate Authors
  */
 
-//DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
+//DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -5,11 +5,11 @@
  */
 
 ///usr/bin/env jbang "$0" "$@" ; exit $?
-//DEPS io.vertx:vertx-pg-client:${vertx.version:4.5.14}
+//DEPS io.vertx:vertx-pg-client:${vertx.version:4.5.15}
 //DEPS com.ongres.scram:client:2.1
-//DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.14}
-//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.14}
-//DEPS io.vertx:vertx-unit:${vertx.version:4.5.14}
+//DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.15}
+//DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.15}
+//DEPS io.vertx:vertx-unit:${vertx.version:4.5.15}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:2.4.0.Final}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2


### PR DESCRIPTION
Backport #2261 for 2.4. branch

We should wait until it's merged in Quarkus.

See See https://github.com/quarkusio/quarkus/blob/4abbcf233f6e75bc86ab070ad3d40ada0502e0e3/bom/application/pom.xml#L114