### PR TITLE
[4.1] Adjust asciidoc task to render the reference guide

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -147,6 +147,7 @@ def renderReferenceDocumentationTask = tasks.register( "renderReferenceDocumenta
 		docExtensions( project( ":local-build-asciidoctor-extensions" ) )
 	}
 
+	sourceDir( asciidocReference )
 	sources {
 		include( "index.adoc" )
 	}
@@ -167,18 +168,18 @@ def renderReferenceDocumentationTask = tasks.register( "renderReferenceDocumenta
 	attributes(
 			icons: "font",
 			"source-highlighter": "rouge",
-			majorMinorVersion: versionFamily,
-			fullVersion: fullVersion,
+			majorMinorVersion: versionFamily.get(),
+			fullVersion: fullVersion.get(),
 			stylesdir: "css",
 			"iconfont-remote": false,
 			"iconfont-name": "font-awesome/css/solid",
 			docinfo: "shared,private",
-			docinfodir: docInfoHibernate,
+			docinfodir: docInfoHibernate.get(),
 			"html.meta.project-key": "reactive",
 			"html.outdated-content.project-key": "reactive",
 			"html-meta-description": "Hibernate Reactive, reactive API for Hibernate ORM - Reference Documentation",
 			"html-meta-keywords": "hibernate, reactive, hibernate reactive, database, db, vert.x",
-			"html-meta-version-family": versionFamily,
+			"html-meta-version-family": versionFamily.get(),
 	)
 
 	dependsOn( tasks.named( "unpackTheme" ) )


### PR DESCRIPTION
```
> Task :documentation:renderReferenceDocumentation NO-SOURCE
file or directory '/home/marko/development/projects/opensource/hibernate-reactive/documentation/src/docs/asciidocRenderReferenceDocumentation', not found
file or directory '/home/marko/development/projects/opensource/hibernate-reactive/documentation/src/docs/asciidocRenderReferenceDocumentation', not found
Skipping task ':documentation:renderReferenceDocumentation' as it has no source files and no previous output files.
```
and then
```
Execution failed for task ':documentation:renderReferenceDocumentation'.
> Cannot fingerprint input property 'attributes': value '{docinfo=provider(?), do
```
for the 1st it seems the task is expecting a strange source location .. so lets be explicit ?
as for the second one, it seems that that map does not like any providers so we'd need to resolve the values when passing them to the map ...