### PR TITLE
[3.1] Keep only major.minor version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,13 +38,17 @@ Hibernate Reactive has been tested with:
 - CockroachDB v25
 - MS SQL Server 2025
 - Oracle 23
-- [Hibernate ORM][] 7.1.0.Final
-- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5.16
-- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5.16
-- [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5.16
-- [Vert.x Reactive MS SQL Server Client](https://vertx.io/docs/vertx-mssql-client/java/) 4.5.16
-- [Vert.x Reactive Oracle Client](https://vertx.io/docs/vertx-oracle-client/java/) 4.5.16
+- [Hibernate ORM][] 7.1
+- [Vert.x Reactive PostgreSQL Client](https://vertx.io/docs/vertx-pg-client/java/) 4.5
+- [Vert.x Reactive MySQL Client](https://vertx.io/docs/vertx-mysql-client/java/) 4.5
+- [Vert.x Reactive Db2 Client](https://vertx.io/docs/vertx-db2-client/java/) 4.5
+- [Vert.x Reactive MS SQL Server Client](https://vertx.io/docs/vertx-mssql-client/java/) 4.5
+- [Vert.x Reactive Oracle Client](https://vertx.io/docs/vertx-oracle-client/java/) 4.5
 - [Quarkus][Quarkus] via the Hibernate Reactive extension
+
+The exact version of the libraries and images are in the
+[catalog](https://github.com/hibernate/hibernate-reactive/blob/3.1/gradle/libs.versions.toml)
+and in the [tooling/docker](https://github.com/hibernate/hibernate-reactive/tree/3.1/tooling/docker) folder.
 
 [PostgreSQL]: https://www.postgresql.org
 [MySQL]: https://www.mysql.com


### PR DESCRIPTION
For Hibernate ORM and Vert.x.
The current automated release system and dependabot don't update the readme. It would get out of date at every minor release.

I've included a link to the exact version in the catalog, though.