### PR TITLE
[4.5] Update CI JDK matrix to test with JDK 27 and JDK 28-ea

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,8 +256,8 @@ jobs:
           # and it's useful to test that.
           - { name: "21", java_version_numeric: 21, jvm_args: '--enable-preview' }
           - { name: "25", java_version_numeric: 25, jvm_args: '--enable-preview' }
-          - { name: "26", java_version_numeric: 26, from: 'jdk.java.net', jvm_args: '--enable-preview' }
-          - { name: "27-ea", java_version_numeric: 27, from: 'jdk.java.net', jvm_args: '--enable-preview' }
+          - { name: "27", java_version_numeric: 27, jvm_args: '--enable-preview' }
+          - { name: "28-ea", java_version_numeric: 28, from: 'jdk.java.net', jvm_args: '--enable-preview' }
     steps:
       - name: Checkout ${{ inputs.branch }}
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
Fix #4026 