### PR TITLE
[4.4] Artifact name for reports should be unique

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: reports-examples-${{ matrix.db }}-${{ matrix.example }}-${{steps.current-branch-suffix.outputs.value}}
+          name: reports-examples-${{ matrix.db }}-${{ matrix.example }}-${{ steps.current-branch-suffix.outputs.value }}-${{ strategy.job-index }}
           path: './**/build/reports/'
 
   test_dbs:
@@ -187,12 +187,12 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: reports-db-${{ matrix.db }}-${{steps.current-branch-suffix.outputs.value}}
+          name: reports-db-${{ matrix.db }}-${{ steps.current-branch-suffix.outputs.value }}-${{ strategy.job-index }}
           path: './**/build/reports/'
       - name: Upload coverage reports
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: build-coverage-data-db-${{ matrix.db }}
+          name: build-coverage-data-db-${{ matrix.db }}-${{ steps.current-branch-suffix.outputs.value }}-${{ strategy.job-index }}
           path: |
             ./**/build/jacoco/*.exec
             ./**/build/classes/
@@ -327,7 +327,7 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: failure()
         with:
-          name: reports-java${{ matrix.java.name }}-${{steps.current-branch-suffix.outputs.value}}
+          name: reports-java${{ matrix.java.name }}-${{ steps.current-branch-suffix.outputs.value }}-${{ strategy.job-index }}
           path: './**/build/reports/'
 
   prepare-sonar-bundle:


### PR DESCRIPTION
When we upload the failures and we have a matrix, we need to make sure that the artifact name is unique.

This commmit will add an index suffix based on the current execution of
the matrix.