### PR TITLE
[3.1] Reduce the number of jdk we test with

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,9 +188,7 @@ jobs:
           # We want to enable preview features when testing newer builds of OpenJDK:
           # even if we don't use these features, just enabling them can cause side effects
           # and it's useful to test that.
-          - { name: "20", java_version_numeric: 20, jvm_args: '--enable-preview' }
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
-          - { name: "24", java_version_numeric: 24, jvm_args: '--enable-preview' }
           - { name: "25", java_version_numeric: 25, from: 'jdk.java.net', jvm_args: '--enable-preview' }
           - { name: "26-ea", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:


### PR DESCRIPTION
We only need the latest LTSs