### PR TITLE
[4.5] Add .currentTransaction method

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/Mutiny.java
@@ -1553,7 +1553,10 @@ public interface Mutiny {
 		 * if any.
 		 *
 		 * @return the {@link Transaction}, or null if no transaction
-		 * was started using {@link #withTransaction(Function)}.
+		 * is active. Returns a non-null value both when a transaction
+		 * was started via {@link #withTransaction(Function)} and when
+		 * a transaction was started externally on the underlying
+		 * connection (for example, by a framework-level connection pool).
 		 *
 		 * @see #withTransaction(Function)
 		 * @see SessionFactory#withTransaction(BiFunction)
@@ -1941,7 +1944,10 @@ public interface Mutiny {
 		 * if any.
 		 *
 		 * @return the {@link Transaction}, or null if no transaction
-		 * was started using {@link #withTransaction(Function)}.
+		 * is active. Returns a non-null value both when a transaction
+		 * was started via {@link #withTransaction(Function)} and when
+		 * a transaction was started externally on the underlying
+		 * connection (for example, by a framework-level connection pool).
 		 *
 		 * @see #withTransaction(Function)
 		 * @see SessionFactory#withTransaction(BiFunction)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -24,6 +24,8 @@ import org.hibernate.reactive.query.ReactiveQuery;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.reactive.session.ReactiveQueryProducer;
 import org.hibernate.reactive.session.ReactiveSession;
+import org.hibernate.reactive.session.impl.CurrentTransaction;
+import org.hibernate.reactive.session.impl.ExecutableTransaction;
 
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.CacheRetrieveMode;
@@ -495,24 +497,29 @@ public class MutinySessionImpl implements Mutiny.Session {
 
 	@Override
 	public <T> Uni<T> withTransaction(Function<Mutiny.Transaction, Uni<T>> work) {
-		return currentTransaction == null
-				? new Transaction<T>().execute( work )
-				: work.apply( currentTransaction );
+		return transactionState().execute( work, InternalTransaction<T>::new );
 	}
 
-	private Transaction<?> currentTransaction;
+	private CurrentTransaction<Mutiny.Transaction> transactionState;
+
+	private CurrentTransaction<Mutiny.Transaction> transactionState() {
+		if ( transactionState == null ) {
+			transactionState = new CurrentTransaction<>( delegate.getReactiveConnection() );
+		}
+		return transactionState;
+	}
 
 	@Override
 	public Mutiny.Transaction currentTransaction() {
-		return currentTransaction;
+		return transactionState().get();
 	}
 
-	private class Transaction<T> implements Mutiny.Transaction {
+	private class InternalTransaction<R> implements Mutiny.Transaction, ExecutableTransaction<Mutiny.Transaction, Uni<R>> {
 		boolean markedForRollback;
 
-		Uni<T> execute(Function<Mutiny.Transaction, Uni<T>> work) {
-			currentTransaction = this;
-			return begin().chain( () -> executeInTransaction( work ) ).eventually( () -> currentTransaction = null );
+		@Override
+		public Uni<R> execute(Function<Mutiny.Transaction, Uni<R>> work, Runnable cleanup) {
+			return begin().chain( () -> executeInTransaction( work ) ).eventually( cleanup );
 		}
 
 		/**
@@ -520,7 +527,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 		 * differentiate an error starting a transaction (and therefore doesn't need to
 		 * roll back) and an error thrown by the work.
 		 */
-		Uni<T> executeInTransaction(Function<Mutiny.Transaction, Uni<T>> work) {
+		Uni<R> executeInTransaction(Function<Mutiny.Transaction, Uni<R>> work) {
 			return Uni.createFrom()
 					.deferred( () -> work.apply( this ) )
 					// only flush() if the work completed with no exception

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinyStatelessSessionImpl.java
@@ -15,6 +15,8 @@ import org.hibernate.reactive.mutiny.Mutiny.SelectionQuery;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.query.ReactiveQuery;
 import org.hibernate.reactive.session.ReactiveStatelessSession;
+import org.hibernate.reactive.session.impl.CurrentTransaction;
+import org.hibernate.reactive.session.impl.ExecutableTransaction;
 
 import io.smallrye.mutiny.Uni;
 import jakarta.persistence.EntityGraph;
@@ -291,28 +293,31 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 
 	@Override
 	public <T> Uni<T> withTransaction(Function<Mutiny.Transaction, Uni<T>> work) {
-		return currentTransaction == null ? new Transaction<T>().execute( work ) : work.apply( currentTransaction );
+		return transactionState().execute( work, InternalTransaction<T>::new );
 	}
 
-	private Transaction<?> currentTransaction;
+	private CurrentTransaction<Mutiny.Transaction> transactionState;
+
+	private CurrentTransaction<Mutiny.Transaction> transactionState() {
+		if ( transactionState == null ) {
+			transactionState = new CurrentTransaction<>( delegate.getReactiveConnection() );
+		}
+		return transactionState;
+	}
 
 	@Override
 	public Mutiny.Transaction currentTransaction() {
-		return currentTransaction;
+		return transactionState().get();
 	}
 
-	private class Transaction<T> implements Mutiny.Transaction {
+	private class InternalTransaction<R> implements Mutiny.Transaction, ExecutableTransaction<Mutiny.Transaction, Uni<R>> {
 		boolean rollback;
 
-		/**
-		 * Execute the given work in a new transaction. Called only
-		 * when no existing transaction was active.
-		 */
-		Uni<T> execute(Function<Mutiny.Transaction, Uni<T>> work) {
-			currentTransaction = this;
+		@Override
+		public Uni<R> execute(Function<Mutiny.Transaction, Uni<R>> work, Runnable cleanup) {
 			return begin()
 					.chain( () -> executeInTransaction( work ) )
-					.eventually( () -> currentTransaction = null );
+					.eventually( cleanup );
 		}
 
 		/**
@@ -321,7 +326,7 @@ public class MutinyStatelessSessionImpl implements Mutiny.StatelessSession {
 		 * (which therefore does not need to trigger rollback) from an
 		 * error thrown by the work (which does).
 		 */
-		Uni<T> executeInTransaction(Function<Mutiny.Transaction, Uni<T>> work) {
+		Uni<R> executeInTransaction(Function<Mutiny.Transaction, Uni<R>> work) {
 			return Uni.createFrom().deferred( () -> work.apply( this ) )
 					// in the case of an exception or cancellation
 					// we need to roll back the transaction

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/BatchingConnection.java
@@ -57,6 +57,11 @@ public class BatchingConnection implements ReactiveConnection {
 	}
 
 	@Override
+	public Object currentTransactionId() {
+		return delegate.currentTransactionId();
+	}
+
+	@Override
 	public ReactiveConnection withBatchSize(int batchSize) {
 		if ( batchSize <= 1 ) {
 			return delegate;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/ReactiveConnection.java
@@ -31,6 +31,21 @@ public interface ReactiveConnection {
 
 	boolean isTransactionInProgress();
 
+	/**
+	 * Returns an opaque identifier for the current transaction, or {@code null}
+	 * if no transaction is in progress. The returned object must have stable
+	 * identity ({@code ==}) for the lifetime of a single transaction, and must
+	 * differ (by identity) across distinct transactions on the same connection.
+	 * <p>
+	 * This is used by {@link org.hibernate.reactive.session.impl.CurrentTransaction}
+	 * to detect when the underlying connection has cycled to a new external
+	 * transaction, so that cached state (e.g. {@code markedForRollback}) is
+	 * not carried over from a previous transaction.
+	 */
+	default Object currentTransactionId() {
+		return null;
+	}
+
 	@FunctionalInterface
 	interface Expectation {
 		void verifyOutcome(int rowCount, int batchPosition, String sql);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientConnection.java
@@ -108,6 +108,13 @@ public class SqlClientConnection implements ReactiveConnection {
 	}
 
 	@Override
+	public Object currentTransactionId() {
+		// The Vert.x Transaction object has stable identity for a given
+		// transaction and changes when a new transaction is started.
+		return connection.transaction();
+	}
+
+	@Override
 	public CompletionStage<Integer> update(String sql, Object[] paramValues) {
 		translateNulls( paramValues );
 		return update( sql, Tuple.wrap( paramValues ) );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/pool/impl/SqlClientPool.java
@@ -296,6 +296,12 @@ public abstract class SqlClientPool implements ReactiveConnectionPool {
 		}
 
 		@Override
+		public Object currentTransactionId() {
+			ReactiveConnection reactiveConnection = connectionFuture.getNow( null );
+			return reactiveConnection != null ? reactiveConnection.currentTransactionId() : null;
+		}
+
+		@Override
 		public DatabaseMetadata getDatabaseMetadata() {
 			if ( closed ) {
 				throw LOG.connectionIsClosed();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/CurrentTransaction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/CurrentTransaction.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.session.impl;
+
+import org.hibernate.reactive.pool.ReactiveConnection;
+
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+/**
+ * Holds the current transaction state for a session, tracking both internally-opened
+ * transactions (via {@code withTransaction()}) and externally-opened transactions
+ * (started on the underlying connection by a framework-level pool).
+ *
+ * @param <T> the transaction interface type ({@link org.hibernate.reactive.mutiny.Mutiny.Transaction}
+ *            or {@link org.hibernate.reactive.stage.Stage.Transaction})
+ */
+public class CurrentTransaction<T> {
+
+	private final ReactiveConnection connection;
+	private T internalTransaction;
+
+	/**
+	 * Cached {@link ExternalTransaction} wrapper. The wrapper captures
+	 * the opaque transaction identity at creation time (see
+	 * {@link ExternalTransaction#transactionId()}), so repeated calls
+	 * return the same instance within a single external transaction
+	 * while still detecting when the connection has cycled to a new
+	 * transaction and creating a fresh wrapper.
+	 *
+	 * @see ReactiveConnection#currentTransactionId()
+	 */
+	private ExternalTransaction externalTransaction;
+
+	public CurrentTransaction(ReactiveConnection connection) {
+		this.connection = connection;
+	}
+
+	/**
+	 * Returns the active transaction, if any. Checks the internally-opened
+	 * transaction first, then falls back to detecting an externally-opened
+	 * transaction on the underlying connection.
+	 * <p>
+	 * The {@link ExternalTransaction} instance is cached so that repeated
+	 * calls return the same object while the external transaction is active.
+	 * If the underlying transaction identity has changed (the connection
+	 * committed or rolled back and started a new transaction), a fresh
+	 * wrapper is created to avoid carrying stale state such as
+	 * {@code markedForRollback} from the previous transaction.
+	 *
+	 * @see ReactiveConnection#currentTransactionId()
+	 */
+	@SuppressWarnings("unchecked")
+	public T get() {
+		if ( internalTransaction != null ) {
+			return internalTransaction;
+		}
+		if ( connection.isTransactionInProgress() ) {
+			// Compare the current transaction identity with the one cached
+			// in the wrapper. If they differ, the connection has moved to a
+			// new transaction and we must create a fresh wrapper to avoid
+			// carrying stale markedForRollback state.
+			if ( externalTransaction == null
+					|| connection.currentTransactionId() != externalTransaction.transactionId() ) {
+				externalTransaction = new ExternalTransaction( connection );
+			}
+			return (T) externalTransaction;
+		}
+		// No transaction in progress — clear the cache
+		externalTransaction = null;
+		return null;
+	}
+
+	/**
+	 * If a transaction is already active (internal or external), joins it by
+	 * applying the work directly. Otherwise, creates a new internal transaction
+	 * via the factory and delegates to its {@link ExecutableTransaction#execute}
+	 * method, passing a cleanup callback to invoke when the transaction completes.
+	 *
+	 * @param work    the transactional work; applied directly when joining
+	 * @param factory creates the new {@link ExecutableTransaction}
+	 */
+	@SuppressWarnings("unchecked")
+	public <R> R execute(
+			Function<T, R> work,
+			Supplier<? extends ExecutableTransaction<T, R>> factory) {
+		T existing = get();
+		if ( existing != null ) {
+			return work.apply( existing );
+		}
+		ExecutableTransaction<T, R> tx = factory.get();
+		internalTransaction = (T) tx;
+		return tx.execute( work, this::clear );
+	}
+
+	private void clear() {
+		internalTransaction = null;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ExecutableTransaction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ExecutableTransaction.java
@@ -1,0 +1,21 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.session.impl;
+
+import java.util.function.Function;
+
+/**
+ * A transaction that can execute transactional work. Implemented by the
+ * inner {@code InternalTransaction} classes in each session implementation,
+ * allowing {@link CurrentTransaction#execute} to invoke the transaction
+ * without knowing its concrete type.
+ *
+ * @param <T> the transaction interface type ({@link org.hibernate.reactive.mutiny.Mutiny.Transaction}
+ *            or {@link org.hibernate.reactive.stage.Stage.Transaction})
+ * @param <R> the result type of the transactional work
+ */
+public interface ExecutableTransaction<T, R> {
+	R execute(Function<T, R> work, Runnable cleanup);
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ExternalTransaction.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ExternalTransaction.java
@@ -1,0 +1,56 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.session.impl;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.stage.Stage;
+
+/**
+ * Represents a transaction that was started externally (e.g., by a framework-level
+ * connection pool) rather than through {@link Mutiny.Session#withTransaction} or
+ * {@link Stage.Session#withTransaction}. Returned by {@code currentTransaction()}
+ * when the underlying connection has an active transaction that was not initiated
+ * by this session.
+ * <p>
+ * The {@link #markForRollback()} flag is informational: the external transaction
+ * owner is responsible for the actual commit/rollback lifecycle.
+ */
+public class ExternalTransaction implements Mutiny.Transaction, Stage.Transaction {
+
+	private final ReactiveConnection connection;
+	private final Object transactionId;
+	private boolean markedForRollback;
+
+	public ExternalTransaction(ReactiveConnection connection) {
+		this.connection = connection;
+		this.transactionId = connection.currentTransactionId();
+	}
+
+	public boolean isTransactionInProgress() {
+		return connection.isTransactionInProgress();
+	}
+
+	/**
+	 * The opaque transaction identity captured when this wrapper was created.
+	 * Used by {@link CurrentTransaction} to detect when the connection has
+	 * cycled to a new transaction.
+	 *
+	 * @see ReactiveConnection#currentTransactionId()
+	 */
+	Object transactionId() {
+		return transactionId;
+	}
+
+	@Override
+	public void markForRollback() {
+		markedForRollback = true;
+	}
+
+	@Override
+	public boolean isMarkedForRollback() {
+		return markedForRollback;
+	}
+}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/Stage.java
@@ -1518,7 +1518,10 @@ public interface Stage {
 		 * if any.
 		 *
 		 * @return the {@link Transaction}, or null if no transaction
-		 * was started using {@link #withTransaction(Function)}.
+		 * is active. Returns a non-null value both when a transaction
+		 * was started via {@link #withTransaction(Function)} and when
+		 * a transaction was started externally on the underlying
+		 * connection (for example, by a framework-level connection pool).
 		 *
 		 * @see #withTransaction(Function)
 		 * @see SessionFactory#withTransaction(BiFunction)
@@ -1931,7 +1934,10 @@ public interface Stage {
 		 * if any.
 		 *
 		 * @return the {@link Transaction}, or null if no transaction
-		 * was started using {@link #withTransaction(Function)}.
+		 * is active. Returns a non-null value both when a transaction
+		 * was started via {@link #withTransaction(Function)} and when
+		 * a transaction was started externally on the underlying
+		 * connection (for example, by a framework-level connection pool).
 		 *
 		 * @see #withTransaction(Function)
 		 * @see SessionFactory#withTransaction(BiFunction)

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageSessionImpl.java
@@ -23,6 +23,8 @@ import org.hibernate.reactive.query.ReactiveQuery;
 import org.hibernate.reactive.session.ReactiveConnectionSupplier;
 import org.hibernate.reactive.session.ReactiveQueryProducer;
 import org.hibernate.reactive.session.ReactiveSession;
+import org.hibernate.reactive.session.impl.CurrentTransaction;
+import org.hibernate.reactive.session.impl.ExecutableTransaction;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.Stage.MutationQuery;
 import org.hibernate.reactive.stage.Stage.Query;
@@ -395,25 +397,32 @@ public class StageSessionImpl implements Stage.Session {
 
 	@Override
 	public <T> CompletionStage<T> withTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
-		return currentTransaction == null ? new Transaction<T>().execute( work ) : work.apply( currentTransaction );
+		return transactionState().execute( work, InternalTransaction<T>::new );
 	}
 
-	private Transaction<?> currentTransaction;
+	private CurrentTransaction<Stage.Transaction> transactionState;
+
+	private CurrentTransaction<Stage.Transaction> transactionState() {
+		if ( transactionState == null ) {
+			transactionState = new CurrentTransaction<>( delegate.getReactiveConnection() );
+		}
+		return transactionState;
+	}
 
 	@Override
 	public Stage.Transaction currentTransaction() {
-		return currentTransaction;
+		return transactionState().get();
 	}
 
-	private class Transaction<T> implements Stage.Transaction {
+	private class InternalTransaction<R> implements Stage.Transaction, ExecutableTransaction<Stage.Transaction, CompletionStage<R>> {
 		boolean rollback;
 		Throwable error;
 
-		CompletionStage<T> execute(Function<Stage.Transaction, CompletionStage<T>> work) {
-			currentTransaction = this;
+		@Override
+		public CompletionStage<R> execute(Function<Stage.Transaction, CompletionStage<R>> work, Runnable cleanup) {
 			return begin()
 					.thenCompose( v -> executeInTransaction( work ) )
-					.whenComplete( (t, x) -> currentTransaction = null );
+					.whenComplete( (t, x) -> cleanup.run() );
 		}
 
 		/**
@@ -421,7 +430,7 @@ public class StageSessionImpl implements Stage.Session {
 		 * differentiate an error starting a transaction (and therefore doesn't need to
 		 * roll back) and an error thrown by the work.
 		 */
-		CompletionStage<T> executeInTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
+		CompletionStage<R> executeInTransaction(Function<Stage.Transaction, CompletionStage<R>> work) {
 			return voidFuture().thenCompose( v -> work.apply( this ) )
 					// only flush() if the work completed with no exception
 					.thenCompose( result -> flush().thenApply( v -> result ) )
@@ -438,7 +447,6 @@ public class StageSessionImpl implements Stage.Session {
 							// finally, rethrow the original error, if any
 							.thenApply( v -> returnOrRethrow( error, result ) )
 					);
-
 		}
 
 		CompletionStage<Void> flush() {
@@ -457,14 +465,14 @@ public class StageSessionImpl implements Stage.Session {
 					.thenCompose( v -> actionQueue.afterTransactionCompletion( !rollback ) );
 		}
 
-		<R> R processError(R result, Throwable e) {
-			if ( e!=null ) {
+		<E> E processError(E result, Throwable e) {
+			if ( e != null ) {
 				rollback = true;
-				if (error == null) {
+				if ( error == null ) {
 					error = e;
 				}
 				else {
-					error.addSuppressed(e);
+					error.addSuppressed( e );
 				}
 			}
 			return result;

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/stage/impl/StageStatelessSessionImpl.java
@@ -12,6 +12,8 @@ import org.hibernate.reactive.common.ResultSetMapping;
 import org.hibernate.reactive.pool.ReactiveConnection;
 import org.hibernate.reactive.query.ReactiveQuery;
 import org.hibernate.reactive.session.ReactiveStatelessSession;
+import org.hibernate.reactive.session.impl.CurrentTransaction;
+import org.hibernate.reactive.session.impl.ExecutableTransaction;
 import org.hibernate.reactive.stage.Stage;
 import org.hibernate.reactive.stage.Stage.MutationQuery;
 import org.hibernate.reactive.stage.Stage.Query;
@@ -190,9 +192,7 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 
 	@Override
 	public <T> CompletionStage<T> withTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
-		return currentTransaction == null
-				? new Transaction<T>().execute( work )
-				: work.apply( currentTransaction );
+		return transactionState().execute( work, InternalTransaction<T>::new );
 	}
 
 	@Override
@@ -217,22 +217,29 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 		return getFactory().getCriteriaBuilder();
 	}
 
-	private Transaction<?> currentTransaction;
+	private CurrentTransaction<Stage.Transaction> transactionState;
+
+	private CurrentTransaction<Stage.Transaction> transactionState() {
+		if ( transactionState == null ) {
+			transactionState = new CurrentTransaction<>( delegate.getReactiveConnection() );
+		}
+		return transactionState;
+	}
 
 	@Override
 	public Stage.Transaction currentTransaction() {
-		return currentTransaction;
+		return transactionState().get();
 	}
 
-	private class Transaction<T> implements Stage.Transaction {
+	private class InternalTransaction<R> implements Stage.Transaction, ExecutableTransaction<Stage.Transaction, CompletionStage<R>> {
 		boolean rollback;
 		Throwable error;
 
-		CompletionStage<T> execute(Function<Stage.Transaction, CompletionStage<T>> work) {
-			currentTransaction = this;
+		@Override
+		public CompletionStage<R> execute(Function<Stage.Transaction, CompletionStage<R>> work, Runnable cleanup) {
 			return begin()
 					.thenCompose( v -> executeInTransaction( work ) )
-					.whenComplete( (t, x) -> currentTransaction = null );
+					.whenComplete( (t, x) -> cleanup.run() );
 		}
 
 		/**
@@ -240,7 +247,7 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 		 * differentiate an error starting a transaction (and therefore doesn't need to rollback)
 		 * and an error thrown by the work.
 		 */
-		CompletionStage<T> executeInTransaction(Function<Stage.Transaction, CompletionStage<T>> work) {
+		CompletionStage<R> executeInTransaction(Function<Stage.Transaction, CompletionStage<R>> work) {
 			return voidFuture()
 					.thenCompose( v -> work.apply( this ) )
 					// have to capture the error here and pass it along,
@@ -267,7 +274,7 @@ public class StageStatelessSessionImpl implements Stage.StatelessSession {
 			return rollback ? c.rollbackTransaction() : c.commitTransaction();
 		}
 
-		<R> R processError(R result, Throwable e) {
+		<E> E processError(E result, Throwable e) {
 			if ( e != null ) {
 				rollback = true;
 				if ( error == null ) {

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ExternalTransactionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/ExternalTransactionTest.java
@@ -1,0 +1,316 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.mutiny.impl.MutinySessionImpl;
+import org.hibernate.reactive.pool.ReactiveConnection;
+import org.hibernate.reactive.session.impl.ExternalTransaction;
+import org.hibernate.reactive.stage.Stage;
+import org.hibernate.reactive.stage.impl.StageSessionImpl;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Tests that {@code currentTransaction()} and {@code withTransaction()} correctly
+ * detect and join transactions that were opened externally on the underlying
+ * connection (e.g., by a framework-level connection pool), rather than through
+ * the session's own {@code withTransaction()} method.
+ *
+ * @see <a href="https://github.com/hibernate/hibernate-reactive/issues/2852">#2852</a>
+ */
+@Timeout(value = 10, timeUnit = MINUTES)
+public class ExternalTransactionTest extends BaseReactiveTest {
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( Thing.class );
+	}
+
+	@Test
+	public void testMutinyCurrentTransactionDetectsExternalTransaction(VertxTestContext context) {
+		test(
+				context, getMutinySessionFactory()
+						.openSession()
+						.chain( session -> {
+							assertThat( session.currentTransaction() )
+									.as( "No transaction should be active before begin" )
+									.isNull();
+
+							ReactiveConnection connection = ( (MutinySessionImpl) session ).getReactiveConnection();
+							return Uni.createFrom().completionStage( connection.beginTransaction() )
+									.invoke( () -> {
+										Mutiny.Transaction tx = session.currentTransaction();
+										assertThat( tx )
+												.as( "currentTransaction() should detect externally-opened transaction" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+
+										assertThat( tx.isMarkedForRollback() ).isFalse();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+
+										Mutiny.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "ExternalTransaction should be returned" )
+												.isInstanceOf( ExternalTransaction.class );
+									} )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									.invoke( () -> assertThat( session.currentTransaction() )
+											.as( "currentTransaction() should return null after rollback" )
+											.isNull()
+									)
+									.chain( session::close );
+						} )
+		);
+	}
+
+	@Test
+	public void testStageCurrentTransactionDetectsExternalTransaction(VertxTestContext context) {
+		test(
+				context, getSessionFactory()
+						.openSession()
+						.thenCompose( session -> {
+							assertThat( session.currentTransaction() )
+									.as( "No transaction should be active before begin" )
+									.isNull();
+
+							ReactiveConnection connection = ( (StageSessionImpl) session ).getReactiveConnection();
+							return connection.beginTransaction()
+									.thenAccept( v -> {
+										Stage.Transaction tx = session.currentTransaction();
+										assertThat( tx )
+												.as( "currentTransaction() should detect externally-opened transaction" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+
+										assertThat( tx.isMarkedForRollback() ).isFalse();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+
+										Stage.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "ExternalTransaction should be returned" )
+												.isInstanceOf( ExternalTransaction.class );
+									} )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									.thenAccept( v -> assertThat( session.currentTransaction() )
+											.as( "currentTransaction() should return null after rollback" )
+											.isNull()
+									)
+									.thenCompose( v -> session.close() );
+						} )
+		);
+	}
+
+	@Test
+	public void testMutinyWithTransactionJoinsExternalTransaction(VertxTestContext context) {
+		test(
+				context, getMutinySessionFactory()
+						.openSession()
+						.chain( session -> {
+							ReactiveConnection connection = ( (MutinySessionImpl) session ).getReactiveConnection();
+							return Uni.createFrom().completionStage( connection.beginTransaction() )
+									.chain( () -> session.withTransaction( tx -> {
+										assertThat( tx )
+												.as( "withTransaction should join external transaction" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										return session
+												.createSelectionQuery( "from Thing", Thing.class )
+												.getResultList();
+									} ) )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									.chain( session::close );
+						} )
+		);
+	}
+
+	@Test
+	public void testStageWithTransactionJoinsExternalTransaction(VertxTestContext context) {
+		test(
+				context, getSessionFactory()
+						.openSession()
+						.thenCompose( session -> {
+							ReactiveConnection connection = ( (StageSessionImpl) session ).getReactiveConnection();
+							return connection.beginTransaction()
+									.thenCompose( v -> session.withTransaction( tx -> {
+										assertThat( tx )
+												.as( "withTransaction should join external transaction" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										return session
+												.createSelectionQuery( "from Thing", Thing.class )
+												.getResultList();
+									} ) )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									.thenCompose( v -> session.close() );
+						} )
+		);
+	}
+
+	@Test
+	public void testMutinyNewExternalTransactionResetsState(VertxTestContext context) {
+		test(
+				context, getMutinySessionFactory()
+						.openSession()
+						.chain( session -> {
+							ReactiveConnection connection = ( (MutinySessionImpl) session ).getReactiveConnection();
+							return Uni.createFrom().completionStage( connection.beginTransaction() )
+									.invoke( () -> {
+										Mutiny.Transaction tx = session.currentTransaction();
+										assertThat( tx ).isNotNull();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+									} )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									.invoke( () -> assertThat( session.currentTransaction() ).isNull() )
+									// Start a second external transaction on the same connection
+									.chain( () -> Uni.createFrom().completionStage( connection.beginTransaction() ) )
+									.invoke( () -> {
+										Mutiny.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "New external transaction should return a fresh instance" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										assertThat( tx2.isMarkedForRollback() )
+												.as( "Fresh ExternalTransaction should not carry stale rollback state" )
+												.isFalse();
+									} )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									.chain( session::close );
+						} )
+		);
+	}
+
+	@Test
+	public void testStageNewExternalTransactionResetsState(VertxTestContext context) {
+		test(
+				context, getSessionFactory()
+						.openSession()
+						.thenCompose( session -> {
+							ReactiveConnection connection = ( (StageSessionImpl) session ).getReactiveConnection();
+							return connection.beginTransaction()
+									.thenAccept( v -> {
+										Stage.Transaction tx = session.currentTransaction();
+										assertThat( tx ).isNotNull();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+									} )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									.thenAccept( v -> assertThat( session.currentTransaction() ).isNull() )
+									// Start a second external transaction on the same connection
+									.thenCompose( v -> connection.beginTransaction() )
+									.thenAccept( v -> {
+										Stage.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "New external transaction should return a fresh instance" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										assertThat( tx2.isMarkedForRollback() )
+												.as( "Fresh ExternalTransaction should not carry stale rollback state" )
+												.isFalse();
+									} )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									.thenCompose( v -> session.close() );
+						} )
+		);
+	}
+
+	@Test
+	public void testMutinyBackToBackExternalTransactionsResetState(VertxTestContext context) {
+		test(
+				context, getMutinySessionFactory()
+						.openSession()
+						.chain( session -> {
+							ReactiveConnection connection = ( (MutinySessionImpl) session ).getReactiveConnection();
+							return Uni.createFrom().completionStage( connection.beginTransaction() )
+									.invoke( () -> {
+										Mutiny.Transaction tx = session.currentTransaction();
+										assertThat( tx ).isNotNull();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+									} )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									// Start a second transaction WITHOUT calling currentTransaction() in between
+									.chain( () -> Uni.createFrom().completionStage( connection.beginTransaction() ) )
+									.invoke( () -> {
+										Mutiny.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "New external transaction should not carry stale rollback state" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										assertThat( tx2.isMarkedForRollback() )
+												.as( "Back-to-back external transaction must not inherit markedForRollback" )
+												.isFalse();
+									} )
+									.chain( () -> Uni.createFrom().completionStage( connection.rollbackTransaction() ) )
+									.chain( session::close );
+						} )
+		);
+	}
+
+	@Test
+	public void testStageBackToBackExternalTransactionsResetState(VertxTestContext context) {
+		test(
+				context, getSessionFactory()
+						.openSession()
+						.thenCompose( session -> {
+							ReactiveConnection connection = ( (StageSessionImpl) session ).getReactiveConnection();
+							return connection.beginTransaction()
+									.thenAccept( v -> {
+										Stage.Transaction tx = session.currentTransaction();
+										assertThat( tx ).isNotNull();
+										tx.markForRollback();
+										assertThat( tx.isMarkedForRollback() ).isTrue();
+									} )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									// Start a second transaction WITHOUT calling currentTransaction() in between
+									.thenCompose( v -> connection.beginTransaction() )
+									.thenAccept( v -> {
+										Stage.Transaction tx2 = session.currentTransaction();
+										assertThat( tx2 )
+												.as( "New external transaction should not carry stale rollback state" )
+												.isNotNull()
+												.isInstanceOf( ExternalTransaction.class );
+										assertThat( tx2.isMarkedForRollback() )
+												.as( "Back-to-back external transaction must not inherit markedForRollback" )
+												.isFalse();
+									} )
+									.thenCompose( v -> connection.rollbackTransaction() )
+									.thenCompose( v -> session.close() );
+						} )
+		);
+	}
+
+	@Entity(name = "Thing")
+	@Table(name = "external_tx_thing")
+	public static class Thing {
+		@Id
+		public Integer id;
+		public String name;
+
+		public Thing() {
+		}
+
+		public Thing(Integer id, String name) {
+			this.id = id;
+			this.name = name;
+		}
+	}
+}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/session/impl/ExternalTransactionTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/session/impl/ExternalTransactionTest.java
@@ -1,0 +1,232 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive.session.impl;
+
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.concurrent.CompletionStage;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.hibernate.reactive.mutiny.Mutiny;
+import org.hibernate.reactive.pool.ReactiveConnection;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.sqlclient.spi.DatabaseMetadata;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit tests for {@link ExternalTransaction}.
+ */
+public class ExternalTransactionTest {
+
+	@Test
+	public void testMarkForRollback() {
+		ExternalTransaction tx = new ExternalTransaction( stubConnection( true ) );
+		assertThat( tx.isMarkedForRollback() ).isFalse();
+		tx.markForRollback();
+		assertThat( tx.isMarkedForRollback() ).isTrue();
+	}
+
+	@Test
+	public void testIsTransactionInProgressDelegatesToConnection() {
+		AtomicBoolean inProgress = new AtomicBoolean( true );
+		ExternalTransaction tx = new ExternalTransaction( stubConnection( inProgress ) );
+
+		assertThat( tx.isTransactionInProgress() ).isTrue();
+
+		inProgress.set( false );
+		assertThat( tx.isTransactionInProgress() ).isFalse();
+	}
+
+	@Test
+	public void testNewInstanceIsNotMarkedForRollback() {
+		ExternalTransaction tx = new ExternalTransaction( stubConnection( true ) );
+		assertThat( tx.isMarkedForRollback() ).isFalse();
+	}
+
+	@Test
+	public void testCurrentTransactionCachesWithinSameTransaction() {
+		AtomicBoolean inProgress = new AtomicBoolean( true );
+		AtomicReference<Object> txId = new AtomicReference<>( new Object() );
+		ReactiveConnection conn = stubConnection( inProgress, txId );
+		CurrentTransaction<Mutiny.Transaction> ct = new CurrentTransaction<>( conn );
+
+		// Repeated calls within the same transaction should return the same instance
+		Mutiny.Transaction tx1 = ct.get();
+		Mutiny.Transaction tx2 = ct.get();
+		assertThat( tx1 ).isNotNull().isSameAs( tx2 );
+	}
+
+	@Test
+	public void testCurrentTransactionResetsOnTransactionChange() {
+		AtomicBoolean inProgress = new AtomicBoolean( true );
+		AtomicReference<Object> txId = new AtomicReference<>( new Object() );
+		ReactiveConnection conn = stubConnection( inProgress, txId );
+		CurrentTransaction<Mutiny.Transaction> ct = new CurrentTransaction<>( conn );
+
+		// First transaction: get a reference and mark it
+		Mutiny.Transaction tx1 = ct.get();
+		assertThat( tx1 ).isNotNull();
+		tx1.markForRollback();
+		assertThat( tx1.isMarkedForRollback() ).isTrue();
+
+		// Simulate commit + new begin: change the transaction identity
+		// without an intermediate call to get() while no tx is active
+		txId.set( new Object() );
+
+		// Second transaction: must be a fresh instance without stale state
+		Mutiny.Transaction tx2 = ct.get();
+		assertThat( tx2 )
+				.as( "Back-to-back transaction must return a new instance" )
+				.isNotNull()
+				.isNotSameAs( tx1 );
+		assertThat( tx2.isMarkedForRollback() )
+				.as( "New transaction must not inherit markedForRollback" )
+				.isFalse();
+	}
+
+	private static ReactiveConnection stubConnection(boolean transactionInProgress) {
+		return stubConnection(
+				new AtomicBoolean( transactionInProgress ),
+				new AtomicReference<>( transactionInProgress ? new Object() : null )
+		);
+	}
+
+	private static ReactiveConnection stubConnection(AtomicBoolean transactionInProgress) {
+		return stubConnection(
+				transactionInProgress,
+				new AtomicReference<>( transactionInProgress.get() ? new Object() : null )
+		);
+	}
+
+	private static ReactiveConnection stubConnection(AtomicBoolean transactionInProgress, AtomicReference<Object> txId) {
+		return new ReactiveConnection() {
+			@Override
+			public boolean isTransactionInProgress() {
+				return transactionInProgress.get();
+			}
+
+			@Override
+			public Object currentTransactionId() {
+				return txId.get();
+			}
+
+			@Override
+			public DatabaseMetadata getDatabaseMetadata() {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> execute(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> executeOutsideTransaction(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> executeUnprepared(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Integer> update(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Integer> update(String sql, Object[] paramValues) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> update(String sql, Object[] paramValues, boolean allowBatching, Expectation expectation) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<int[]> update(String sql, List<Object[]> paramValues) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Result> select(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Result> select(String sql, Object[] paramValues) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<ResultSet> selectJdbc(String sql, Object[] paramValues) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			@SuppressWarnings("deprecation")
+			public <T> CompletionStage<T> insertAndSelectIdentifier(String sql, Object[] paramValues, Class<T> idClass, String idColumnName) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			@SuppressWarnings("deprecation")
+			public CompletionStage<ResultSet> insertAndSelectIdentifierAsResultSet(String sql, Object[] paramValues, Class<?> idClass, String idColumnName) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<ResultSet> selectJdbc(String sql) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<ResultSet> executeAndSelectGeneratedValues(String sql, Object[] paramValues, List<Class<?>> idClass, List<String> generatedColumnName) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public <T> CompletionStage<T> selectIdentifier(String sql, Object[] paramValues, Class<T> idClass) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> beginTransaction() {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> commitTransaction() {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> rollbackTransaction() {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public ReactiveConnection withBatchSize(int batchSize) {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> executeBatch() {
+				throw new UnsupportedOperationException();
+			}
+
+			@Override
+			public CompletionStage<Void> close() {
+				throw new UnsupportedOperationException();
+			}
+		};
+	}
+}


### PR DESCRIPTION
Fix #2852 - It's a draft because I Want to test it with Quarkus and make sure that it actually solves the issue

Introduce CurrentTransaction holder that tracks both internally-opened
transactions (via withTransaction()) and externally-opened transactions
(started on the underlying connection by a framework-level pool such as
Quarkus's TransactionalContextPool).

When an external transaction is detected via
ReactiveConnection.isTransactionInProgress(), currentTransaction() now
returns an ExternalTransaction instead of null, and withTransaction()
joins the existing transaction instead of failing.