### PR TITLE
Add comprehensive tests for @SoftDelete annotation (#1890)

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteCollectionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteCollectionTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.Id;
@@ -26,15 +27,22 @@ import jakarta.persistence.Table;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.dbType;
 
 /**
  * Tests @SoftDelete annotation applied to collection relationships.
+ * Covers basic filtering, CascadeType.REMOVE, and orphanRemoval=true scenarios.
  */
 public class SoftDeleteCollectionTest extends BaseReactiveTest {
 
 	@Override
 	protected Collection<Class<?>> annotatedEntities() {
-		return List.of( Author.class, Book.class );
+		return List.of(
+				Author.class, Book.class,
+				CascadeAuthor.class, CascadeBook.class,
+				OrphanAuthor.class, OrphanBook.class
+		);
 	}
 
 	@BeforeEach
@@ -61,11 +69,16 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 		);
 	}
 
+	// Entities are annotated with @SoftDelete, we need to execute a native query to actually empty the table
 	@Override
 	protected CompletionStage<Void> cleanDb() {
 		return getSessionFactory()
 				.withTransaction( s -> s.createNativeQuery( "delete from Book" ).executeUpdate()
 						.thenCompose( v -> s.createNativeQuery( "delete from Author" ).executeUpdate() )
+						.thenCompose( v -> s.createNativeQuery( "delete from CascadeBook" ).executeUpdate() )
+						.thenCompose( v -> s.createNativeQuery( "delete from CascadeAuthor" ).executeUpdate() )
+						.thenCompose( v -> s.createNativeQuery( "delete from OrphanBook" ).executeUpdate() )
+						.thenCompose( v -> s.createNativeQuery( "delete from OrphanAuthor" ).executeUpdate() )
 						.thenCompose( CompletionStages::voidFuture ) );
 	}
 
@@ -97,6 +110,22 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 									.containsExactlyInAnyOrder( "The Hobbit", "The Lord of the Rings" );
 						} )
 				) )
+				// Verify the soft-deleted book still exists in the table with deleted=true
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from Book order by id" )
+						.getResultList()
+						.invoke( rows -> {
+							// All 5 rows must still exist (soft delete does not remove rows)
+							assertThat( rows ).hasSize( 5 );
+							long deletedCount = rows.stream()
+									.map( r -> (Object[]) r )
+									.filter( r -> dbType() == DB2
+											? (short) r[2] == (short) 1
+											: (boolean) r[2] )
+									.count();
+							assertThat( deletedCount ).isEqualTo( 1 );
+						} )
+				) )
 		);
 	}
 
@@ -126,6 +155,21 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 						.getSingleResult()
 						.invoke( author -> assertThat( author.getBooks() ).hasSize( 2 ) )
 				) )
+				// All 5 rows must still exist; exactly 2 should be marked deleted
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from Book order by id" )
+						.getResultList()
+						.invoke( rows -> {
+							assertThat( rows ).hasSize( 5 );
+							long deletedCount = rows.stream()
+									.map( r -> (Object[]) r )
+									.filter( r -> dbType() == DB2
+											? (short) r[2] == (short) 1
+											: (boolean) r[2] )
+									.count();
+							assertThat( deletedCount ).isEqualTo( 2 );
+						} )
+				) )
 		);
 	}
 
@@ -148,6 +192,21 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 							assertThat( author.getBooks().get( 0 ).getTitle() ).isEqualTo( "It" );
 						} )
 				) )
+				// Verify the soft-deleted book still exists in the table
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from Book order by id" )
+						.getResultList()
+						.invoke( rows -> {
+							assertThat( rows ).hasSize( 5 );
+							long deletedCount = rows.stream()
+									.map( r -> (Object[]) r )
+									.filter( r -> dbType() == DB2
+											? (short) r[2] == (short) 1
+											: (boolean) r[2] )
+									.count();
+							assertThat( deletedCount ).isEqualTo( 1 );
+						} )
+				) )
 		);
 	}
 
@@ -160,14 +219,113 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 						.setParameter( "title", "The Hobbit" )
 						.executeUpdate()
 				)
-				// Direct query should only find non-deleted books
+				// Direct HQL query should only find non-deleted books
 				.call( () -> getMutinySessionFactory().withSession( s -> s
 						.createSelectionQuery( "from Book order by id", Book.class )
 						.getResultList()
 						.invoke( books -> assertThat( books ).hasSize( 4 ) )
 				) )
+				// Native query must show all 5 rows still present in the table
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from Book order by id" )
+						.getResultList()
+						.invoke( rows -> assertThat( rows ).hasSize( 5 ) )
+				) )
 		);
 	}
