### PR TITLE
[#1783] Fix NullPointerException when overriding logger

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/DefaultSqlClientPool.java
@@ -123,7 +123,8 @@ public class DefaultSqlClientPool extends SqlClientPool
 	@Override
 	public void injectServices(ServiceRegistryImplementor serviceRegistry) {
 		this.serviceRegistry = serviceRegistry;
-		this.sqlStatementLogger = serviceRegistry.getService( SqlStatementLogger.class );
+		SqlStatementLogger logger = serviceRegistry.getService( SqlStatementLogger.class );
+		this.sqlStatementLogger = logger != null ? logger : new SqlStatementLogger();
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -20,6 +20,10 @@ import org.hibernate.reactive.pool.impl.DefaultSqlClientPool;
 import org.hibernate.reactive.pool.impl.DefaultSqlClientPoolConfiguration;
 import org.hibernate.reactive.pool.impl.SqlClientPoolConfiguration;
 import org.hibernate.reactive.testing.TestingRegistryExtension;
+import org.hibernate.service.Service;
+import org.hibernate.service.ServiceRegistry;
+import org.hibernate.service.spi.ServiceBinding;
+import org.hibernate.service.spi.ServiceRegistryImplementor;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
@@ -115,11 +119,95 @@ public class ReactiveConnectionPoolTest {
 		);
 	}
 
+	@Test
+	public void configureWithNullSqlStatementLogger(VertxTestContext context) {
+		Map<String, Object> config = new HashMap<>();
+		config.put( URL, getJdbcUrl() );
+
+		DefaultSqlClientPoolConfiguration poolConfig = new DefaultSqlClientPoolConfiguration();
+		poolConfig.configure( config );
+		registryExtension.addService( SqlClientPoolConfiguration.class, poolConfig );
+		registryExtension.addService( JdbcServices.class, new JdbcServicesImpl() {
+			@Override
+			public SqlStatementLogger getSqlStatementLogger() {
+				return new SqlStatementLogger();
+			}
+
+			@Override
+			public SqlExceptionHelper getSqlExceptionHelper() {
+				return new SqlExceptionHelper( true );
+			}
+		} );
+
+		// Wrap registry to return null for SqlStatementLogger, simulating a custom logger setup
+		ServiceRegistryImplementor nullLoggerRegistry = new NullStatementLoggerRegistry(
+				registryExtension.getServiceRegistry()
+		);
+		DefaultSqlClientPool reactivePool = new DefaultSqlClientPool();
+		reactivePool.injectServices( nullLoggerRegistry );
+		reactivePool.configure( config );
+		reactivePool.start();
+
+		test( context, verifyConnectivity( reactivePool ) );
+	}
+
 	private static CompletionStage<Void> verifyConnectivity(ReactiveConnectionPool reactivePool) {
 		return reactivePool.getConnection().thenCompose(
 				connection -> connection.select( "SELECT 1" )
 						.thenAccept( result -> assertThat( result ).hasNext()
 								.satisfies( iterator -> assertEquals( 1, result.next()[0] ) )
 						) );
+	}
+
+	private static class NullStatementLoggerRegistry implements ServiceRegistryImplementor {
+		private final ServiceRegistryImplementor delegate;
+
+		NullStatementLoggerRegistry(ServiceRegistryImplementor delegate) {
+			this.delegate = delegate;
+		}
+
+		@Override
+		@SuppressWarnings("unchecked")
+		public <R extends Service> R getService(Class<R> serviceRole) {
+			if ( serviceRole == SqlStatementLogger.class ) {
+				return null;
+			}
+			return delegate.getService( serviceRole );
+		}
+
+		@Override
+		public <R extends Service> ServiceBinding<R> locateServiceBinding(Class<R> serviceRole) {
+			return delegate.locateServiceBinding( serviceRole );
+		}
+
+		@Override
+		public void destroy() {
+			delegate.destroy();
+		}
+
+		@Override
+		public boolean isActive() {
+			return delegate.isActive();
+		}
+
+		@Override
+		public void registerChild(ServiceRegistryImplementor child) {
+			delegate.registerChild( child );
+		}
+
+		@Override
+		public void deRegisterChild(ServiceRegistryImplementor child) {
+			delegate.deRegisterChild( child );
+		}
+
+		@Override
+		public ServiceRegistry getParentServiceRegistry() {
+			return delegate.getParentServiceRegistry();
+		}
+
+		@Override
+		public <T extends Service> T fromRegistryOrChildren(Class<T> serviceRole) {
+			return delegate.fromRegistryOrChildren( serviceRole );
+		}
 	}
 }


### PR DESCRIPTION
Fixes #1783

Custom logger setups that don't provide SqlStatementLogger were causing NPEs when the pool tried to use a null reference. Added a null check to fall back to a default logger instance if the service isn't available. Includes a test that reproduces the scenario.