### PR TITLE
Dependencies upgrades: JBoss Logging, jdbc drivers, AssertJ, and Testcontainers 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ ext {
         vertxSqlClientVersion = '4.5.14'
     }
 
-    testcontainersVersion = '1.20.6'
+    testcontainersVersion = '1.21.0'
 
     logger.lifecycle "Vert.x SQL Client Version: " + project.vertxSqlClientVersion
 }

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.11.3'
 
     // JDBC driver to test with ORM and PostgreSQL
-    testRuntimeOnly "org.postgresql:postgresql:42.7.4"
+    testRuntimeOnly "org.postgresql:postgresql:42.7.5"
 
     // JDBC driver for Testcontainers with MS SQL Server
     testRuntimeOnly "com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre11"

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -16,9 +16,9 @@ dependencies {
     implementation 'org.jboss.logging:jboss-logging:3.6.1.Final'
     annotationProcessor 'org.jboss.logging:jboss-logging:3.6.1.Final'
 
-    compileOnly 'org.jboss.logging:jboss-logging-annotations:3.0.3.Final'
-    annotationProcessor 'org.jboss.logging:jboss-logging-annotations:3.0.3.Final'
-    annotationProcessor 'org.jboss.logging:jboss-logging-processor:3.0.3.Final'
+    compileOnly 'org.jboss.logging:jboss-logging-annotations:3.0.4.Final'
+    annotationProcessor 'org.jboss.logging:jboss-logging-annotations:3.0.4.Final'
+    annotationProcessor 'org.jboss.logging:jboss-logging-processor:3.0.4.Final'
 
 
     //Specific implementation details of Hibernate Reactive:

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     testRuntimeOnly "org.postgresql:postgresql:42.7.5"
 
     // JDBC driver for Testcontainers with MS SQL Server
-    testRuntimeOnly "com.microsoft.sqlserver:mssql-jdbc:12.8.1.jre11"
+    testRuntimeOnly "com.microsoft.sqlserver:mssql-jdbc:12.10.0.jre11"
 
     // JDBC driver for Testcontainers with MariaDB Server
     testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.5.1"

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     implementation "io.vertx:vertx-sql-client:${vertxSqlClientVersion}"
 
     // Testing
-    testImplementation 'org.assertj:assertj-core:3.26.3'
+    testImplementation 'org.assertj:assertj-core:3.27.3'
     testImplementation "io.vertx:vertx-junit5:${vertxSqlClientVersion}"
 
     // Drivers

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     testRuntimeOnly "com.microsoft.sqlserver:mssql-jdbc:12.10.0.jre11"
 
     // JDBC driver for Testcontainers with MariaDB Server
-    testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.5.1"
+    testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.5.3"
 
     // JDBC driver for Testcontainers with MYSQL Server
     testRuntimeOnly "com.mysql:mysql-connector-j:9.1.0"

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     testRuntimeOnly "org.mariadb.jdbc:mariadb-java-client:3.5.3"
 
     // JDBC driver for Testcontainers with MYSQL Server
-    testRuntimeOnly "com.mysql:mysql-connector-j:9.1.0"
+    testRuntimeOnly "com.mysql:mysql-connector-j:9.3.0"
 
     // JDBC driver for Db2 server, for testing
     testRuntimeOnly "com.ibm.db2:jcc:12.1.0.0"

--- a/integration-tests/bytecode-enhancements-it/build.gradle
+++ b/integration-tests/bytecode-enhancements-it/build.gradle
@@ -17,7 +17,7 @@ description = 'Bytecode enhancements integration tests'
 
 ext {
     log4jVersion = '2.20.0'
-    assertjVersion = '3.26.3'
+    assertjVersion = '3.27.3'
 }
 
 dependencies {

--- a/integration-tests/hibernate-validator-postgres-it/build.gradle
+++ b/integration-tests/hibernate-validator-postgres-it/build.gradle
@@ -17,7 +17,7 @@ description = 'Quarkus QE integration tests'
 
 ext {
     log4jVersion = '2.20.0'
-    assertjVersion = '3.26.3'
+    assertjVersion = '3.27.3'
 }
 
 dependencies {

--- a/integration-tests/techempower-postgres-it/build.gradle
+++ b/integration-tests/techempower-postgres-it/build.gradle
@@ -14,7 +14,7 @@ description = 'TechEmpower integration tests'
 ext {
 	jacksonDatabindVersion = '2.15.2'
 	jbossLoggingVersion = '3.5.0.Final'
-	assertjVersion = '3.26.3'
+	assertjVersion = '3.27.3'
 	vertxWebVersion = project.hasProperty( 'vertxWebVersion' )
 			? project.property( 'vertxWebVersion' )
 			: vertxSqlClientVersion

--- a/integration-tests/verticle-postgres-it/build.gradle
+++ b/integration-tests/verticle-postgres-it/build.gradle
@@ -14,7 +14,7 @@ description = 'Bytecode enhancements integration tests'
 ext {
     jacksonDatabindVersion = '2.15.2'
     jbossLoggingVersion = '3.5.0.Final'
-    assertjVersion = '3.26.3'
+    assertjVersion = '3.27.3'
     vertxWebVersion = project.hasProperty( 'vertxWebVersion' )
             ? project.property( 'vertxWebVersion' )
             : vertxSqlClientVersion

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -8,7 +8,7 @@
 //DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:cockroachdb:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -10,7 +10,7 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:cockroachdb:1.20.6
+//DEPS org.testcontainers:cockroachdb:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7
 
 //// Testcontainer needs the JDBC drivers to start the container

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -15,7 +15,7 @@
 
 //// Testcontainer needs the JDBC drivers to start the container
 //// Hibernate Reactive doesn't need it
-//DEPS org.postgresql:postgresql:42.7.4
+//DEPS org.postgresql:postgresql:42.7.5
 
 import java.io.IOException;
 import jakarta.persistence.Entity;

--- a/tooling/jbang/Db2ReactiveTest.java.qute
+++ b/tooling/jbang/Db2ReactiveTest.java.qute
@@ -8,7 +8,7 @@
 //DEPS io.vertx:vertx-db2-client:$\{vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:db2:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7

--- a/tooling/jbang/Db2ReactiveTest.java.qute
+++ b/tooling/jbang/Db2ReactiveTest.java.qute
@@ -10,7 +10,7 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:db2:1.20.6
+//DEPS org.testcontainers:db2:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7
 
 import jakarta.persistence.Entity;

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -10,7 +10,7 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:mariadb:1.20.6
+//DEPS org.testcontainers:mariadb:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7
 
 //// Testcontainer needs the JDBC drivers to start the container

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -8,7 +8,7 @@
 //DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:mariadb:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -15,7 +15,7 @@
 
 //// Testcontainer needs the JDBC drivers to start the container
 //// Hibernate Reactive doesn't need it
-//DEPS org.mariadb.jdbc:mariadb-java-client:3.5.1
+//DEPS org.mariadb.jdbc:mariadb-java-client:3.5.3
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -10,7 +10,7 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:mysql:1.20.6
+//DEPS org.testcontainers:mysql:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7
 
 //// Testcontainer needs the JDBC drivers to start the container

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -15,7 +15,7 @@
 
 //// Testcontainer needs the JDBC drivers to start the container
 //// Hibernate Reactive doesn't need it
-//DEPS com.mysql:mysql-connector-j:9.1.0
+//DEPS com.mysql:mysql-connector-j:9.3.0
 
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -8,7 +8,7 @@
 //DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:mysql:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -8,7 +8,7 @@
 //DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:postgresql:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -10,7 +10,7 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:postgresql:1.20.6
+//DEPS org.testcontainers:postgresql:1.21.0
 //DEPS org.slf4j:slf4j-simple:2.0.7
 //DESCRIPTION Allow authentication to PostgreSQL using SCRAM:
 //DEPS com.ongres.scram:client:2.1

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -22,7 +22,7 @@
 //// Testcontainer needs the JDBC drivers to start the containers
 //// Hibernate Reactive doesn't use them
 //DEPS org.postgresql:postgresql:42.7.5
-//DEPS com.mysql:mysql-connector-j:9.1.0
+//DEPS com.mysql:mysql-connector-j:9.3.0
 //DEPS org.mariadb.jdbc:mariadb-java-client:3.5.3
 //
 

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -23,7 +23,7 @@
 //// Hibernate Reactive doesn't use them
 //DEPS org.postgresql:postgresql:42.7.5
 //DEPS com.mysql:mysql-connector-j:9.1.0
-//DEPS org.mariadb.jdbc:mariadb-java-client:3.5.1
+//DEPS org.mariadb.jdbc:mariadb-java-client:3.5.3
 //
 
 import java.util.function.Supplier;

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -11,7 +11,7 @@
 //DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.14}
 //DEPS io.vertx:vertx-unit:${vertx.version:4.5.14}
 //DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:3.0.0.Beta1}
-//DEPS org.assertj:assertj-core:3.26.3
+//DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:postgresql:1.21.0
 //DEPS org.testcontainers:mysql:1.21.0

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -13,11 +13,11 @@
 //DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:3.0.0.Beta1}
 //DEPS org.assertj:assertj-core:3.26.3
 //DEPS junit:junit:4.13.2
-//DEPS org.testcontainers:postgresql:1.20.6
-//DEPS org.testcontainers:mysql:1.20.6
-//DEPS org.testcontainers:db2:1.20.6
-//DEPS org.testcontainers:mariadb:1.20.6
-//DEPS org.testcontainers:cockroachdb:1.20.6
+//DEPS org.testcontainers:postgresql:1.21.0
+//DEPS org.testcontainers:mysql:1.21.0
+//DEPS org.testcontainers:db2:1.21.0
+//DEPS org.testcontainers:mariadb:1.21.0
+//DEPS org.testcontainers:cockroachdb:1.21.0
 //
 //// Testcontainer needs the JDBC drivers to start the containers
 //// Hibernate Reactive doesn't use them

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -21,7 +21,7 @@
 //
 //// Testcontainer needs the JDBC drivers to start the containers
 //// Hibernate Reactive doesn't use them
-//DEPS org.postgresql:postgresql:42.7.4
+//DEPS org.postgresql:postgresql:42.7.5
 //DEPS com.mysql:mysql-connector-j:9.1.0
 //DEPS org.mariadb.jdbc:mariadb-java-client:3.5.1
 //


### PR DESCRIPTION
- Upgrade JBoss Logging Annotations and Processor to 3.0.4
- Upgrade MySQL JDBC driver to 9.3.0
- Upgrade MariaDB JDBC driver to 3.5.3
- Upgrade MSSQL JDBC driver to 12.10.0.jre11
- Upgrade PostgresSQL JDBC driver to 42.7.5
- Upgrade AssertJ to 3.27.3
- Upgrade Testcontainers to 1.21.0