### PR TITLE
Check compatibility with Hibernate ORM 7.1

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/mutation/internal/temptable/ReactiveUpdateExecutionDelegate.java
@@ -96,6 +96,7 @@ public class ReactiveUpdateExecutionDelegate extends UpdateExecutionDelegate imp
 	public CompletionStage<Integer> reactiveExecute(ExecutionContext executionContext) {
 		return performBeforeTemporaryTableUseActions(
 						getIdTable(),
+						getTemporaryTableStrategy(),
 						executionContext
 				)
 				.thenCompose( v -> saveMatchingIdsIntoIdTable(


### PR DESCRIPTION
use the non deprecated `ReactiveExecuteWithTemporaryTableHelper#performBeforeTemporaryTableUseActions`  method