### PR TITLE
[2.4] Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+#2855 Update license header via Spotless
+4bbb7667d1f5d6cfd60b2e76cedea9bb924b8cd7
+


### PR DESCRIPTION
Backport #2865 to `2.4`