### PR TITLE
Rename snapshot repo property

### DIFF
--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -75,3 +75,36 @@ tasks.register( "runAllExamples" ) {
     dependsOn = ["runAllExamplesOnPostgreSQL"]
     description = "Run all examples on ${dbs}"
 }
+
+// Optional: Task to print the resolved versions of Hibernate ORM and Vert.x
+tasks.register( "printResolvedVersions" ) {
+    description = "Print the resolved hibernate-orm-core and vert.x versions"
+    doLast {
+        def hibernateCoreVersion = "n/a"
+        def vertxVersion = "n/a"
+
+        // Resolve Hibernate Core and Vert.x versions from compile classpath
+        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            if (artifact.moduleVersion.id.name == 'hibernate-core') {
+                hibernateCoreVersion = artifact.moduleVersion.id.version
+            }
+            if (artifact.moduleVersion.id.group == 'io.vertx' && artifact.moduleVersion.id.name == 'vertx-sql-client') {
+                vertxVersion = artifact.moduleVersion.id.version
+            }
+        }
+
+        // Print the resolved versions
+        println "Resolved Hibernate ORM Core Version: ${hibernateCoreVersion}"
+        println "Resolved Vert.x SQL client Version: ${vertxVersion}"
+    }
+}
+
+// Make the version printing task run before tests and JavaExec tasks
+tasks.withType( Test ).configureEach {
+    dependsOn printResolvedVersions
+}
+
+tasks.withType( JavaExec ).configureEach {
+    dependsOn printResolvedVersions
+}
+

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -81,3 +81,35 @@ tasks.register( "runAllExamples" ) {
     dependsOn = ["runAllExamplesOnPostgreSQL", "runAllExamplesOnMySQL"]
     description = "Run all examples on ${dbs}"
 }
+
+// Optional: Task to print the resolved versions of Hibernate ORM and Vert.x
+tasks.register( "printResolvedVersions" ) {
+    description = "Print the resolved hibernate-orm-core and vert.x versions"
+    doLast {
+        def hibernateCoreVersion = "n/a"
+        def vertxVersion = "n/a"
+
+        // Resolve Hibernate Core and Vert.x versions from compile classpath
+        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            if (artifact.moduleVersion.id.name == 'hibernate-core') {
+                hibernateCoreVersion = artifact.moduleVersion.id.version
+            }
+            if (artifact.moduleVersion.id.group == 'io.vertx' && artifact.moduleVersion.id.name == 'vertx-sql-client') {
+                vertxVersion = artifact.moduleVersion.id.version
+            }
+        }
+
+        // Print the resolved versions
+        println "Resolved Hibernate ORM Core Version: ${hibernateCoreVersion}"
+        println "Resolved Vert.x SQL client Version: ${vertxVersion}"
+    }
+}
+
+// Make the version printing task run before tests and JavaExec tasks
+tasks.withType( Test ).configureEach {
+    dependsOn printResolvedVersions
+}
+
+tasks.withType( JavaExec ).configureEach {
+    dependsOn printResolvedVersions
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -28,8 +28,8 @@ org.gradle.java.installations.auto-download=false
 # Db2, MySql, PostgreSQL, CockroachDB, SqlServer, Oracle
 #db = MSSQL
 
-# Enable the SonatypeOS maven repository (mainly for Vert.x snapshots) when present (value ignored)
-#enableSonatypeOpenSourceSnapshotsRep = true
+# Enable the maven Central Snapshot repository, when set to any value (the value is ignored)
+#enableCentralSonatypeSnapshotsRep = true
 
 # Enable the maven local repository (for local development when needed) when present (value ignored)
 #enableMavenLocalRepo = true

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -167,3 +167,35 @@ tasks.register( "testAll", Test ) {
     description = "Run tests for ${dbs}"
     dependsOn = dbs.collect( [] as HashSet ) { db -> "testDb${db}" }
 }
+
+// Task to print the resolved versions of Hibernate ORM and Vert.x
+tasks.register( "printResolvedVersions" ) {
+    description = "Print the resolved hibernate-orm-core and vert.x versions"
+    doLast {
+        def hibernateCoreVersion = "n/a"
+        def vertxVersion = "n/a"
+        
+        // Resolve Hibernate Core and Vert.x versions from compile classpath
+        configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.each { artifact ->
+            if (artifact.moduleVersion.id.name == 'hibernate-core') {
+                hibernateCoreVersion = artifact.moduleVersion.id.version
+            }
+            if (artifact.moduleVersion.id.group == 'io.vertx' && artifact.moduleVersion.id.name == 'vertx-sql-client') {
+                vertxVersion = artifact.moduleVersion.id.version
+            }
+        }
+
+        // Print the resolved versions
+        println "Resolved Hibernate ORM Core Version: ${hibernateCoreVersion}"
+        println "Resolved Vert.x SQL client Version: ${vertxVersion}"
+    }
+}
+
+// Make the version printing task run before tests and JavaExec tasks
+tasks.withType( Test ).configureEach {
+    dependsOn printResolvedVersions
+}
+
+tasks.withType( JavaExec ).configureEach {
+    dependsOn printResolvedVersions
+}


### PR DESCRIPTION
Fix #2333 

It also adds a commit to print the resolved Hibernate ORM and Vert.x versions. Useful when building with snapshots and the version is specified using ranges.