### PR TITLE
[2.4] Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,61 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      workflow-actions:
+        patterns:
+          - "*"
+    allow:
+      - dependency-name: "actions/*"
+      - dependency-name: "redhat-actions/*"
+
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 20
+    groups:
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      vertx:
+        patterns:
+          - "io.vertx*"
+      mutiny:
+        patterns:
+          - "io.smallrye.reactive*"
+      # Testcontainers plus the JDBC driver we need for testing
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+          - "com.ibm.db2*"
+          - "com.microsoft.sqlserver*"
+          - "org.postgresql*"
+          - "con.ongres.scram*"
+          - "com.fasterxml.jackson.core*"
+          - "com.mysql*"
+          - "org.mariadb.jdbc*"
+
+    ignore:
+      # Only patches for Hibernate ORM and Vert.x
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.vertx*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  # Dockerfiles in tooling/docker/, and database services we use for examples (MySQL and PostgreSQL)
+  - package-ecosystem: "docker"
+    directory: "/tooling/docker"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"


### PR DESCRIPTION
Backport #1136 (PR https://github.com/hibernate/hibernate-reactive/pull/2344) to 2.4