### PR TITLE
[3.3] In the docs, inlcude the SCRAM GAV as variable

### DIFF
--- a/documentation/build.gradle
+++ b/documentation/build.gradle
@@ -150,6 +150,10 @@ def renderReferenceDocumentationTask = tasks.register( "renderReferenceDocumenta
 			throw new IllegalArgumentException("Cannot parse the version of Hibernate ORM from '" + v + "' string.")
 		}
 	}
+	def scramArtifact = providers.provider {
+		def lib = libs.com.ongres.scram.scram.client.get()
+		return "${lib.module.group}:${lib.module.name}:${lib.versionConstraint.requiredVersion}"
+	}
 
 	asciidoctorj {
 		version = "3.0.0"
@@ -180,6 +184,7 @@ def renderReferenceDocumentationTask = tasks.register( "renderReferenceDocumenta
 			majorMinorVersion: versionFamily.get(),
 			fullVersion: fullVersion.get(),
 			ormMinorVersion: ormMinorVersion.get(),
+			scramArtifact: scramArtifact.get(),
 			stylesdir: "css",
 			"iconfont-remote": false,
 			"iconfont-name": "font-awesome/css/solid",

--- a/documentation/src/main/asciidoc/reference/introduction.adoc
+++ b/documentation/src/main/asciidoc/reference/introduction.adoc
@@ -89,7 +89,7 @@ Optionally, you might also add any of the following additional features:
 | Hibernate Validator | `org.hibernate.validator:hibernate-validator` and `org.glassfish:jakarta.el`
 | Compile-time checking for your HQL queries | `org.hibernate:query-validator`
 | Second-level cache support via JCache and EHCache | `org.hibernate.orm:hibernate-jcache` along with `org.ehcache:ehcache`
-| SCRAM authentication support for PostgreSQL | `com.ongres.scram:scram-client:3.2`
+| SCRAM authentication support for PostgreSQL | `{scramArtifact}`
 |===
 
 You might also add the Hibernate {enhancer}[bytecode enhancer] to your


### PR DESCRIPTION
The value was hardcoded in the documentation. Now it's obtaioned by the actual dependency in the catalogue