### PR TITLE
[4.1] Test '?' operator for PostgreSQL

### DIFF
--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -41,6 +41,9 @@ dependencies {
     testImplementation(libs.io.vertx.vertx.mssql.client)
     testImplementation(libs.io.vertx.vertx.oracle.client)
 
+	// Some tests using JSON need a formatter
+	testRuntimeOnly(libs.com.fasterxml.jackson.core.jackson.databind)
+
     // Metrics
     testImplementation(libs.io.vertx.vertx.micrometer.metrics)
 


### PR DESCRIPTION
Closes #2012 

The issue was fixed when we removed parameters processing (via #2465). We just need to add the test case.

Now it's possible to escape the `?` in native queries with `\\?` (instead of `\\\\\\?`).