### PR TITLE
[2.4] Update JDKs for CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,8 +175,9 @@ jobs:
           # even if we don't use these features, just enabling them can cause side effects
           # and it's useful to test that.
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
-          - { name: "25", java_version_numeric: 25, from: 'jdk.java.net', jvm_args: '--enable-preview' }
-          - { name: "26-ea", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "25", java_version_numeric: 25, jvm_args: '--enable-preview' }
+          - { name: "26", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "27-ea", java_version_numeric: 27, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:
       - name: Checkout ${{ inputs.branch }}
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
Test build with JDK 25 temurin, JDK 26 GA, and 27-ea

Fix #3446
