### PR TITLE
[2.4] Add ReactiveBulkOperationCleanupAction

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/action/internal/ReactiveBulkOperationCleanupAction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/action/internal/ReactiveBulkOperationCleanupAction.java
@@ -1,0 +1,57 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.action.internal;
+
+import java.util.Set;
+
+import org.hibernate.action.internal.BulkOperationCleanupAction;
+import org.hibernate.engine.spi.SharedSessionContractImplementor;
+import org.hibernate.query.sqm.tree.SqmDmlStatement;
+import org.hibernate.reactive.session.ReactiveSession;
+
+/**
+ * Helper class to schedule bulk operation cleanup actions in the reactive action queue.
+ * <p>
+ * This delegates to Hibernate ORM's {@link BulkOperationCleanupAction} for the actual
+ * cleanup logic, but ensures the action is added to {@link org.hibernate.reactive.engine.ReactiveActionQueue}
+ * instead of the standard {@link org.hibernate.engine.spi.ActionQueue}.
+ */
+public class ReactiveBulkOperationCleanupAction {
+
+	/**
+	 * Schedules a bulk operation cleanup action for a DML statement.
+	 * This is the reactive equivalent of {@code BulkOperationCleanupAction.schedule()}.
+	 *
+	 * @param session The session
+	 * @param statement The DML statement (UPDATE, DELETE, etc.)
+	 */
+	public static void schedule(SharedSessionContractImplementor session, SqmDmlStatement<?> statement) {
+		final var metamodel = session.getFactory().getMappingMetamodel();
+		final var persister = metamodel.getEntityDescriptor( statement.getTarget().getEntityName() );
+		schedule( session, new BulkOperationCleanupAction( session, persister ) );
+	}
+
+	/**
+	 * Schedules a bulk operation cleanup action for a set of affected table names.
+	 * This is the reactive equivalent of {@code BulkOperationCleanupAction.schedule()}.
+	 *
+	 * @param session The session
+	 * @param affectedTableNames The set of affected table names
+	 */
+	public static void schedule(SharedSessionContractImplementor session, Set<String> affectedTableNames) {
+		schedule( session, new BulkOperationCleanupAction( session, affectedTableNames ) );
+	}
+
+	private static void schedule(SharedSessionContractImplementor session, BulkOperationCleanupAction action) {
+		if ( session.isEventSource() ) {
+			// Regular session - add action to the reactive action queue
+			( (ReactiveSession) session ).getReactiveActionQueue().addAction( action );
+		}
+		else {
+			// Stateless session - execute cleanup immediately
+			action.getAfterTransactionCompletionProcess().doAfterTransactionCompletion( true, session );
+		}
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sql/internal/ReactiveNativeNonSelectQueryPlan.java
@@ -11,13 +11,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.spi.QueryParameterBindings;
 import org.hibernate.query.sql.internal.SQLQueryParser;
 import org.hibernate.query.sql.spi.ParameterOccurrence;
 import org.hibernate.query.sqm.internal.SqmJdbcExecutionContextAdapter;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.engine.spi.ReactiveSharedSessionContractImplementor;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
@@ -49,7 +49,8 @@ public class ReactiveNativeNonSelectQueryPlan implements ReactiveNonSelectQueryP
 		return reactiveSession.reactiveAutoFlushIfRequired( affectedTableNames )
 						.thenCompose( aBoolean -> {
 							SharedSessionContractImplementor session = executionContext.getSession();
-							BulkOperationCleanupAction.schedule( session, affectedTableNames );
+							ReactiveBulkOperationCleanupAction.schedule( session, affectedTableNames );
+
 							final List<JdbcParameterBinder> jdbcParameterBinders;
 							final JdbcParameterBindings jdbcParameterBindings;
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableDeleteQueryPlan.java
@@ -6,10 +6,10 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.query.sqm.mutation.spi.ReactiveSqmMultiTableMutationStrategy;
 
@@ -32,7 +32,7 @@ public class ReactiveMultiTableDeleteQueryPlan implements ReactiveNonSelectQuery
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
 		return deleteStrategy.reactiveExecuteDelete( sqmDelete, domainParameterXref, executionContext );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableInsertQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableInsertQueryPlan.java
@@ -6,10 +6,10 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.query.sqm.mutation.spi.ReactiveSqmMultiTableInsertStrategy;
 
@@ -32,7 +32,7 @@ public class ReactiveMultiTableInsertQueryPlan implements ReactiveNonSelectQuery
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
 		return mutationStrategy.reactiveExecuteInsert( sqmInsert, domainParameterXref, executionContext );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableUpdateQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveMultiTableUpdateQueryPlan.java
@@ -6,10 +6,10 @@ package org.hibernate.reactive.query.sqm.internal;
 
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.query.spi.DomainQueryExecutionContext;
 import org.hibernate.query.sqm.internal.DomainParameterXref;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.query.sqm.mutation.spi.ReactiveSqmMultiTableMutationStrategy;
 
@@ -32,7 +32,7 @@ public class ReactiveMultiTableUpdateQueryPlan implements ReactiveNonSelectQuery
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
 		return mutationStrategy.reactiveExecuteUpdate( sqmUpdate, domainParameterXref, executionContext );
 	}
 }

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleDeleteQueryPlan.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.EntityMappingType;
@@ -29,6 +28,7 @@ import org.hibernate.query.sqm.sql.SqmTranslation;
 import org.hibernate.query.sqm.sql.SqmTranslator;
 import org.hibernate.query.sqm.tree.delete.SqmDeleteStatement;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.query.sqm.mutation.internal.ReactiveSqmMutationStrategyHelper;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
@@ -121,7 +121,7 @@ public class ReactiveSimpleDeleteQueryPlan extends SimpleDeleteQueryPlan impleme
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmDelete );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		final SessionFactoryImplementor factory = session.getFactory();
 		SqlAstTranslator<? extends JdbcOperationQueryMutation> sqlAstTranslator = null;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleInsertQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleInsertQueryPlan.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.MappingModelExpressible;
@@ -25,6 +24,7 @@ import org.hibernate.query.sqm.sql.SqmTranslator;
 import org.hibernate.query.sqm.sql.SqmTranslatorFactory;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
 import org.hibernate.query.sqm.tree.insert.SqmInsertStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -58,7 +58,7 @@ public class ReactiveSimpleInsertQueryPlan implements ReactiveNonSelectQueryPlan
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmInsert );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		SqlAstTranslator<JdbcOperationQueryInsert> insertTranslator = null;
 		if ( jdbcInsert == null ) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleUpdateQueryPlan.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/sqm/internal/ReactiveSimpleUpdateQueryPlan.java
