### PR TITLE
[4.1] Disable CancelSignalTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CancelSignalTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CancelSignalTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.IntStream;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import org.jboss.logging.Logger;
@@ -32,6 +33,12 @@ import static java.util.concurrent.CompletableFuture.runAsync;
 import static java.util.stream.Stream.concat;
 import static org.assertj.core.api.Assertions.assertThat;
 
+/*
+ * The test fails occasionally because the find returns before the cancel operation is executed.
+ * It also logs a lot of errors because the session is opened in a thread and closed in another.
+ * I couldn't find a solution that works consistently, so I'm disabling it for now.
+ */
+@Disabled
 public class CancelSignalTest extends BaseReactiveTest {
 	private static final Logger LOG = Logger.getLogger( CancelSignalTest.class );
 


### PR DESCRIPTION
See issue #2975 

The issue of this test is that sometimes the find operation returns before the cancel is invoker. This means that the latch doesn't get released and the test goes in time out.

Note that this test causes a lot of errors because the session gets open in one thread and closed in another.

I'm disabling it for now because it fails too often, and I couldn't find a solution that works consistently.