### PR TITLE
[3.1] Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+#2855 Update license header via Spotless
+f402a467e3b6579a4dabd43f7e6ad03bd5d1de00
+


### PR DESCRIPTION
Backport #2865 to `3.1`