### PR TITLE
Assert custom @SQL* statements in CustomStoredProcedureSqlTest

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomStoredProcedureSqlTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/CustomStoredProcedureSqlTest.java
@@ -12,7 +12,10 @@ import org.hibernate.HibernateException;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.SQLInsert;
 import org.hibernate.annotations.SQLUpdate;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.cfg.Configuration;
 import org.hibernate.reactive.testing.ReactiveAssertions;
+import org.hibernate.reactive.testing.SqlStatementTracker;
 import org.hibernate.reactive.annotations.EnabledFor;
 
 import org.junit.jupiter.api.Assertions;
@@ -40,6 +43,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 
 	private SimpleRecord theRecord;
+
+	// Tracks the SQL statements emitted by Hibernate so that the tests can assert
+	// the custom @SQLInsert / @SQLUpdate / @SQLDelete queries are actually used.
+	// Static because BaseReactiveTest reuses one SessionFactory across test methods,
+	// so constructConfiguration() (which creates the tracker) runs only once per class.
+	private static SqlStatementTracker sqlTracker;
 
 	private static final String INITIAL_TEXT = "blue suede shoes";
 	private static final String UPDATED_TEXT = "ruby slippers";
@@ -83,10 +92,33 @@ public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 		return List.of( SimpleRecord.class );
 	}
 
+	@Override
+	protected Configuration constructConfiguration() {
+		Configuration configuration = super.constructConfiguration();
+		// Collect only the custom @SQL* calls (the "SELECT PROC_*" statements),
+		// excluding the "CREATE OR REPLACE FUNCTION" statements used to set up
+		// the stored procedures and any other framework-issued query.
+		sqlTracker = new SqlStatementTracker(
+				CustomStoredProcedureSqlTest::isCustomProcedureCall,
+				configuration.getProperties()
+		);
+		return configuration;
+	}
+
+	@Override
+	protected void addServices(StandardServiceRegistryBuilder builder) {
+		sqlTracker.registerService( builder );
+	}
+
+	private static boolean isCustomProcedureCall(String sql) {
+		return sql.toLowerCase().startsWith( "select proc_" );
+	}
+
 	@BeforeEach
 	public void populateDb(VertxTestContext context) {
 		theRecord = new SimpleRecord();
 		theRecord.text = INITIAL_TEXT;
+		sqlTracker.clear();
 
 		test( context, openSession()
 				.thenCompose( s -> s
@@ -117,9 +149,12 @@ public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 
 	@Test
 	public void testInsertStoredProcedure(VertxTestContext context) {
-		test( context, openSession().thenCompose( session -> session
-				.find( SimpleRecord.class, theRecord.id )
-				.thenAccept( Assertions::assertNotNull ) )
+		test( context, openSession()
+				.thenCompose( session -> session.find( SimpleRecord.class, theRecord.id ) )
+				.thenAccept( Assertions::assertNotNull )
+				.thenAccept( v -> assertThat( sqlTracker.getLoggedQueries() )
+						.as( "Custom @SQLInsert statement was not emitted" )
+						.containsExactly( "SELECT PROC_INSERT_RECORD( $1, $2 );" ) )
 		);
 	}
 
@@ -128,8 +163,14 @@ public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 		test( context, openSession()
 				.thenCompose( session -> session
 						.find( SimpleRecord.class, theRecord.id )
-						.thenAccept( foundRecord -> foundRecord.text = UPDATED_TEXT )
+						.thenAccept( foundRecord -> {
+							sqlTracker.clear();
+							foundRecord.text = UPDATED_TEXT;
+						} )
 						.thenCompose( v -> session.flush() ) )
+				.thenAccept( v -> assertThat( sqlTracker.getLoggedQueries() )
+						.as( "Custom @SQLUpdate statement was not emitted" )
+						.containsExactly( "SELECT PROC_UPDATE_RECORD( $1, $2 );" ) )
 				.thenCompose( v -> openSession() )
 				.thenCompose( session -> session.find( SimpleRecord.class, theRecord.id ) )
 				.thenAccept( foundRecord -> {
@@ -145,8 +186,14 @@ public class CustomStoredProcedureSqlTest extends BaseReactiveTest {
 		test( context, openSession()
 				.thenCompose( session -> session
 						.find( SimpleRecord.class, theRecord.id )
-						.thenCompose( session::remove )
+						.thenCompose( foundRecord -> {
+							sqlTracker.clear();
+							return session.remove( foundRecord );
+						} )
 						.thenCompose( v -> session.flush() ) )
+				.thenAccept( v -> assertThat( sqlTracker.getLoggedQueries() )
+						.as( "Custom @SQLDelete statement was not emitted" )
+						.containsExactly( "SELECT PROC_DELETE_RECORD( $1 );" ) )
 				.thenCompose( v -> openSession() )
 				.thenCompose( session -> session.find( SimpleRecord.class, theRecord.id ) )
 				.thenAccept( foundRecord -> {


### PR DESCRIPTION
## Summary

Fixes https://github.com/hibernate/hibernate-reactive/issues/1673

`CustomStoredProcedureSqlTest` already exercises `@SQLInsert` / `@SQLUpdate` / `@SQLDelete` via stored procedures, but never asserted that Hibernate actually emitted those custom `SELECT PROC_*` statements.

This wires in `SqlStatementTracker` the same way neighboring tests do (`OrderQueriesTestBase`, etc.) and asserts each CRUD path logged the expected `PROC_INSERT_RECORD` / `PROC_UPDATE_RECORD` / `PROC_DELETE_RECORD` call.

Prior attempts: #1709 / #1710 (closed).

## Test plan

- [x] `./gradlew :hibernate-reactive-core:test --tests org.hibernate.reactive.CustomStoredProcedureSqlTest` — 5/5 pass (PostgreSQL / Testcontainers)

Made with [Cursor](https://cursor.com)