### PR TITLE
[3.2] Ugrade Hibernate ORM to 7.2.0.CR2

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 assertjVersion = "3.27.6"
-hibernateOrmVersion = "7.2.0.CR1"
-hibernateOrmGradlePluginVersion = "7.2.0.CR1"
+hibernateOrmVersion = "7.2.0.CR2"
+hibernateOrmGradlePluginVersion = "7.2.0.CR2"
 jacksonDatabindVersion = "2.20.1"
 jbossLoggingAnnotationVersion = "3.0.4.Final"
 jbossLoggingVersion = "3.6.1.Final"

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcEnvironmentInitiator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/provider/service/NoJdbcEnvironmentInitiator.java
@@ -10,6 +10,7 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.engine.jdbc.connections.spi.DatabaseConnectionInfo;
 import org.hibernate.engine.jdbc.dialect.spi.DialectFactory;
 import org.hibernate.engine.jdbc.dialect.spi.DialectResolutionInfo;
+import org.hibernate.engine.jdbc.env.JdbcMetadataOnBoot;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentImpl;
 import org.hibernate.engine.jdbc.env.internal.JdbcEnvironmentInitiator;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
@@ -77,6 +78,7 @@ public class NoJdbcEnvironmentInitiator extends JdbcEnvironmentInitiator
 
 	@Override
 	protected JdbcEnvironmentImpl getJdbcEnvironmentUsingJdbcMetadata(
+			JdbcMetadataOnBoot jdbcMetadataAccess,
 			Map<String, Object> configurationValues,
 			ServiceRegistryImplementor registry,
 			DialectFactory dialectFactory,

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/TestingRegistryExtension.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/testing/TestingRegistryExtension.java
@@ -136,6 +136,11 @@ public class TestingRegistryExtension implements BeforeEachCallback, AfterEachCa
 		}
 
 		@Override
+		public boolean isActive() {
+			return true;
+		}
+
+		@Override
 		public void registerChild(ServiceRegistryImplementor child) {
 		}
 


### PR DESCRIPTION
Backport #2763 (PR #2764) to `3.2`

Update the catalog and fix compilation errors.