### PR TITLE
[#2506] Use Jenkins lock to prevent multiple releases pushing to the hibernate.org at the same time

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -239,12 +239,15 @@ pipeline {
 						]) {
 							sshagent( ['ed25519.Hibernate-CI.github.com', 'hibernate.filemgmt.jboss.org', 'hibernate-ci.frs.sourceforge.net'] ) {
 								dir( '.release/hibernate.org' ) {
-									checkout scmGit(
-											branches: [[name: '*/production']],
-											extensions: [],
-											userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
-									)
-									sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+									// Lock to avoid rejected pushes when multiple releases try to clone-commit-push
+									lock('hibernate.org-git') {
+										checkout scmGit(
+												branches: [[name: '*/production']],
+												extensions: [],
+												userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
+										)
+										sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+									}
 								}
 							}
 						}


### PR DESCRIPTION
* Fixes https://github.com/hibernate/hibernate-reactive/issues/2506