### PR TITLE
[2.4] Upgrade Mutiny to 2.9.0

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     api "org.hibernate.orm:hibernate-core:${hibernateOrmVersion}"
 
-    api 'io.smallrye.reactive:mutiny:2.7.0'
+    api 'io.smallrye.reactive:mutiny:2.9.0'
 
     //Logging
     implementation 'org.jboss.logging:jboss-logging:3.5.0.Final'


### PR DESCRIPTION
Backport #2266 (PR https://github.com/hibernate/hibernate-reactive/pull/2268) for 2.4