### PR TITLE
Update dependabot rules

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -121,6 +121,59 @@ updates:
     allow:
       - dependency-type: "all"
 
+  #################################################################################
+  # Duplicate the package-ecosystems for main because we want to target branch 3.2
+  # and dependabot doesn't support YAML aliases and anchors at the moment
+  #################################################################################
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "3.2"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 20
+    groups:
+      hibernate-validator:
+        patterns:
+          - "org.hibernate.validator*"
+          - "org.glassfish.expressly*"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      vertx:
+        patterns:
+          - "io.vertx*"
+      mutiny:
+        patterns:
+          - "io.smallrye.reactive*"
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+          - "com.ibm.db2*"
+          - "com.microsoft.sqlserver*"
+          - "org.postgresql*"
+          - "con.ongres.scram*"
+          - "com.fasterxml.jackson.core*"
+          - "com.mysql*"
+          - "org.mariadb.jdbc*"
+    ignore:
+      - dependency-name: "org.glassfish.expressly*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.vertx*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.smallrye.reactive*"
+        update-types: [ "version-update:semver-major" ]
+
+  - package-ecosystem: "docker"
+    directory: "/tooling/docker"
+    target-branch: "3.2"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+
 #################################################################################
 # Duplicate the package-ecosystems for main because we want to target branch 3.1
 # and dependabot doesn't support YAML aliases and anchors at the moment


### PR DESCRIPTION
- Limit the upgrade to Mutiny based on the branch
- Add branch 3.2 to the rules