### PR TITLE
Enable CI for 3.3 branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -175,6 +175,59 @@ updates:
       - dependency-type: "all"
 
   #################################################################################
+  # Duplicate the package-ecosystems for main because we want to target branch 3.3
+  # and dependabot doesn't support YAML aliases and anchors at the moment
+  #################################################################################
+  - package-ecosystem: "gradle"
+    directory: "/"
+    target-branch: "3.3"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    open-pull-requests-limit: 20
+    groups:
+      hibernate-validator:
+        patterns:
+          - "org.hibernate.validator*"
+          - "org.glassfish.expressly*"
+      hibernate:
+        patterns:
+          - "org.hibernate*"
+      vertx:
+        patterns:
+          - "io.vertx*"
+      mutiny:
+        patterns:
+          - "io.smallrye.reactive*"
+      testcontainers:
+        patterns:
+          - "org.testcontainers*"
+          - "com.ibm.db2*"
+          - "com.microsoft.sqlserver*"
+          - "org.postgresql*"
+          - "con.ongres.scram*"
+          - "com.fasterxml.jackson.core*"
+          - "com.mysql*"
+          - "org.mariadb.jdbc*"
+    ignore:
+      - dependency-name: "org.glassfish.expressly*"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "org.hibernate*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.vertx*"
+        update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      - dependency-name: "io.smallrye.reactive*"
+        update-types: [ "version-update:semver-major" ]
+
+  - package-ecosystem: "docker"
+    directory: "/tooling/docker"
+    target-branch: "3.3"
+    schedule:
+      interval: "weekly"
+    allow:
+      - dependency-type: "all"
+
+  #################################################################################
   # Duplicate the package-ecosystems for main because we want to target branch 3.2
   # and dependabot doesn't support YAML aliases and anchors at the moment
   #################################################################################

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'wip/2.4', 'wip/3.1', 'wip/3.2', 'wip/4.1', 'wip/4.2', 'wip/4.3' ]
+        branch: [ 'wip/2.4', 'wip/3.1', 'wip/3.2', 'wip/3.3', 'wip/4.1', 'wip/4.2', 'wip/4.3' ]
     uses: ./.github/workflows/build.yml
     with:
       branch: ${{ matrix.branch }}


### PR DESCRIPTION
Fix #3051 

Enable dependabot andWIP build with latest ORM 7.3 snapshots for 3.3