### PR TITLE
[4.4] Use an ssh git repository URL for the "website release" step

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -235,20 +235,16 @@ pipeline {
 							configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"),
 							configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")
 					]) {
-						withCredentials([
-								gitUsernamePassword(credentialsId: 'username-and-token.Hibernate-CI.github.com', gitToolName: 'Default')
-						]) {
-							sshagent( ['ed25519.Hibernate-CI.github.com'] ) {
-								dir( '.release/hibernate.org' ) {
-									checkout scmGit(
-											branches: [[name: '*/production']],
-											extensions: [],
-											userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
-									)
-									sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
-								}
-							}
-						}
+                        sshagent( ['ed25519.Hibernate-CI.github.com'] ) {
+                            dir( '.release/hibernate.org' ) {
+                                checkout scmGit(
+                                        branches: [[name: '*/production']],
+                                        extensions: [],
+                                        userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'git@github.com:hibernate/hibernate.org.git']]
+                                )
+                                sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+                            }
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
see:

- https://github.com/hibernate/hibernate-search/pull/5117#discussion_r3186742781

As we are getting these commits as Hibernate-ci user: https://github.com/hibernate/hibernate.org/commit/2c945d993907c7c922c25f8959fd3953a437d2da, I suspect that the config for a Jenkins job works and we don't need the extra config to set the user here 🤞🏻 

Let's give it a try on the next reactive release, and if it works, adjust other projects?