### PR TITLE
Improve error message when asking for a JDBC connection

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.logging.impl;
 
 
 
+import java.sql.SQLException;
 import java.sql.SQLWarning;
 
 import jakarta.persistence.PersistenceException;
@@ -265,6 +266,9 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 83, value = "Unexpected request of a non reactive connection")
 	HibernateException unexpectedConnectionRequest();
+
+	@Message(id = 84, value = "The application requested a JDBC connection, but Hibernate Reactive doesn't use JDBC. This could be caused by a bug or the use of an unsupported feature in Hibernate Reactive")
+	SQLException notUsingJdbc();
 
 	// Same method that exists in CoreMessageLogger
 	@LogMessage(level = WARN)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcConnectionProvider.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcConnectionProvider.java
@@ -6,9 +6,13 @@
 package org.hibernate.reactive.provider.service;
 
 import org.hibernate.engine.jdbc.connections.spi.ConnectionProvider;
+import org.hibernate.reactive.logging.impl.Log;
 
 import java.sql.Connection;
 import java.sql.SQLException;
+
+import static java.lang.invoke.MethodHandles.lookup;
+import static org.hibernate.reactive.logging.impl.LoggerFactory.make;
 
 /**
  * A dummy Hibernate {@link ConnectionProvider} throws an
@@ -17,12 +21,13 @@ import java.sql.SQLException;
  * @author Gavin King
  */
 public class NoJdbcConnectionProvider implements ConnectionProvider {
+	private static final Log LOG = make( Log.class, lookup() );
 
 	public static final NoJdbcConnectionProvider INSTANCE = new NoJdbcConnectionProvider();
 
 	@Override
 	public Connection getConnection() throws SQLException {
-		throw new SQLException( "Not using JDBC" );
+		throw LOG.notUsingJdbc();
 	}
 
 	@Override


### PR DESCRIPTION
Fix #2186

@yrodiere, is this better?

@dreab8, You are workging on https://github.com/hibernate/hibernate-reactive/issues/2154, right? Do you have a test case I can borrow to see the error? Thanks

The new error message:
```
The application requested a JDBC connection, but Hibernate Reactive doesn't use JDBC.
This could be caused by a bug or the use of an unsupported feature in Hibernate Reactive
```