### PR TITLE
[3.3] Make QueryProducer interfaces sealed

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -492,7 +492,7 @@ public interface Mutiny {
 	 *
 	 * @since 3.0
 	 */
-	sealed interface QueryProducer permits Session, StatelessSession {
+	sealed interface QueryProducer extends Closeable permits Session, StatelessSession {
 		/**
 		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
 		 * query string.
@@ -828,7 +828,7 @@ public interface Mutiny {
 	 *
 	 * @see org.hibernate.Session
 	 */
-    non-sealed interface Session extends QueryProducer, Closeable {
+    non-sealed interface Session extends QueryProducer {
 
 		/**
 		 * Asynchronously return the persistent instance of the given entity
@@ -1548,7 +1548,7 @@ public interface Mutiny {
 	 *
 	 * @see org.hibernate.StatelessSession
 	 */
-    non-sealed interface StatelessSession extends QueryProducer, Closeable {
+    non-sealed interface StatelessSession extends QueryProducer {
 
 		/**
 		 * Retrieve a row.

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -489,7 +489,7 @@ public interface Stage {
 	 *
 	 * @since 3.0
 	 */
-	sealed interface QueryProducer permits Session, StatelessSession {
+	sealed interface QueryProducer extends Closeable permits Session, StatelessSession {
 		/**
 		 * Create an instance of {@link SelectionQuery} for the given HQL/JPQL
 		 * query string.
@@ -829,7 +829,7 @@ public interface Stage {
 	 *
 	 * @see org.hibernate.Session
 	 */
-    non-sealed interface Session extends QueryProducer, Closeable {
+    non-sealed interface Session extends QueryProducer {
 
 		/**
 		 * Asynchronously return the persistent instance of the given entity
@@ -1549,7 +1549,7 @@ public interface Stage {
 	 *
 	 * @see org.hibernate.StatelessSession
 	 */
-    non-sealed interface StatelessSession extends QueryProducer, Closeable {
+    non-sealed interface StatelessSession extends QueryProducer {
 
 		/**
 		 * Retrieve a row.


### PR DESCRIPTION
Backport #3175 to `3.3`