+
+	@Test
+	public void testCascadeRemoveSoftDeletesBooks(VertxTestContext context) {
+		test( context, getMutinySessionFactory()
+				// Create a CascadeAuthor with two books
+				.withTransaction( session -> {
+					CascadeAuthor author = new CascadeAuthor( "Cascade Author" );
+					CascadeBook book1 = new CascadeBook( "Cascade Book 1", author );
+					CascadeBook book2 = new CascadeBook( "Cascade Book 2", author );
+					author.addBook( book1 );
+					author.addBook( book2 );
+					return session.persistAll( author, book1, book2 );
+				} )
+				// Remove the author — CascadeType.REMOVE should propagate to books
+				.call( () -> getMutinySessionFactory().withTransaction( s -> s
+						.createSelectionQuery( "from CascadeAuthor", CascadeAuthor.class )
+						.getSingleResult()
+						.chain( s::remove )
+				) )
+				// Books should no longer be visible via HQL (soft-delete filter applied)
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createSelectionQuery( "from CascadeBook", CascadeBook.class )
+						.getResultList()
+						.invoke( books -> assertThat( books ).isEmpty() )
+				) )
+				// But rows must still exist in the table with deleted=true
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from CascadeBook order by id" )
+						.getResultList()
+						.invoke( rows -> {
+							assertThat( rows ).hasSize( 2 );
+							for ( Object row : rows ) {
+								Object[] r = (Object[]) row;
+								if ( dbType() == DB2 ) {
+									assertThat( (short) r[2] ).isEqualTo( (short) 1 );
+								}
+								else {
+									assertThat( (boolean) r[2] ).isTrue();
+								}
+							}
+						} )
+				) )
+		);
+	}
+
+	@Test
+	public void testOrphanRemovalSoftDeletesBook(VertxTestContext context) {
+		test( context, getMutinySessionFactory()
+				// Create an OrphanAuthor with two books
+				.withTransaction( session -> {
+					OrphanAuthor author = new OrphanAuthor( "Orphan Author" );
+					OrphanBook book1 = new OrphanBook( "Orphan Book 1", author );
+					OrphanBook book2 = new OrphanBook( "Orphan Book 2", author );
+					author.addBook( book1 );
+					author.addBook( book2 );
+					return session.persistAll( author, book1, book2 );
+				} )
+				// Remove one book from the collection — orphanRemoval should soft-delete it
+				.call( () -> getMutinySessionFactory().withTransaction( s -> s
+						.createSelectionQuery(
+								"from OrphanAuthor a join fetch a.books order by a.id",
+								OrphanAuthor.class
+						)
+						.getSingleResult()
+						.invoke( author -> author.getBooks().remove( 0 ) )
+				) )
+				// HQL should return only 1 book
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createSelectionQuery( "from OrphanBook", OrphanBook.class )
+						.getResultList()
+						.invoke( books -> assertThat( books ).hasSize( 1 ) )
+				) )
+				// Both rows must still exist in the table; one should be marked deleted
+				.call( () -> getMutinySessionFactory().withSession( s -> s
+						.createNativeQuery( "select id, title, deleted from OrphanBook order by id" )
+						.getResultList()
+						.invoke( rows -> {
+							assertThat( rows ).hasSize( 2 );
+							long deletedCount = rows.stream()
+									.map( r -> (Object[]) r )
+									.filter( r -> dbType() == DB2
+											? (short) r[2] == (short) 1
+											: (boolean) r[2] )
+									.count();
+							assertThat( deletedCount ).isEqualTo( 1 );
+						} )
+				) )
+		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Entities for basic collection tests
+	// -------------------------------------------------------------------------
 
 	@Entity(name = "Author")
 	@Table(name = "Author")
