### PR TITLE
[4.2] FetchModeSubselectEagerTest#testEagerFetchQuery throws NullPointerException

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
@@ -17,7 +17,6 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.Timeout;
@@ -120,7 +119,6 @@ public class FetchModeSubselectEagerTest extends BaseReactiveTest {
 	}
 
 	@Test
-	@Disabled("NullPointerException: see https://hibernate.atlassian.net/browse/HHH-19874")
 	public void testEagerFetchQuery(VertxTestContext context) {
 		Node basik = new Node( "Child" );
 		basik.parent = new Node( "Parent" );


### PR DESCRIPTION
Fix #2650 
Supersedes https://github.com/hibernate/hibernate-reactive/pull/2691

The issue is solved by the Hibernate ORM upgrade to 7.2.0.CR2. See issue HHH-19874: https://hibernate.atlassian.net/browse/HHH-19874
