### PR TITLE
Bump junitVersion from 5.11.3 to 5.13.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,7 +5,8 @@ hibernateOrmGradlePluginVersion = "7.0.2.Final"
 jacksonDatabindVersion = "2.19.1"
 jbossLoggingAnnotationVersion = "3.0.4.Final"
 jbossLoggingVersion = "3.6.1.Final"
-junitVersion = "5.11.3"
+junitVersion = "5.13.3"
+junitPlatformVersion = "1.13.3"
 log4jVersion = "2.25.1"
 testcontainersVersion = "1.21.3"
 vertxSqlClientVersion = "5.0.0"
@@ -42,6 +43,7 @@ org-jboss-logging-jboss-logging-annotations = { group = "org.jboss.logging", nam
 org-jboss-logging-jboss-logging-processor = { group = "org.jboss.logging", name = "jboss-logging-processor", version.ref = "jbossLoggingAnnotationVersion" }
 org-junit-jupiter-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitVersion" }
 org-junit-jupiter-junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
+org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "junitPlatformVersion" }
 org-mariadb-jdbc-mariadb-java-client = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version = "3.5.4" }
 org-postgresql-postgresql = { group = "org.postgresql", name = "postgresql", version = "42.7.7" }
 org-testcontainers-cockroachdb = { group = "org.testcontainers", name = "cockroachdb", version.ref = "testcontainersVersion" }

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     // JUnit Jupiter
     testImplementation(libs.org.junit.jupiter.junit.jupiter.api)
     testRuntimeOnly(libs.org.junit.jupiter.junit.jupiter.engine)
+    testRuntimeOnly(libs.org.junit.platform.junit.platform.launcher)
 
     // JDBC driver to test with ORM and PostgreSQL
     testRuntimeOnly(libs.org.postgresql.postgresql)


### PR DESCRIPTION
Supersedes https://github.com/hibernate/hibernate-reactive/pull/2357

Requires extra dependency org.junit.platform:junit-platform-launcher:1.13.3

---
updated-dependencies:
- dependency-name: org.junit.jupiter:junit-jupiter-api dependency-version: 5.13.3 dependency-type: direct:production update-type: version-update:semver-minor
- dependency-name: org.junit.jupiter:junit-jupiter-engine dependency-version: 5.13.3 dependency-type: direct:production update-type: version-update:semver-minor ...