### PR TITLE
[4.4] Collect executionData for Jacoco only when needed

### DIFF
--- a/reporting/build.gradle
+++ b/reporting/build.gradle
@@ -13,9 +13,9 @@ ext {
 }
 
 tasks.register('mergeCodeCoverageReport', JacocoReport) {
-    executionData fileTree(rootProject.layout.projectDirectory.asFile).include("**/build/jacoco/*.exec")
     parent.subprojects.each { Project subProject ->
         if ( project.projectsToIncludeWhenAggregatingCoverage.contains( subProject.name ) ) {
+            executionData fileTree( subProject.layout.buildDirectory.asFile ).include( "jacoco/*.exec" )
             sourceSets  subProject.sourceSets.main
         }
     }


### PR DESCRIPTION
We enable Jacoco only for some modules, but we were trying to collect the data for every module causing the job to fail on GitHub.