### PR TITLE
Enable dependabot on 3.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,7 @@ updates:
 
   - package-ecosystem: "gradle"
     directory: "/"
+    target-branch: "main"
     schedule:
       interval: "weekly"
       day: "tuesday"
@@ -48,7 +49,6 @@ updates:
           - "com.fasterxml.jackson.core*"
           - "com.mysql*"
           - "org.mariadb.jdbc*"
-
     ignore:
       # For Hibernate Validator, we will need to update major version manually as needed (but we only use it in tests)
       - dependency-name: "org.glassfish.expressly*"
@@ -62,6 +62,56 @@ updates:
   # Dockerfiles in tooling/docker/, and database services we use for examples (MySQL and PostgreSQL)
   - package-ecosystem: "docker"
     directory: "/tooling/docker"
+    target-branch: "main"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+
+# Duplicate the previous package-ecosystems because we want to target branch 3.1
+# and dependabot doesn't support YAML aliases and anchors at the moment
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "3.1"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 20
+    groups:
+      hibernate-validator:
+        patterns:
+          - "org.hibernate.validator*"
+          - "org.glassfish.expressly*"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      vertx:
+        patterns:
+          - "io.vertx*"
+      mutiny:
+        patterns:
+          - "io.smallrye.reactive*"
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+          - "com.ibm.db2*"
+          - "com.microsoft.sqlserver*"
+          - "org.postgresql*"
+          - "con.ongres.scram*"
+          - "com.fasterxml.jackson.core*"
+          - "com.mysql*"
+          - "org.mariadb.jdbc*"
+    ignore:
+      - dependency-name: "org.glassfish.expressly*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.vertx*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+
+  - package-ecosystem: "docker"
+    directory: "/tooling/docker"
+    target-branch: "3.1"
     schedule:
       interval: "weekly"
     allow:


### PR DESCRIPTION
At the moment, dependabot doesn't support YAML aliased and anchors. So, we need to duplicate the configuration if we want to target multiple branches.