### PR TITLE
[4.5] Capture errors with  SqlConnection#exceptionHandler

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -22,6 +22,7 @@ import org.hibernate.reactive.logging.impl.LoggerFactory;
 import org.hibernate.reactive.pool.BatchingConnection;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.util.impl.CompletionStages;
+import org.hibernate.reactive.util.impl.CompletionStages.CompletionStageHandler;
 
 import io.vertx.core.internal.ContextInternal;
 import io.vertx.core.json.JsonArray;
@@ -39,7 +40,6 @@ import io.vertx.sqlclient.Tuple;
 import io.vertx.sqlclient.spi.DatabaseMetadata;
 
 import static org.hibernate.reactive.util.impl.CompletionStages.failedFuture;
-import static org.hibernate.reactive.util.impl.CompletionStages.rethrow;
 import static org.hibernate.reactive.util.impl.CompletionStages.supplyStage;
 import static org.hibernate.reactive.util.impl.CompletionStages.voidFuture;
 
@@ -67,6 +67,8 @@ public class SqlClientConnection implements ReactiveConnection {
 	// if we execute it every time, we will have several useless messages in the log
 	private boolean closed = false;
 
+	private Throwable connectionError;
+
 	SqlClientConnection(
 			SqlConnection connection,
 			Pool pool,
@@ -74,11 +76,25 @@ public class SqlClientConnection implements ReactiveConnection {
 			SqlExceptionHelper sqlExceptionHelper,
 			ContextInternal connectionContext) {
 		this.connectionContext = connectionContext;
+		this.connection = connection;
+		this.connection.exceptionHandler( this::onConnectionError );
 		this.pool = pool;
 		this.sqlStatementLogger = sqlStatementLogger;
-		this.connection = connection;
 		this.sqlExceptionHelper = sqlExceptionHelper;
 		LOG.tracef( "Connection created for %1$s associated to context %2$s: ", connection, connectionContext );
+	}
+
+	private void onConnectionError(Throwable throwable) {
+		if ( connectionError == null ) {
+			// This is the original cause of the error, the one we are interested
+			LOG.tracef( "Connection error received for %s: %s", connection, throwable.getMessage() );
+			connectionError = throwable;
+		}
+		else {
+			// Subsequent errors are probably caused by the first one, I think we can skip them
+			// I'm not sure if this is actually something that can happen
+			LOG.tracef( "The connection has already failed, ignoring error %s", connection, throwable.getMessage() );
+		}
 	}
 
 	@Override
@@ -117,7 +133,8 @@ public class SqlClientConnection implements ReactiveConnection {
 	public <T> CompletionStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass) {
 		translateNulls( paramValues );
 		return preparedQuery( sql, Tuple.wrap( paramValues ) )
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) )
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) )
 				.thenApply( rowSet -> {
 					for ( Row row : rowSet ) {
 						return row.get( idClass, 0 );
@@ -162,22 +179,30 @@ public class SqlClientConnection implements ReactiveConnection {
 	public CompletionStage<Void> executeUnprepared(String sql) {
 		feedback( sql );
 		return client().query( sql ).execute().toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) )
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) )
 				.thenCompose( CompletionStages::voidFuture );
+	}
+
+	private <T> CompletionStage<T> convertException(String sql, CompletionStageHandler<T, Throwable> handler) {
+		if ( handler.hasFailed() ) {
+			return failedFuture( convertException( sql, handler.getThrowable() ) );
+		}
+		return handler.getResultAsCompletionStage();
 	}
 
 	/**
 	 * Similar to {@link org.hibernate.exception.internal.SQLExceptionTypeDelegate#convert(SQLException, String, String)}
 	 */
-	private <T> T convertException(T rows, String sql, Throwable sqlException) {
-		if ( sqlException == null ) {
-			return rows;
-		}
+	private Throwable convertException(String sql, Throwable sqlException) {
 		if ( sqlException instanceof DatabaseException de ) {
-			sqlException = sqlExceptionHelper
+			return sqlExceptionHelper
 					.convert( new SQLException( de.getMessage(), de.getSqlState(), de.getErrorCode() ), "error executing SQL statement", sql );
 		}
-		return rethrow( sqlException );
+		if ( connectionError != null ) {
+			return connectionError;
+		}
+		return sqlException;
 	}
 
 	@Override
@@ -322,31 +347,39 @@ public class SqlClientConnection implements ReactiveConnection {
 	public CompletionStage<RowSet<Row>> preparedQuery(String sql, Tuple parameters) {
 		feedback( sql );
 		return client().preparedQuery( sql ).execute( parameters ).toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) );
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) );
 	}
 
 	public CompletionStage<RowSet<Row>> preparedQuery(String sql, Tuple parameters, PrepareOptions options) {
 		feedback( sql );
 		return client().preparedQuery( sql, options ).execute( parameters ).toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) );
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) );
+
 	}
 
 	public CompletionStage<RowSet<Row>> preparedQueryBatch(String sql, List<Tuple> parameters) {
 		feedback( sql );
 		return client().preparedQuery( sql ).executeBatch( parameters ).toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) );
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) );
+
 	}
 
 	public CompletionStage<RowSet<Row>> preparedQuery(String sql) {
 		feedback( sql );
 		return client().preparedQuery( sql ).execute().toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) );
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) );
+
 	}
 
 	public CompletionStage<RowSet<Row>> preparedQueryOutsideTransaction(String sql) {
 		feedback( sql );
 		return pool.preparedQuery( sql ).execute().toCompletionStage()
-				.handle( (rows, throwable) -> convertException( rows, sql, throwable ) );
+				.handle( CompletionStages::handle )
+				.thenCompose( handler -> convertException( sql, handler ) );
 	}
 
 	private void feedback(String sql) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateTest.java
