### PR TITLE
[4.3] Wrap IOException in HibernateException when connection is refused

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/logging/impl/Log.java
@@ -282,6 +282,9 @@ public interface Log extends BasicLogger {
 	@Message(id = 89, value = "Connection is closed")
 	IllegalStateException connectionIsClosed();
 
+	@Message(id = 92, value = "Unable to open a connection to the database")
+	HibernateException unableToOpenConnection(@Cause Throwable cause);
+
 	@Message(id = 90, value = "Live transaction detected while closing the connection: it will be roll backed")
 	IllegalStateException liveTransactionDetectedOnClose();
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -4,6 +4,7 @@
  */
 package org.hibernate.reactive.pool.impl;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
 import java.sql.ResultSet;
@@ -57,6 +58,8 @@ import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
  * @see ExternalSqlClientPool the implementation used in Quarkus
  */
 public abstract class SqlClientPool implements ReactiveConnectionPool {
+
+	private static final Log LOG = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	/**
 	 * @return the underlying Vert.x {@link Pool} for the current context.
@@ -131,7 +134,7 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 		return completeFuture(
 				pool.getConnection().map( this::newConnection ),
 				ReactiveConnection::close
-		);
+		).handle( SqlClientPool::convertConnectionException );
 	}
 
 	private CompletionStage<ReactiveConnection> getConnectionFromPool(Pool pool, SqlExceptionHelper sqlExceptionHelper) {
@@ -139,7 +142,17 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 				pool.getConnection()
 						.map( sqlConnection -> newConnection( sqlConnection, sqlExceptionHelper ) ),
 				ReactiveConnection::close
-		);
+		).handle( SqlClientPool::convertConnectionException );
+	}
+
+	private static <T> T convertConnectionException(T result, Throwable throwable) {
+		if ( throwable == null ) {
+			return result;
+		}
+		if ( throwable instanceof IOException || throwable.getCause() instanceof IOException ) {
+			throw LOG.unableToOpenConnection( throwable );
+		}
+		return rethrow( throwable );
 	}
 
 	/**

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/configuration/ReactiveConnectionPoolTest.java
@@ -9,6 +9,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.TimeUnit;
 
+import org.hibernate.HibernateException;
 import org.hibernate.engine.jdbc.internal.JdbcServicesImpl;
 import org.hibernate.engine.jdbc.spi.JdbcServices;
 import org.hibernate.engine.jdbc.spi.SqlExceptionHelper;
@@ -112,6 +113,18 @@ public class ReactiveConnectionPoolTest {
 		ReactiveConnectionPool reactivePool = configureAndStartPool( config );
 		test( context, assertThrown( PgException.class, verifyConnectivity( reactivePool ) )
 				.thenAccept( e -> assertThat( e.getMessage() ).contains( "bogus" ) )
+		);
+	}
+
+	@Test
+	public void configureWithUnreachableDatabase(VertxTestContext context) {
+		String url = getJdbcUrl().replaceAll( ":\\d+/", ":19191/" );
+		Map<String, Object> config = new HashMap<>();
+		config.put( URL, url );
+		ReactiveConnectionPool reactivePool = configureAndStartPool( config );
+		test( context, assertThrown( HibernateException.class, reactivePool.getConnection() )
+				.thenAccept( e -> assertThat( e.getMessage() )
+						.startsWith( "HR000092:" ) )
 		);
 	}
 


### PR DESCRIPTION
Backport #3020 to `4.3`

When the database is unreachable, Vert.x throws an IOException (AnnotatedConnectException) which Quarkus REST silently logs at DEBUG level. Wrapping it in HibernateException ensures it is visible in production logs, consistent with how Hibernate ORM handles JDBC connection failures.

This should also fix https://github.com/quarkusio/quarkus/issues/34301