### PR TITLE
[2.4] Update optional snapshot repositories to point to central snapshots instead of ossrh ones

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,9 +56,9 @@ subprojects {
             // Useful for local development, it should be disabled otherwise
             mavenLocal()
         }
-        // Example: ./gradlew build -PenableSonatypeOpenSourceSnapshotsRep
-        if ( project.hasProperty('enableSonatypeOpenSourceSnapshotsRep') ) {
-            maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+        // Example: ./gradlew build -PenableCentralSonatypeSnapshotsRep
+        if ( project.hasProperty('enableCentralSonatypeSnapshotsRep') ) {
+            maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
         }
 
         mavenCentral()

--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -8,9 +8,9 @@ buildscript {
             mavenLocal()
         }
         // Optional: Enables snapshots repository
-        // Example: ./gradlew build -PenableSonatypeOpenSourceSnapshotsRep
-        if ( project.hasProperty('enableSonatypeOpenSourceSnapshotsRep') ) {
-            maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+        // Example: ./gradlew build -PenableCentralSonatypeSnapshotsRep
+        if ( project.hasProperty('enableCentralSonatypeSnapshotsRep') ) {
+            maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
         }
         mavenCentral()
     }

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -8,9 +8,9 @@ buildscript {
             mavenLocal()
         }
         // Optional: Enables snapshots repository
-        // Example: ./gradlew build -PenableSonatypeOpenSourceSnapshotsRep
-        if ( project.hasProperty('enableSonatypeOpenSourceSnapshotsRep') ) {
-            maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
+        // Example: ./gradlew build -PenableCentralSonatypeSnapshotsRep
+        if ( project.hasProperty('enableCentralSonatypeSnapshotsRep') ) {
+            maven { url 'https://central.sonatype.com/repository/maven-snapshots/' }
         }
         mavenCentral()
     }


### PR DESCRIPTION
Backport extra bit of issue https://github.com/hibernate/hibernate-reactive/issues/2305 (PR https://github.com/hibernate/hibernate-reactive/pull/2313) for 2.4