@@ -24,6 +24,7 @@ import io.vertx.junit5.Timeout;
 import io.vertx.junit5.VertxTestContext;
 
 import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hibernate.cfg.SchemaToolingSettings.HBM2DDL_JDBC_METADATA_EXTRACTOR_STRATEGY;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.DB2;
 import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.SQLSERVER;
@@ -87,13 +88,18 @@ public class SchemaUpdateTest extends BaseReactiveTest {
 	@MethodSource("settings")
 	@Timeout(value = 10, timeUnit = MINUTES)
 	public void testMissingColumnsCreation(final String strategy, final String type, VertxTestContext context) {
-		assertTest(
-				type, context, () -> setupSessionFactory( constructConfiguration( "drop", strategy, type ) )
-						.thenCompose( v -> getSessionFactory().withTransaction( SchemaUpdateTest::createTable ) )
-						.whenComplete( (u, throwable) -> factoryManager.stop() )
-						.thenCompose( vv -> setupSessionFactory( constructConfiguration( "update", strategy, type ) ) )
-						.thenCompose( u -> getSessionFactory().withSession( SchemaUpdateTest::checkAllColumnsExist ) )
-		);
+		final Supplier<CompletionStage<?>> testSupplier = () -> setupSessionFactory( constructConfiguration( "drop", strategy, type ) )
+				.thenCompose( v -> getSessionFactory().withTransaction( SchemaUpdateTest::createTable ) )
+				.whenComplete( (u, throwable) -> factoryManager.stop() )
+				.thenCompose( vv -> setupSessionFactory( constructConfiguration( "update", strategy, type ) ) )
+				.thenCompose( u -> getSessionFactory().withSession( SchemaUpdateTest::checkAllColumnsExist ) );
+		if ( dbType() == SQLSERVER && type == null ) {
+			test( context, assertThrown( HibernateException.class, testSupplier.get() )
+						  .thenAccept( e -> assertThat( e.getMessage() ).startsWith( "HR000081: " ) ) );
+		}
+		else {
+			test( context, testSupplier.get() );
+		}
 	}
 
 	/**
@@ -103,22 +109,13 @@ public class SchemaUpdateTest extends BaseReactiveTest {
 	@MethodSource("settings")
 	@Timeout(value = 10, timeUnit = MINUTES)
 	public void testWholeTableCreation(final String strategy, final String type, VertxTestContext context) {
-		assertTest(
-				type, context, () -> setupSessionFactory( constructConfiguration( "drop", strategy, type ) )
-						.whenComplete( (u, throwable) -> factoryManager.stop() )
-						.thenCompose( v -> setupSessionFactory( constructConfiguration( "update", strategy, type ) )
-								.thenCompose( vv -> getSessionFactory().withSession( SchemaUpdateTest::checkAllColumnsExist ) ) )
-		);
-	}
-
-	// MSSQL does not support some operations, so we need to deal with it
-	private static void assertTest(String type, VertxTestContext context, Supplier<CompletionStage<?>> testSupplier) {
+		final Supplier<CompletionStage<?>> testSupplier = () -> setupSessionFactory( constructConfiguration( "drop", strategy, type ) )
+				.whenComplete( (u, throwable) -> factoryManager.stop() )
+				.thenCompose( v -> setupSessionFactory( constructConfiguration( "update", strategy, type ) )
+						.thenCompose( vv -> getSessionFactory().withSession( SchemaUpdateTest::checkAllColumnsExist ) ) );
 		if ( dbType() == SQLSERVER && type == null ) {
 			test( context, assertThrown( HibernateException.class, testSupplier.get() )
-					// Because of an issue in Vert.x SQL client, we cannot infer the reason of the error.
-					// See https://github.com/eclipse-vertx/vertx-sql-client/issues/1672
-					//.thenAccept( e -> assertThat( e.getMessage() ).startsWith( "HR000081: " ) )
-			);
+					.thenAccept( e -> assertThat( e.getMessage() ).startsWith( "HR000081: " ) ) );
 		}
 		else {
 			test( context, testSupplier.get() );


### PR DESCRIPTION
Starting with Vert.x 5.1.0, connection-level exceptions (such as UnsupportedOperationException for unsupported data types like XML in MSSQL) are no longer propagated through the query result. Instead, only a ClosedConnectionException reaches the caller, hiding the root cause. The original exception is now reported via
SqlConnection#exceptionHandler.

Register an exceptionHandler on the SqlConnection to capture these errors and substitute them when a query fails with an opaque connection-closed exception, restoring the previous behavior.