### PR TITLE
[4.1] Add Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+#2855 Update license header via Spotless
+5a7cf9b0e8786c26d9aefcfb9fc337f55a2c6b62
+


### PR DESCRIPTION
Backport #2865 to `4.1`