### PR TITLE
Update workflows for WIP branches and enable releases from main

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'wip/2.4', 'wip/3.1', 'wip/3.2', 'wip/3.3', 'wip/4.1', 'wip/4.2', 'wip/4.3' ]
+        branch: [ 'wip/2.4', 'wip/3.2', 'wip/3.3', 'wip/3.4', 'wip/4.2', 'wip/4.3', 'wip/4.4' ]
     uses: ./.github/workflows/build.yml
     with:
       branch: ${{ matrix.branch }}

--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -15,7 +15,7 @@ import org.hibernate.jenkins.pipeline.helpers.version.Version
 // Global build configuration
 env.PROJECT = "reactive"
 env.JIRA_KEY = "HREACT"
-def RELEASE_ON_SCHEDULE = false // Set to `true` *only* on branches where you want a scheduled release.
+def RELEASE_ON_SCHEDULE = true // Set to `true` *only* on branches where you want a scheduled release.
 
 print "INFO: env.PROJECT = ${env.PROJECT}"
 print "INFO: env.JIRA_KEY = ${env.JIRA_KEY}"


### PR DESCRIPTION
* Enable scheduled releases from `main` for the `4.3` family
* Add `wip/3.4` and `wip/4.4`
* Remove `wip/3.1` and `wip/4.1` from the scheduled builds