### PR TITLE
[3.2] Upgrade Vert.x to 4.5.23

### DIFF
--- a/examples/native-sql-example/build.gradle
+++ b/examples/native-sql-example/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly(libs.org.apache.logging.log4j.log4j.core)
 
     // Allow authentication to PostgreSQL using SCRAM:
-    runtimeOnly(libs.com.ongres.scram.client)
+    runtimeOnly(libs.com.ongres.scram.scram.client)
 }
 
 // Optional: enable the bytecode enhancements

--- a/examples/session-example/build.gradle
+++ b/examples/session-example/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     runtimeOnly(libs.org.apache.logging.log4j.log4j.core)
 
     // Allow authentication to PostgreSQL using SCRAM:
-    runtimeOnly(libs.com.ongres.scram.client)
+    runtimeOnly(libs.com.ongres.scram.scram.client)
 }
 
 // Optional: enable the bytecode enhancements

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,16 +9,16 @@ junitVersion = "6.0.1"
 junitPlatformVersion = "1.13.4"
 log4jVersion = "2.25.3"
 testcontainersVersion = "1.21.4"
-vertxSqlClientVersion = "4.5.22"
-vertxWebVersion= "4.5.22"
-vertxWebClientVersion = "4.5.22"
+vertxSqlClientVersion = "4.5.23"
+vertxWebVersion= "4.5.23"
+vertxWebClientVersion = "4.5.23"
 
 [libraries]
 com-fasterxml-jackson-core-jackson-databind = { group = "com.fasterxml.jackson.core", name = "jackson-databind", version.ref = "jacksonDatabindVersion" }
 com-ibm-db2-jcc = { group = "com.ibm.db2", name = "jcc", version = "12.1.3.0" }
 com-microsoft-sqlserver-mssql-jdbc = { group = "com.microsoft.sqlserver", name = "mssql-jdbc", version = "13.3.0.jre11-preview" }
 com-mysql-mysql-connector-j = { group = "com.mysql", name = "mysql-connector-j", version = "9.5.0" }
-com-ongres-scram-client = { group = "com.ongres.scram", name = "client", version = "2.1" }
+com-ongres-scram-scram-client = { group = "com.ongres.scram", name = "scram-client", version = "3.2" }
 io-smallrye-reactive-mutiny = { group = "io.smallrye.reactive", name = "mutiny", version = "2.9.5" }
 io-vertx-vertx-db2-client = { group = "io.vertx", name = "vertx-db2-client", version.ref = "vertxSqlClientVersion" }
 io-vertx-vertx-junit5 = { group = "io.vertx", name = "vertx-junit5", version.ref = "vertxSqlClientVersion" }

--- a/hibernate-reactive-core/build.gradle
+++ b/hibernate-reactive-core/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     testImplementation(libs.io.vertx.vertx.micrometer.metrics)
 
     // Optional dependency of vertx-pg-client, essential when connecting via SASL SCRAM
-    testImplementation(libs.com.ongres.scram.client)
+    testImplementation(libs.com.ongres.scram.scram.client)
 
     // JUnit Jupiter
     testImplementation(libs.org.junit.jupiter.junit.jupiter.api)

--- a/integration-tests/bytecode-enhancements-it/build.gradle
+++ b/integration-tests/bytecode-enhancements-it/build.gradle
@@ -25,7 +25,7 @@ dependencies {
     runtimeOnly(libs.io.vertx.vertx.pg.client)
 
     // Allow authentication to PostgreSQL using SCRAM:
-    runtimeOnly(libs.com.ongres.scram.client)
+    runtimeOnly(libs.com.ongres.scram.scram.client)
 
     // logging
     runtimeOnly(libs.org.apache.logging.log4j.log4j.core)

--- a/integration-tests/hibernate-validator-postgres-it/build.gradle
+++ b/integration-tests/hibernate-validator-postgres-it/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     runtimeOnly(libs.io.vertx.vertx.pg.client)
 
     // Allow authentication to PostgreSQL using SCRAM:
-    runtimeOnly(libs.com.ongres.scram.client)
+    runtimeOnly(libs.com.ongres.scram.scram.client)
 
     // logging
     runtimeOnly(libs.org.apache.logging.log4j.log4j.core)

--- a/integration-tests/techempower-postgres-it/build.gradle
+++ b/integration-tests/techempower-postgres-it/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
 	runtimeOnly(libs.io.vertx.vertx.pg.client)
 	// The Pg client requires this dependency
-	runtimeOnly(libs.com.ongres.scram.client)
+	runtimeOnly(libs.com.ongres.scram.scram.client)
 	runtimeOnly(libs.com.fasterxml.jackson.core.jackson.databind)
 
 	// logging

--- a/integration-tests/verticle-postgres-it/build.gradle
+++ b/integration-tests/verticle-postgres-it/build.gradle
@@ -18,7 +18,7 @@ dependencies {
 
     runtimeOnly(libs.io.vertx.vertx.pg.client)
     // The Pg client requires this dependency
-    runtimeOnly(libs.com.ongres.scram.client)
+    runtimeOnly(libs.com.ongres.scram.scram.client)
     runtimeOnly(libs.com.fasterxml.jackson.core.jackson.databind)
 
     // logging


### PR DESCRIPTION
Supersedes #2920 

Requires the upgrade from `com.ongres.scram:client:2.1` to `com.ongres.scram:scram-client:3.2`

Bumps the vertx group with 10 updates:

| Package | From | To |
| --- | --- | --- |
| [io.vertx:vertx-db2-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-junit5](https://github.com/eclipse-vertx/vertx-junit5) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-micrometer-metrics](https://github.com/vert-x3/vertx-micrometer-metrics) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-mssql-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-mysql-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-oracle-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-pg-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-sql-client](https://github.com/eclipse-vertx/vertx-sql-client) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-web](https://github.com/vert-x3/vertx-web) | `4.5.22` | `4.5.23` | | [io.vertx:vertx-web-client](https://github.com/vert-x3/vertx-web) | `4.5.22` | `4.5.23` |

Updates `io.vertx:vertx-db2-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-junit5` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-junit5/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-micrometer-metrics` from 4.5.22 to 4.5.23
- [Commits](https://github.com/vert-x3/vertx-micrometer-metrics/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-mssql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-mysql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-oracle-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-pg-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-sql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-junit5` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-junit5/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-micrometer-metrics` from 4.5.22 to 4.5.23
- [Commits](https://github.com/vert-x3/vertx-micrometer-metrics/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-mssql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-mysql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-oracle-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-pg-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-sql-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/eclipse-vertx/vertx-sql-client/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-web` from 4.5.22 to 4.5.23
- [Commits](https://github.com/vert-x3/vertx-web/compare/4.5.22...4.5.23)

Updates `io.vertx:vertx-web-client` from 4.5.22 to 4.5.23
- [Commits](https://github.com/vert-x3/vertx-web/compare/4.5.22...4.5.23)

---
updated-dependencies:
- dependency-name: io.vertx:vertx-db2-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-junit5 dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-micrometer-metrics dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-mssql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-mysql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-oracle-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-pg-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-sql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-junit5 dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-micrometer-metrics dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-mssql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-mysql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-oracle-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-pg-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-sql-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-web dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx
- dependency-name: io.vertx:vertx-web-client dependency-version: 4.5.23 dependency-type: direct:production update-type: version-update:semver-patch dependency-group: vertx ...