### PR TITLE
[3.1] Use GA version of JDK 25 in the build 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,7 +190,7 @@ jobs:
           # and it's useful to test that.
           - { name: "20", java_version_numeric: 20, jvm_args: '--enable-preview' }
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
-          - { name: "24", java_version_numeric: 24, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "24", java_version_numeric: 24, jvm_args: '--enable-preview' }
           - { name: "25", java_version_numeric: 25, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "26-ea", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,7 +191,7 @@ jobs:
           - { name: "20", java_version_numeric: 20, jvm_args: '--enable-preview' }
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
           - { name: "24", java_version_numeric: 24, from: 'jdk.java.net', jvm_args: '--enable-preview' }
-          - { name: "25-ea", java_version_numeric: 25, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "25", java_version_numeric: 25, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "26-ea", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:
       - name: Checkout ${{ inputs.branch }}


### PR DESCRIPTION
Backport #2516 (PR https://github.com/hibernate/hibernate-reactive/pull/2540) to `3.1`