### PR TITLE
[3.3] Fix scram version in docs

### DIFF
--- a/documentation/src/main/asciidoc/reference/introduction.adoc
+++ b/documentation/src/main/asciidoc/reference/introduction.adoc
@@ -89,7 +89,7 @@ Optionally, you might also add any of the following additional features:
 | Hibernate Validator | `org.hibernate.validator:hibernate-validator` and `org.glassfish:jakarta.el`
 | Compile-time checking for your HQL queries | `org.hibernate:query-validator`
 | Second-level cache support via JCache and EHCache | `org.hibernate.orm:hibernate-jcache` along with `org.ehcache:ehcache`
-| SCRAM authentication support for PostgreSQL | `com.ongres.scram:client:2.1`
+| SCRAM authentication support for PostgreSQL | `com.ongres.scram:scram-client:3.2`
 |===
 
 You might also add the Hibernate {enhancer}[bytecode enhancer] to your


### PR DESCRIPTION
From `com.ongres.scram:client:2.1`to `com.ongres.scram:scram-client:3.2`

Fix #3232 