### PR TITLE
[2.4] Upgrade MySQL docker image to container-registry.oracle.com/mysql/community-server:9.3.0 dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,8 +49,7 @@ jobs:
     services:
       # Label used to access the service container
       mysql:
-        # Docker Hub image
-        image: mysql:9.2.0
+        image: container-registry.oracle.com/mysql/community-server:9.3.0
         env:
           MYSQL_ROOT_PASSWORD: hreact
           MYSQL_DATABASE: hreact

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/containers/MySQLDatabase.java
@@ -87,7 +87,7 @@ class MySQLDatabase implements TestableDatabase {
 	 * TIP: To reuse the same containers across multiple runs, set `testcontainers.reuse.enable=true` in a file located
 	 * at `$HOME/.testcontainers.properties` (create the file if it does not exist).
 	 */
-	public static final MySQLContainer<?> mysql = new MySQLContainer<>( fromDockerfile( "mysql" ) )
+	public static final MySQLContainer<?> mysql = new MySQLContainer<>( fromDockerfile( "mysql" ).asCompatibleSubstituteFor( "mysql" ) )
 			.withUsername( DatabaseConfiguration.USERNAME )
 			.withPassword( DatabaseConfiguration.PASSWORD )
 			.withDatabaseName( DatabaseConfiguration.DB_NAME )

--- a/tooling/docker/mysql.Dockerfile
+++ b/tooling/docker/mysql.Dockerfile
@@ -1,3 +1,3 @@
 # MySQL
 # See https://hub.docker.com/_/mysql
-FROM docker.io/mysql:9.2.0
+FROM container-registry.oracle.com/mysql/community-server:9.3.0

--- a/tooling/jbang/MySQLReactiveTest.java.qute
+++ b/tooling/jbang/MySQLReactiveTest.java.qute
@@ -72,7 +72,7 @@ public class {baseName} {
 	}
 
     @ClassRule
-    public final static MySQLContainer<?> database = new MySQLContainer<>( imageName( "docker.io", "mysql", "9.2.0" ) );
+    public final static MySQLContainer<?> database = new MySQLContainer<>( imageName( "container-registry.oracle.com", "mysql/community-server", "9.3.0" ).asCompatibleSubstituteFor( "mysql" ) );
 
 	private Mutiny.SessionFactory sessionFactory;
 

--- a/tooling/jbang/ReactiveTest.java
+++ b/tooling/jbang/ReactiveTest.java
@@ -229,7 +229,7 @@ public class ReactiveTest {
 	 */
 	enum Database {
 		POSTGRESQL( () -> new PostgreSQLContainer( "postgres:17.5" ) ),
-		MYSQL( () -> new MySQLContainer( "mysql:9.2.0" ) ),
+		MYSQL( () -> new MySQLContainer( "container-registry.oracle.com/mysql/community-server:9.3.0" ) ),
 		DB2( () -> new Db2Container( "docker.io/icr.io/db2_community/db2:12.1.0.0" ).acceptLicense() ),
 		MARIADB( () -> new MariaDBContainer( "mariadb:11.7.2" ) ),
 		COCKROACHDB( () -> new CockroachContainer( "cockroachdb/cockroach:v24.3.13" ) );


### PR DESCRIPTION
Backport https://github.com/hibernate/hibernate-reactive/issues/2270 (PR https://github.com/hibernate/hibernate-reactive/pull/2365) to 2.4