### PR TITLE
[4.3] Add ReactiveBulkOperationCleanupAction

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/action/internal/ReactiveBulkOperationCleanupAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/action/internal/ReactiveBulkOperationCleanupAction.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.action.internal;
+
+import java.util.Set;
+
+import org.hibernate.action.internal.BulkOperationCleanupAction;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.query.sqm.tree.SqmDmlStatement;
+import org.hibernate.reactive.session.ReactiveSession;
+
+/**
+ * Helper class to schedule bulk operation cleanup actions in the reactive action queue.
+ * <p>
+ * This delegates to Hibernate ORM's {@link BulkOperationCleanupAction} for the actual
+ * cleanup logic, but ensures the action is added to {@link org.hibernate.reactive.engine.ReactiveActionQueue}
+ * instead of the standard {@link org.hibernate.engine.spi.ActionQueue}.
+ */
+public class ReactiveBulkOperationCleanupAction {
+
+	/**
+	 * Schedules a bulk operation cleanup action for a DML statement.
+	 * This is the reactive equivalent of {@code BulkOperationCleanupAction.schedule()}.
+	 *
+	 * @param session The session
+	 * @param statement The DML statement (UPDATE, DELETE, etc.)
+	 */
+	public static void schedule(SharedSessionContractImplementor session, SqmDmlStatement<?> statement) {
+		final var metamodel = session.getFactory().getMappingMetamodel();
+		final var persister = metamodel.getEntityDescriptor( statement.getTarget().getEntityName() );
+		schedule( session, new BulkOperationCleanupAction( session, persister ) );
+	}
+
+	/**
+	 * Schedules a bulk operation cleanup action for a set of affected table names.
+	 * This is the reactive equivalent of {@code BulkOperationCleanupAction.schedule()}.
+	 *
+	 * @param session The session
+	 * @param affectedTableNames The set of affected table names
+	 */
+	public static void schedule(SharedSessionContractImplementor session, Set<String> affectedTableNames) {
+		schedule( session, new BulkOperationCleanupAction( session, affectedTableNames ) );
+	}
+
+	private static void schedule(SharedSessionContractImplementor session, BulkOperationCleanupAction action) {
+		if ( session.isEventSource() ) {
+			// Regular session - add action to the reactive action queue
+			ReactiveSession reactiveSession = session.unwrap( ReactiveSession.class );
+			reactiveSession.getReactiveActionQueue().addAction( action );
+		}
+		else {
+			// Stateless session - execute cleanup immediately
+			action.getAfterTransactionCompletionProcess().doAfterTransactionCompletion( true, session );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
@@ -10,13 +10,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sql.internal.SQLQueryParser;
 import org.hibernate.query.sql.spi.ParameterOccurrence;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.engine.spi.ReactiveSharedSessionContractImplementor;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
@@ -48,7 +48,8 @@ public class ReactiveNativeNonSelectQueryPlan implements ReactiveNonSelectQueryP
 		return reactiveSession.reactiveAutoFlushIfRequired( affectedTableNames )
 						.thenCompose( aBoolean -> {
 							SharedSessionContractImplementor session = executionContext.getSession();
-							BulkOperationCleanupAction.schedule( session, affectedTableNames );
+							ReactiveBulkOperationCleanupAction.schedule( session, affectedTableNames );
+
 							final List<JdbcParameterBinder> jdbcParameterBinders;
 							final JdbcParameterBindings jdbcParameterBindings;
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveAbstractMultiTableMutationQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveAbstractMultiTableMutationQueryPlan.java
@@ -4,11 +4,11 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.AbstractMultiTableMutationQueryPlan;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.tree.SqmDmlStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.query.sqm.mutation.internal.ReactiveHandler;
 
@@ -26,7 +26,7 @@ public abstract class ReactiveAbstractMultiTableMutationQueryPlan<S extends SqmD
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext context) {
-		BulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
+		ReactiveBulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
 		final Interpretation interpretation = getInterpretation( context );
 		return ((ReactiveHandler)interpretation.handler()).reactiveExecute( interpretation.jdbcParameterBindings(), context );
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.persister.entity.EntityPersister;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
@@ -13,6 +12,7 @@ import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.internal.SimpleDeleteQueryPlan;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
@@ -45,7 +45,7 @@ public class ReactiveSimpleDeleteQueryPlan
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext context) {
-		BulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
+		ReactiveBulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
 		final Interpretation interpretation = getInterpretation( context );
 		final ExecutionContext executionContext = SqmJdbcExecutionContextAdapter.omittingLockingAndPaging( context );
 		return executeReactive( interpretation.interpretation(), interpretation.jdbcParameterBindings(), executionContext );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleNonSelectQueryPlan.java
@@ -4,7 +4,6 @@
  */
 package org.hibernate.reactive.query.sqm.internal;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.CacheableSqmInterpretation;
@@ -12,6 +11,7 @@ import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.internal.SimpleNonSelectQueryPlan;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
 import org.hibernate.query.sqm.tree.SqmDmlStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
 import org.hibernate.sql.ast.tree.MutationStatement;
@@ -32,7 +32,7 @@ public class ReactiveSimpleNonSelectQueryPlan extends
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext context) {
-		BulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
+		ReactiveBulkOperationCleanupAction.schedule( context.getSession(), getStatement() );
 		final Interpretation interpretation = getInterpretation( context );
 		final ExecutionContext executionContext = SqmJdbcExecutionContextAdapter.omittingLockingAndPaging( context );
 		return executeReactive( interpretation.interpretation(), interpretation.jdbcParameterBindings(), executionContext );


### PR DESCRIPTION
Fix #3177

The problem is that Hibernate Reactive was adding the clean up actions in the Hiberante ORM action queue instead of the Hibernate Reactive one.

This was causing some warnings in the logs when executing update operations.

I couldn't figure out how to write a JUnit test for this issue, though.

I think this fix should solve this specific issue, but I need to review the transaction callbacks interfaces. It seems we are not aligned with Hibernate ORM at the moment. But I think I will work on it as a separate issue.