@@ -8,7 +8,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 
-import org.hibernate.action.internal.BulkOperationCleanupAction;
 import org.hibernate.engine.spi.SessionFactoryImplementor;
 import org.hibernate.engine.spi.SharedSessionContractImplementor;
 import org.hibernate.metamodel.mapping.MappingModelExpressible;
@@ -24,6 +23,7 @@ import org.hibernate.query.sqm.sql.SqmTranslator;
 import org.hibernate.query.sqm.sql.SqmTranslatorFactory;
 import org.hibernate.query.sqm.tree.expression.SqmParameter;
 import org.hibernate.query.sqm.tree.update.SqmUpdateStatement;
+import org.hibernate.reactive.action.internal.ReactiveBulkOperationCleanupAction;
 import org.hibernate.reactive.query.sql.spi.ReactiveNonSelectQueryPlan;
 import org.hibernate.reactive.sql.exec.internal.StandardReactiveJdbcMutationExecutor;
 import org.hibernate.sql.ast.SqlAstTranslator;
@@ -54,7 +54,7 @@ public class ReactiveSimpleUpdateQueryPlan implements ReactiveNonSelectQueryPlan
 
 	@Override
 	public CompletionStage<Integer> executeReactiveUpdate(DomainQueryExecutionContext executionContext) {
-		BulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
+		ReactiveBulkOperationCleanupAction.schedule( executionContext.getSession(), sqmUpdate );
 		final SharedSessionContractImplementor session = executionContext.getSession();
 		SqlAstTranslator<JdbcOperationQueryUpdate> updateTranslator = null;
 		if ( jdbcUpdate == null ) {


### PR DESCRIPTION
Backport #3177 to `2.4`

The problem is that Hibernate Reactive was adding the clean up actions in the Hiberante ORM action queue instead of the Hibernate Reactive one.

This was causing some warnings in the logs when executing update operations.

I couldn't figure out how to write a JUnit test for this issue, though.