### PR TITLE
Remove gradle-nexus:publish-plugin from the catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,6 @@ plugins {
     id 'maven-publish'
     alias(libs.plugins.com.diffplug.spotless)
     alias(libs.plugins.org.asciidoctor.jvm.convert) apply false
-    alias(libs.plugins.io.github.gradle.nexus.publish.plugin)
 }
 
 group = "org.hibernate.reactive"

--- a/ci/snapshot-publish.Jenkinsfile
+++ b/ci/snapshot-publish.Jenkinsfile
@@ -40,7 +40,6 @@ pipeline {
 			steps {
 				script {
 					withCredentials([
-							// https://github.com/gradle-nexus/publish-plugin#publishing-to-maven-central-via-sonatype-ossrh
 							// TODO: Once we switch to maven-central publishing (from nexus2) we need to update credentialsId:
 							//  https://docs.gradle.org/current/samples/sample_publishing_credentials.html#:~:text=via%20environment%20variables
 							usernamePassword(credentialsId: 'central.sonatype.com', passwordVariable: 'ORG_GRADLE_PROJECT_snapshotsPassword', usernameVariable: 'ORG_GRADLE_PROJECT_snapshotsUsername'),

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,5 @@ org-testcontainers-postgresql = { group = "org.testcontainers", name = "postgres
 
 [plugins]
 com-diffplug-spotless = { id = "com.diffplug.spotless", version = "7.1.0" }
-io-github-gradle-nexus-publish-plugin = { id = "io.github.gradle-nexus.publish-plugin", version = "1.3.0" }
 org-asciidoctor-jvm-convert = { id = "org.asciidoctor.jvm.convert", version = "4.0.4" }
 org-hibernate-orm = { id = "org.hibernate.orm", version.ref = "hibernateOrmGradlePluginVersion" }


### PR DESCRIPTION
Fix #2368 

We don't use it anymore since the switch to JRelease. This was just a left over.