### PR TITLE
[4.2] Fix operations order in BatchingConnection

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
@@ -106,9 +106,8 @@ public class BatchingConnection implements ReactiveConnection {
 					return voidFuture();
 				}
 				else {
-					CompletionStage<Void> lastBatch = executeBatch();
-					newBatch( sql, paramValues, expectation );
-					return lastBatch;
+					return executeBatch()
+							.thenAccept( v -> newBatch( sql, paramValues, expectation ) );
 				}
 			}
 		}


### PR DESCRIPTION
Fix #2535

I think that this is the reason of some NullPoitnerException errors experienced by users, but I couldn't create a reproducer so far