### PR TITLE
[4.5] Tune the content of javadoc jars to reduce the size of files published to Maven Central

### DIFF
--- a/publish.gradle
+++ b/publish.gradle
@@ -98,3 +98,15 @@ tasks.register("releasePrepare") {
 	// Create all the published artifacts (i.e. jars) and move them to the staging directory (for JReleaser):
 	dependsOn publishAllPublicationsToStagingRepository
 }
+
+// Reduce the size of per-module javadoc jars published to Maven Central.
+// These options are intentionally NOT in hr-java-library.gradle,
+// so that the aggregated javadoc published to docs.hibernate.org is unaffected.
+tasks.withType(Javadoc).configureEach {
+	exclude '**/spi/**'
+	configure( options ) {
+		addStringOption('-override-methods', 'summary')
+		use = false
+		noTree = true
+	}
+}


### PR DESCRIPTION
* fixes #4071

```
before:
2438156 Aug 11 10:38 hibernate-reactive-core-4.5.2-SNAPSHOT-javadoc.jar

after:
2023306 Aug 11 10:39 hibernate-reactive-core-4.5.2-SNAPSHOT-javadoc.jar
```