### PR TITLE
[4.1] Re-enable testEagerFetchQuery

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/FetchModeSubselectEagerTest.java
@@ -16,7 +16,6 @@ import org.hibernate.annotations.FetchMode;
 import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.util.impl.CompletionStages;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import io.vertx.junit5.Timeout;
@@ -45,7 +44,6 @@ import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @Timeout(value = 10, timeUnit = MINUTES)
-
 public class FetchModeSubselectEagerTest extends BaseReactiveTest {
 
 	@Override
@@ -117,7 +115,6 @@ public class FetchModeSubselectEagerTest extends BaseReactiveTest {
 	}
 
 	@Test
-	@Disabled("A regression after the upgrade to ORM 7.1.9.Final: https://github.com/hibernate/hibernate-reactive/issues/2808")
 	public void testEagerFetchQuery(VertxTestContext context) {
 
 		Node basik = new Node( "Child" );


### PR DESCRIPTION
Fix #2808 

In FetchModeSubselectEagerTest.
It failed after the upgrade to Hibernate ORM 7.1.9.Final, but it's working again now.

See https://hibernate.atlassian.net/browse/HHH-19949