### PR TITLE
[4.2] Disable Gradle cache

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,12 +5,13 @@ toolchain.compiler.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOf
 toolchain.javadoc.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 toolchain.launcher.jvmargs=-Xmx4g -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -Duser.language=en -Duser.country=US -Duser.timezone=UTC -Dfile.encoding=UTF-8
 
+# Note: I disabled the cache because it was affecting the result of the build locally
 # asciidoctor gradle plugin don't support configuration cache
-org.gradle.configuration-cache=true
+org.gradle.configuration-cache=false
 org.gradle.configureondemand=true
-# configuration of testcontainers need to be updated to prevent bind the same port
+# Disabled because testcontainers might try to connect to the same port
 org.gradle.parallel=false
-org.gradle.caching=true
+org.gradle.caching=false
 org.gradle.daemon=true
 
 # JDK auto-detection is not quite ready yet in Gradle 6.7.


### PR DESCRIPTION
Fix #2622

After the work done for #2492, the tasks should be cacheable, but I have some failures when I build locally that disapper when I disable the cache. I don't have time to investigate this any further right now.

For now, the build is quick enough when using PostgreSQL + Testcontainers.