### PR TITLE
[4.3] Use an ssh git repository URL for the website release

### DIFF
--- a/ci/release/Jenkinsfile
+++ b/ci/release/Jenkinsfile
@@ -235,20 +235,16 @@ pipeline {
 							configFile(fileId: 'release.config.ssh', targetLocation: "${env.HOME}/.ssh/config"),
 							configFile(fileId: 'release.config.ssh.knownhosts', targetLocation: "${env.HOME}/.ssh/known_hosts")
 					]) {
-						withCredentials([
-								gitUsernamePassword(credentialsId: 'username-and-token.Hibernate-CI.github.com', gitToolName: 'Default')
-						]) {
-							sshagent( ['ed25519.Hibernate-CI.github.com'] ) {
-								dir( '.release/hibernate.org' ) {
-									checkout scmGit(
-											branches: [[name: '*/production']],
-											extensions: [],
-											userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'https://github.com/hibernate/hibernate.org.git']]
-									)
-									sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
-								}
-							}
-						}
+                        sshagent( ['ed25519.Hibernate-CI.github.com'] ) {
+                            dir( '.release/hibernate.org' ) {
+                                checkout scmGit(
+                                        branches: [[name: '*/production']],
+                                        extensions: [],
+                                        userRemoteConfigs: [[credentialsId: 'ed25519.Hibernate-CI.github.com', url: 'git@github.com:hibernate/hibernate.org.git']]
+                                )
+                                sh "../scripts/website-release.sh ${env.SCRIPT_OPTIONS} ${env.PROJECT} ${env.RELEASE_VERSION}"
+                            }
+                        }
 					}
 				}
 			}


### PR DESCRIPTION
We want to use SSH key on CI when pushing anything to our remote repositories and do not rely on HTTPS based links/credentials.

Jenkins CI should already configure the git client and set the default user/email. So it should be enough to just use an ssh url when checking out any additional repository we are about to push to.

Main project repositories (the ones which trigger builds) are already checked out via ssh as configured by the Jenkins job itself.