### PR TITLE
[3.3] Remove workaround for CockroachDB

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveIdentityGenerator.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/persister/entity/impl/ReactiveIdentityGenerator.java
@@ -9,12 +9,10 @@ import org.hibernate.dialect.Dialect;
 import org.hibernate.id.IdentityGenerator;
 import org.hibernate.id.insert.InsertGeneratedIdentifierDelegate;
 import org.hibernate.persister.entity.EntityPersister;
-import org.hibernate.reactive.generator.values.internal.ReactiveGeneratedValuesHelper;
 import org.hibernate.reactive.id.insert.ReactiveBasicSelectingDelegate;
 import org.hibernate.reactive.id.insert.ReactiveGetGeneratedKeysDelegate;
 import org.hibernate.reactive.id.insert.ReactiveInsertReturningDelegate;
 import org.hibernate.reactive.id.insert.ReactiveUniqueKeySelectingDelegate;
-
 
 import static org.hibernate.generator.EventType.INSERT;
 import static org.hibernate.generator.values.internal.GeneratedValuesHelper.noCustomSql;
@@ -33,8 +31,7 @@ public class ReactiveIdentityGenerator extends IdentityGenerator {
 			Hibernate ORM allows the selection of different strategies based on the property `hibernate.jdbc.use_get_generated_keys`,
 			but the Vert.x driver does not support get generated keys.
 		 */
-		final boolean supportsInsertReturning = ReactiveGeneratedValuesHelper.supportsInsertReturning( dialect );
-		if ( supportsInsertReturning && noCustomSql( persister, INSERT ) ) {
+		if ( dialect.supportsInsertReturning() && noCustomSql( persister, INSERT ) ) {
 			return new ReactiveInsertReturningDelegate( persister, INSERT );
 		}
 		else if ( supportReactiveGetGeneratedKey( dialect, persister.getGeneratedProperties( INSERT ) ) ) {


### PR DESCRIPTION
Backport #3187 to `3.3`
See https://hibernate.atlassian.net/browse/HHH-19717

CockroachDB supports the return value for insert and updates, but the dialect was saying otherwise. So we had to add a special case. The issue has been solved and we can remove the special handling.