### PR TITLE
[3.1] Fix junit-platform-launcher version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,7 +9,6 @@ jacksonDatabindVersion = "2.21.1"
 jbossLoggingAnnotationVersion = "3.0.4.Final"
 jbossLoggingVersion = "3.6.2.Final"
 junitVersion = "6.0.3"
-junitPlatformVersion = "1.13.4"
 log4jVersion = "2.25.3"
 testcontainersVersion = "1.21.4"
 vertxSqlClientVersion = "4.5.25"
@@ -47,7 +46,7 @@ org-jboss-logging-jboss-logging-annotations = { group = "org.jboss.logging", nam
 org-jboss-logging-jboss-logging-processor = { group = "org.jboss.logging", name = "jboss-logging-processor", version.ref = "jbossLoggingAnnotationVersion" }
 org-junit-jupiter-junit-jupiter-api = { group = "org.junit.jupiter", name = "junit-jupiter-api", version.ref = "junitVersion" }
 org-junit-jupiter-junit-jupiter-engine = { group = "org.junit.jupiter", name = "junit-jupiter-engine", version.ref = "junitVersion" }
-org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version = "6.0.3" }
+org-junit-platform-junit-platform-launcher = { group = "org.junit.platform", name = "junit-platform-launcher", version.ref = "junitVersion" }
 org-mariadb-jdbc-mariadb-java-client = { group = "org.mariadb.jdbc", name = "mariadb-java-client", version = "3.5.7" }
 org-postgresql-postgresql = { group = "org.postgresql", name = "postgresql", version = "42.7.10" }
 org-testcontainers-cockroachdb = { group = "org.testcontainers", name = "cockroachdb", version.ref = "testcontainersVersion" }


### PR DESCRIPTION
From `version="junitVersion"` to `"version.ref="junitVersion"`