### PR TITLE
[3.0] Update dependabot configuration ci 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,3 +16,46 @@ updates:
     allow:
       - dependency-name: "actions/*"
       - dependency-name: "redhat-actions/*"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 20
+    groups:
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      vertx:
+        patterns:
+          - "io.vertx*"
+      mutiny:
+        patterns:
+          - "io.smallrye.reactive*"
+      # Testcontainers plus the JDBC driver we need for testing
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+          - "com.ibm.db2*"
+          - "com.microsoft.sqlserver*"
+          - "org.postgresql*"
+          - "con.ongres.scram*"
+          - "com.fasterxml.jackson.core*"
+          - "com.mysql*"
+          - "org.mariadb.jdbc*"
+
+    ignore:
+      # Only patches for Hibernate ORM and Vert.x
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.vertx*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Dockerfiles in tooling/docker/, and database services we use for examples (MySQL and PostgreSQL)
+  - package-ecosystem: "docker"
+    directory: "/tooling/docker"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Backport #1136 (PR https://github.com/hibernate/hibernate-reactive/pull/2344) to 3.0