### PR TITLE
Enable scheduled releases for 4.1

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -15,7 +15,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 // Global build configuration
 env.PROJECT = "reactive"
 env.JIRA_KEY = "HREACT"
-def RELEASE_ON_SCHEDULE = false // Set to `true` *only* on branches where you want a scheduled release.
+def RELEASE_ON_SCHEDULE = true // Set to `true` *only* on branches where you want a scheduled release.
 
 print "INFO: env.PROJECT = ${env.PROJECT}"
 print "INFO: env.JIRA_KEY = ${env.JIRA_KEY}"


### PR DESCRIPTION
Main is on `4.1`  and we have already released `4.1.0.Final`.
~~We will create a new branch when we upgrade to ORM 4.2~~
I changed my mind, I will create a new branch now, so that we can merge PR in `main` when needed