### PR TITLE
[3.0] Upgrade Hibernate ORM to 7.0.2.Final

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Hibernate Reactive has been tested with:
 - CockroachDB v24
 - MS SQL Server 2022
 - Oracle 23
-- [Hibernate ORM][] 7.0.1.Final
+- [Hibernate ORM][] 7.0.2.Final
 - [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5.15
 - [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5.15
 - [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5.15

--- a/gradle.properties
+++ b/gradle.properties
@@ -35,12 +35,12 @@ org.gradle.java.installations.auto-download=false
 #enableMavenLocalRepo = true
 
 # The default Hibernate ORM version (override using `-PhibernateOrmVersion=the.version.you.want`)
-hibernateOrmVersion = 7.0.1.Final
+hibernateOrmVersion = 7.0.2.Final
 
 # Override default Hibernate ORM Gradle plugin version
 # Using the stable version because I don't know how to configure the build to download the snapshot version from
 # a remote repository
-#hibernateOrmGradlePluginVersion = 7.0.0.Final
+#hibernateOrmGradlePluginVersion = 7.0.2.Final
 
 # If set to true, skip Hibernate ORM version parsing (default is true, if set to null)
 # this is required when using intervals or weird versions or the build will fail


### PR DESCRIPTION
Backport #2300 (PR https://github.com/hibernate/hibernate-reactive/pull/2301) to the 3.0 branch