### PR TITLE
[4.3] Fix a few deprecation warnings in the Gradle build

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -204,8 +204,8 @@ def renderReferenceDocumentationTask = tasks.register( "renderReferenceDocumenta
 
 def assembleDocumentationTask = tasks.register( 'assembleDocumentation' ) {
 	dependsOn aggregateJavadocsTask, renderReferenceDocumentationTask
-	group 'Documentation'
-	description 'Grouping task for performing all documentation building tasks'
+	group = 'Documentation'
+	description = 'Grouping task for performing all documentation building tasks'
 }
 
 assemble.dependsOn assembleDocumentationTask

--- a/local-build-plugins/src/main/groovy/hr-java-library.gradle
+++ b/local-build-plugins/src/main/groovy/hr-java-library.gradle
@@ -8,7 +8,7 @@ version = rootProject.version
 
 spotless {
 	//Don't fail during the check: rather than enforcing guidelines, we use this plugin to fix mistakes automatically.
-	enforceCheck false
+	enforceCheck = false
 	java {
 		licenseHeaderFile rootProject.file('spotless.license.java')
 		removeUnusedImports()

--- a/release/build.gradle
+++ b/release/build.gradle
@@ -24,13 +24,13 @@ final Directory documentationDir = project(":documentation").layout.buildDirecto
  */
 def assembleDocumentationTask = tasks.register( 'assembleDocumentation' ) {
     dependsOn ':documentation:assemble'
-    group 'Documentation'
-    description 'Render the documentation'
+    group = 'Documentation'
+    description = 'Render the documentation'
 }
 assemble.dependsOn assembleDocumentationTask
 
 def updateDocumentationTask = tasks.register( 'updateDocumentation' ) {
-    description "Update the documentation on the cloned static website"
+    description = "Update the documentation on the cloned static website"
     dependsOn assembleDocumentationTask
 
     // copy documentation outputs into target/documentation:
@@ -53,8 +53,8 @@ def updateDocumentationTask = tasks.register( 'updateDocumentation' ) {
 }
 
 tasks.register( "releasePrepare" ) {
-    description "Prepares all the artifacts and documentation for a JReleaser release."
-    group "Release"
+    description = "Prepares all the artifacts and documentation for a JReleaser release."
+    group = "Release"
 
 	// Render the Documentation/Javadocs and move them to the staging directory (for JReleaser):
 	dependsOn updateDocumentationTask


### PR DESCRIPTION
it's a minor thing... but now Gradle complains about property assignments if it does not use the `=` syntax 🙈 