### PR TITLE
Switch from Hibernate Reactive 3.0 to 4.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,18 @@ on:
       - 'wip/**'
       - '2.*'
       - '3.*'
+      - '4.*'
     tags:
       - '2.*'
       - '3.*'
+      - '4.*'
   pull_request:
     branches:
       - 'main'
       - 'wip/**'
       - '2.*'
       - '3.*'
+      - '4.*'
   # For building snapshots
   workflow_call:
     inputs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,7 +2,7 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [ "main", "1.0", "jakarta/main" ]
+    branches: [ "main", "4.0", "3.0", "2.4" ]
   pull_request:
     branches: [ "main" ]
   schedule:

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -11,7 +11,7 @@ jobs:
   build-snapshots:
     strategy:
       matrix:
-        branch: [ 'wip/2.3', 'wip/2.4', 'wip/3.0' ]
+        branch: [ 'wip/2.4', 'wip/3.0', 'wip/4.0' ]
     uses: ./.github/workflows/build.yml
     with:
       branch: ${{ matrix.branch }}

--- a/gradle/version.properties
+++ b/gradle/version.properties
@@ -1,1 +1,1 @@
-projectVersion=3.0.1-SNAPSHOT
+projectVersion=4.0.0-SNAPSHOT

--- a/tooling/jbang/CockroachDBReactiveTest.java.qute
+++ b/tooling/jbang/CockroachDBReactiveTest.java.qute
@@ -7,7 +7,7 @@
 
 //DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:cockroachdb:1.21.0

--- a/tooling/jbang/Db2ReactiveTest.java.qute
+++ b/tooling/jbang/Db2ReactiveTest.java.qute
@@ -7,7 +7,7 @@
 
 //DEPS io.vertx:vertx-db2-client:$\{vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:db2:1.21.0

--- a/tooling/jbang/Example.java
+++ b/tooling/jbang/Example.java
@@ -9,7 +9,7 @@
 //DEPS io.vertx:vertx-pg-client:${vertx.version:4.5.15}
 //DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.15}
 //DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:4.0.0.Final}
 //DEPS org.slf4j:slf4j-simple:2.0.7
 //DESCRIPTION Allow authentication to PostgreSQL using SCRAM:
 

--- a/tooling/jbang/MariaDBReactiveTest.java.qute
+++ b/tooling/jbang/MariaDBReactiveTest.java.qute
@@ -7,7 +7,7 @@
 
 //DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:mariadb:1.21.0

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -7,7 +7,7 @@
 
 //DEPS io.vertx:vertx-mysql-client:$\{vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:mysql:1.21.0

--- a/tooling/jbang/PostgreSQLReactiveTest.java.qute
+++ b/tooling/jbang/PostgreSQLReactiveTest.java.qute
@@ -7,7 +7,7 @@
 
 //DEPS io.vertx:vertx-pg-client:$\{vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:$\{vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:$\{hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:postgresql:1.21.0

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -10,7 +10,7 @@
 //DEPS io.vertx:vertx-db2-client:${vertx.version:4.5.15}
 //DEPS io.vertx:vertx-mysql-client:${vertx.version:4.5.15}
 //DEPS io.vertx:vertx-unit:${vertx.version:4.5.15}
-//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:3.0.0.Final}
+//DEPS org.hibernate.reactive:hibernate-reactive-core:${hibernate-reactive.version:4.0.0.Final}
 //DEPS org.assertj:assertj-core:3.27.3
 //DEPS junit:junit:4.13.2
 //DEPS org.testcontainers:postgresql:1.21.0


### PR DESCRIPTION
Fix  #2272 

* Update JBang templates
* Update development version to 4.0.0-SNAPSHOT
* Enable GitHub workflow on the 4 branches and tags