### PR TITLE
[4.3] Use Vert.x 5 Context local storage API

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/ContextualDataStorage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/ContextualDataStorage.java
@@ -1,0 +1,47 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.context.impl;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.hibernate.reactive.context.Context;
+
+import io.vertx.core.internal.VertxBootstrap;
+import io.vertx.core.spi.VertxServiceProvider;
+import io.vertx.core.spi.context.storage.ContextLocal;
+
+import static io.vertx.core.spi.context.storage.ContextLocal.registerLocal;
+
+/**
+ * SPI Implementation for {@link ContextLocal} storage.
+ */
+public class ContextualDataStorage implements VertxServiceProvider {
+
+	private static final ContextLocal<ConcurrentHashMap> CONTEXTUAL_DATA_KEY =
+			registerLocal( ConcurrentHashMap.class, ConcurrentHashMap::new );
+
+	@Override
+	public void init(VertxBootstrap builder) {
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> void put(io.vertx.core.Context vertxContext, Context.Key<T> key, T value) {
+		( (Map<Context.Key<T>, T>) vertxContext
+				.getLocal( CONTEXTUAL_DATA_KEY, ConcurrentHashMap::new ) )
+				.put( key, value );
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> T get(io.vertx.core.Context vertxContext, Context.Key<T> key) {
+		Map<Context.Key<T>, T> map = vertxContext.getLocal( CONTEXTUAL_DATA_KEY );
+		return map == null ? null : map.get( key );
+	}
+
+	public static boolean remove(io.vertx.core.Context vertxContext, Context.Key<?> key) {
+		var map = vertxContext.getLocal( CONTEXTUAL_DATA_KEY );
+		return map != null && map.remove( key ) != null;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/VertxContext.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/context/impl/VertxContext.java
@@ -6,15 +6,16 @@ package org.hibernate.reactive.context.impl;
 
 import java.lang.invoke.MethodHandles;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.internal.ContextInternal;
-
 import org.hibernate.reactive.context.Context;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.vertx.VertxInstance;
 import org.hibernate.service.spi.ServiceRegistryAwareService;
 import org.hibernate.service.spi.ServiceRegistryImplementor;
+
+import io.vertx.core.internal.ContextInternal;
+
+import static io.vertx.core.Vertx.currentContext;
 
 /**
  * An adaptor for the Vert.x {@link io.vertx.core.Context}.
@@ -35,10 +36,10 @@ public class VertxContext implements Context, ServiceRegistryAwareService {
 
 	@Override
 	public <T> void put(Key<T> key, T instance) {
-		final ContextInternal context = currentContext();
+		final io.vertx.core.Context context = currentContext();
 		if ( context != null ) {
 			if ( trace ) LOG.tracef( "Putting key,value in context: [%1$s, %2$s]", key, instance );
-			context.putLocal( key, instance );
+			ContextualDataStorage.put( context, key, instance );
 		}
 		else {
 			if ( trace ) LOG.tracef( "Context is null for key,value: [%1$s, %2$s]", key, instance  );
@@ -46,15 +47,11 @@ public class VertxContext implements Context, ServiceRegistryAwareService {
 		}
 	}
 
-	private static ContextInternal currentContext() {
-		return (ContextInternal) Vertx.currentContext();
-	}
-
 	@Override
 	public <T> T get(Key<T> key) {
-		final ContextInternal context = currentContext();
+		final io.vertx.core.Context context = currentContext();
 		if ( context != null ) {
-			T local = context.getLocal( key );
+			T local = ContextualDataStorage.get( context, key );
 			if ( trace ) LOG.tracef( "Getting value %2$s from context for key %1$s", key, local  );
 			return local;
 		}
@@ -66,9 +63,9 @@ public class VertxContext implements Context, ServiceRegistryAwareService {
 
 	@Override
 	public void remove(Key<?> key) {
-		final ContextInternal context = currentContext();
+		final io.vertx.core.Context context = currentContext();
 		if ( context != null ) {
-			boolean removed = context.removeLocal( key );
+			boolean removed = ContextualDataStorage.remove( context, key );
 			if ( trace ) LOG.tracef( "Key %s removed from context: %s", key, removed );
 		}
 		else {

--- a/hibernate-reactive-core/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
+++ b/hibernate-reactive-core/src/main/resources/META-INF/services/io.vertx.core.spi.VertxServiceProvider
@@ -1,0 +1,1 @@
+org.hibernate.reactive.context.impl.ContextualDataStorage


### PR DESCRIPTION
When we upgraded to Vert.x 5 we couldn't use the API because Quarkus wasn't ready.

For more details, check the description on issue #3793