### PR TITLE
[4.2] Update the theme versions and fix the project key

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -12,7 +12,7 @@ configurations {
 }
 
 dependencies {
-	themezip 'org.hibernate.infra:hibernate-asciidoctor-theme:6.0.0.Final@zip'
+	themezip 'org.hibernate.infra:hibernate-asciidoctor-theme:6.0.2.Final@zip'
 }
 
 ext {
@@ -168,8 +168,8 @@ def renderReferenceDocumentationTask = tasks.register( 'renderReferenceDocumenta
 			docinfo: 'shared,private',
 			docinfodir: rootProject.layout.buildDirectory.dir("unpacked-theme").get()
 					.dir("hibernate-asciidoctor-theme").dir("asciidoc").dir("docinfo").dir('hibernate').asFile.absolutePath,
-			'html.meta.project-key': 'orm',
-			'html.outdated-content.project-key': 'orm',
+			'html-meta-project-key': 'reactive',
+			'html-outdated-content-project-key': 'reactive',
 			'html-meta-description': 'Hibernate Reactive, reactive API for Hibernate ORM - Reference Documentation',
 			'html-meta-keywords': 'hibernate, reactive, hibernate reactive, database, db, vert.x',
 			'html-meta-version-family': project.projectVersion.family

--- a/documentation/src/main/asciidoc/reference/index.adoc
+++ b/documentation/src/main/asciidoc/reference/index.adoc
@@ -6,6 +6,7 @@ Davide D'Alto <davide@hibernate.org>; Gavin King <gavin@hibernate.org>
 :sourcedir: src/main/asciidoc/reference
 :leveloffset: +1
 :version-selector-enabled: true
+:html-meta-canonical-link: https://docs.hibernate.org/stable/reactive/reference/html_single
 
 include::{sourcedir}/preface.adoc[]
 


### PR DESCRIPTION
This is a small follow-up to the theme update ... I've messed up the project key in the original patch 😔 so here's the fix for it 🫣 and a theme version update to it (and the key on https://docs.hibernate.org/reactive/4.1/reference/html_single/ should be updated so the versions selector should work)