### PR TITLE
[3.2] Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+#2855 Update license header via Spotless
+443381588b281e8802e7507c114fcdc3d2a3ba67
+


### PR DESCRIPTION
Backport #2865 to `3.2`