@@ -299,6 +457,234 @@ public class SoftDeleteCollectionTest extends BaseReactiveTest {
 		@Override
 		public String toString() {
 			return "Book{id=" + id + ", title='" + title + "'}";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Entities for CascadeType.REMOVE test
+	// Both author and book have @SoftDelete to avoid FK constraint violations.
+	// -------------------------------------------------------------------------
+
+	@Entity(name = "CascadeAuthor")
+	@Table(name = "CascadeAuthor")
+	@SoftDelete
+	public static class CascadeAuthor {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "author", cascade = CascadeType.REMOVE)
+		private List<CascadeBook> books = new ArrayList<>();
+
+		public CascadeAuthor() {
+		}
+
+		public CascadeAuthor(String name) {
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public List<CascadeBook> getBooks() {
+			return books;
+		}
+
+		public void addBook(CascadeBook book) {
+			books.add( book );
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			CascadeAuthor that = (CascadeAuthor) o;
+			return Objects.equals( name, that.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+	}
+
+	@Entity(name = "CascadeBook")
+	@Table(name = "CascadeBook")
+	@SoftDelete
+	public static class CascadeBook {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String title;
+
+		@ManyToOne
+		private CascadeAuthor author;
+
+		public CascadeBook() {
+		}
+
+		public CascadeBook(String title, CascadeAuthor author) {
+			this.title = title;
+			this.author = author;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public CascadeAuthor getAuthor() {
+			return author;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			CascadeBook that = (CascadeBook) o;
+			return Objects.equals( title, that.title );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( title );
+		}
+
+		@Override
+		public String toString() {
+			return "CascadeBook{id=" + id + ", title='" + title + "'}";
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// Entities for orphanRemoval=true test
+	// -------------------------------------------------------------------------
+
+	@Entity(name = "OrphanAuthor")
+	@Table(name = "OrphanAuthor")
+	public static class OrphanAuthor {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String name;
+
+		@OneToMany(mappedBy = "author", orphanRemoval = true)
+		private List<OrphanBook> books = new ArrayList<>();
+
+		public OrphanAuthor() {
+		}
+
+		public OrphanAuthor(String name) {
+			this.name = name;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getName() {
+			return name;
+		}
+
+		public List<OrphanBook> getBooks() {
+			return books;
+		}
+
+		public void addBook(OrphanBook book) {
+			books.add( book );
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			OrphanAuthor that = (OrphanAuthor) o;
+			return Objects.equals( name, that.name );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( name );
+		}
+	}
+
+	@Entity(name = "OrphanBook")
+	@Table(name = "OrphanBook")
+	@SoftDelete
+	public static class OrphanBook {
+		@Id
+		@GeneratedValue
+		private Integer id;
+
+		private String title;
+
+		@ManyToOne
+		private OrphanAuthor author;
+
+		public OrphanBook() {
+		}
+
+		public OrphanBook(String title, OrphanAuthor author) {
+			this.title = title;
+			this.author = author;
+		}
+
+		public Integer getId() {
+			return id;
+		}
+
+		public String getTitle() {
+			return title;
+		}
+
+		public OrphanAuthor getAuthor() {
+			return author;
+		}
+
+		@Override
+		public boolean equals(Object o) {
+			if ( this == o ) {
+				return true;
+			}
+			if ( o == null || getClass() != o.getClass() ) {
+				return false;
+			}
+			OrphanBook that = (OrphanBook) o;
+			return Objects.equals( title, that.title );
+		}
+
+		@Override
+		public int hashCode() {
+			return Objects.hash( title );
+		}
+
+		@Override
+		public String toString() {
+			return "OrphanBook{id=" + id + ", title='" + title + "'}";
 		}
 	}
 }

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteConverterTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteConverterTest.java
@@ -67,6 +67,7 @@ public class SoftDeleteConverterTest extends BaseReactiveTest {
 		);
 	}
 
+	// Entities are annotated with @SoftDelete, we need to execute a native query to actually empty the table
 	@Override
 	protected CompletionStage<Void> cleanDb() {
 		return loop(

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteTablePerClassTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SoftDeleteTablePerClassTest.java
@@ -58,6 +58,7 @@ public class SoftDeleteTablePerClassTest extends BaseReactiveTest {
 		);
 	}
 
+	// Entities are annotated with @SoftDelete, we need to execute a native query to actually empty the table
 	@Override
 	protected CompletionStage<Void> cleanDb() {
 		return getSessionFactory()


### PR DESCRIPTION
Add comprehensive tests for @SoftDelete annotation #1890

### Change
1. Renamed existing test
- **Renamed** `SoftDeleteTest` → `SoftDeleteSingleTableTest` to clarify that it tests
  single-table entity mappings (entities without inheritance)

2. Added JOINED inheritance strategy test
- Tests `@SoftDelete` behavior with `@Inheritance(strategy = InheritanceType.JOINED)`

3. Added collection relationship test
- Tests that soft-deleted entities are properly filtered from `@OneToMany` collections
- Uses `join fetch` to load collections with soft delete filter applied

4. Added converter types test
- Tests different converter implementations: `YesNoConverter`, `TrueFalseConverter`, and
  default boolean converter
- Tests both `ACTIVE` and `DELETED` strategies

5. Added TABLE_PER_CLASS inheritance strategy test (disabled)
- Tests are written but currently disabled due to potential issues with `@SoftDelete`
  support for TABLE_PER_CLASS inheritance
- When soft delete is performed via HQL, entities are not properly marked as deleted in the
  database
- Needs investigation to determine if this is a test implementation issue or an unsupported
  feature in Hibernate ORM/Reactive

---

  ### TABLE_PER_CLASS Issue
  The `SoftDeleteTablePerClassTest` is included but disabled because I'm uncertain whether the
   test failures are due to:
  1. Incorrect test implementation on my part
  2. An actual limitation/bug in Hibernate ORM's `@SoftDelete` support for TABLE_PER_CLASS
  inheritance

  The test is well-documented with comments explaining the issue. If this is a known
  limitation, the test can be removed. If it's a bug, the test can serve as a reproduction
  case once the underlying issue is fixed.