### PR TITLE
Serialization of the session operations

### DIFF
--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/Cascade.java
@@ -80,7 +80,7 @@ public final class Cascade {
 					if ( !Hibernate.isInitialized( fetchable ) ) {
 						beforeDelete = beforeDelete.thenCompose( v -> session
 								.unwrap( ReactiveSession.class )
-								.reactiveFetch( fetchable, true )
+								.internalReactiveFetch( fetchable, true )
 						);
 					}
 				}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingActions.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/CascadingActions.java
@@ -63,7 +63,7 @@ public class CascadingActions {
 			final ReactiveSession reactiveSession = session.unwrap( ReactiveSession.class );
 			//TODO: force-fetching it here circumvents the unloaded-delete optimization
 			//      so we don't actually want to do this
-			return reactiveSession.reactiveFetch( child, true )
+			return reactiveSession.internalReactiveFetch( child, true )
 					.thenCompose( c -> reactiveSession.reactiveRemove( entityName, c, isCascadeDeleteEnabled, context ) );
 		}
 	};

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/engine/impl/EntityTypes.java
@@ -267,7 +267,7 @@ public class EntityTypes {
 					// explicitly fetch it here before calling replace(). (Note that in Hibernate
 					// ORM this is unnecessary due to transparent lazy fetching.)
 					return ( (ReactiveQueryProducer) session )
-							.reactiveFetch( id, true )
+							.internalReactiveFetch( id, true )
 							.thenCompose( fetched -> {
 								Object idOrUniqueKey = entityType
 										.getIdentifierOrUniqueKeyType( session.getFactory().getRuntimeMetamodels() )

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveDeleteEventListener.java
@@ -199,7 +199,7 @@ public class DefaultReactiveDeleteEventListener
 
 		//Object entity = persistenceContext.unproxyAndReassociate( event.getObject() );
 		return ( (ReactiveQueryProducer) source )
-				.reactiveFetch( objectEvent, true )
+				.internalReactiveFetch( objectEvent, true )
 				.thenCompose( entity -> delete( event, transientEntities, entity ) );
 
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLoadEventListener.java
@@ -674,7 +674,7 @@ public class DefaultReactiveLoadEventListener implements LoadEventListener, Reac
 				if ( session == null ) {
 					throw LOG.sessionClosedLazyInitializationException();
 				}
-				return ReactiveQueryExecutorLookup.extract( session ).reactiveFetch( entity, false );
+				return ReactiveQueryExecutorLookup.extract( session ).internalReactiveFetch( entity, false );
 			}
 			else {
 				return completedFuture( entity );

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveLockEventListener.java
@@ -76,7 +76,7 @@ public class DefaultReactiveLockEventListener extends DefaultLockEventListener i
 		//TODO: if object was an uninitialized proxy, this is inefficient,
 		//      resulting in two SQL selects
 
-		return ( (ReactiveQueryProducer) source ).reactiveFetch( instance, true )
+		return ( (ReactiveQueryProducer) source ).internalReactiveFetch( instance, true )
 				.thenCompose( entity -> reactiveOnLock( event, entity ) );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveMergeEventListener.java
@@ -329,7 +329,7 @@ public class DefaultReactiveMergeEventListener extends AbstractReactiveSaveEvent
 		final Object clonedIdentifier = persister.getIdentifierType().deepCopy( id, source.getFactory() );
 		return source.getLoadQueryInfluencers()
 				.fromInternalFetchProfile( CascadingFetchProfile.MERGE, () -> source.unwrap( ReactiveSession.class )
-						.reactiveGet( (Class<?>) persister.getMappedClass(), clonedIdentifier )
+						.internalReactiveGet( (Class<?>) persister.getMappedClass(), clonedIdentifier )
 				)
 				.thenCompose( result -> {
 					if ( result == null ) {
@@ -514,7 +514,7 @@ public class DefaultReactiveMergeEventListener extends AbstractReactiveSaveEvent
 			// Initialization must be done before copyValues() executes.
 			return loop( 0, mergeState.length,
 						  i -> Hibernate.isInitialized( mergeState[i] ) && !Hibernate.isInitialized( managedState[i] ),
-						  i -> session.reactiveFetch( managedState[i], true ) )
+						  i -> session.internalReactiveFetch( managedState[i], true ) )
 					.thenCompose( v -> copyValues( persister, entity, target, source, mergeContext ) );
 		}
 	}

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveRefreshEventListener.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/event/impl/DefaultReactiveRefreshEventListener.java
@@ -84,7 +84,7 @@ public class DefaultReactiveRefreshEventListener
 			throw new IllegalArgumentException( "Unmanaged instance passed to refresh()" );
 		}
 		return ( (ReactiveQueryProducer) source )
-				.reactiveFetch( event.getObject(), true )
+				.internalReactiveFetch( event.getObject(), true )
 				.thenCompose( entity -> reactiveOnRefresh( event, refreshedAlready, entity ) );
 	}
 

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/mutiny/impl/MutinySessionImpl.java
@@ -66,6 +66,10 @@ public class MutinySessionImpl implements Mutiny.Session {
 		return factory.uni( stageSupplier );
 	}
 
+	<T> Uni<T> uni(CompletionStage<T> stage) {
+		return Uni.createFrom().completionStage( stage );
+	}
+
 	@Override
 	public Uni<Void> flush() {
 //		checkOpen();
@@ -258,62 +262,62 @@ public class MutinySessionImpl implements Mutiny.Session {
 
 	@Override
 	public Uni<Void> persist(Object entity) {
-		return uni( () -> delegate.reactivePersist( entity ) );
+		return uni( delegate.reactivePersist( entity ) );
 	}
 
 	@Override
 	public Uni<Void> persist(String entityName, Object entity) {
-		return uni( () -> delegate.reactivePersist( entityName, entity ) );
+		return uni( delegate.reactivePersist( entityName, entity ) );
 	}
 
 	@Override
 	public Uni<Void> persistAll(Object... entities) {
-		return uni( () -> applyToAll( delegate::reactivePersist, entities ) );
+		return uni( applyToAll( delegate::reactivePersist, entities ) );
 	}
 
 	@Override
 	public Uni<Void> persistMultiple(List<?> entities) {
-		return uni( () -> applyToAll( delegate::reactivePersist, entities.toArray() ) );
+		return uni( applyToAll( delegate::reactivePersist, entities.toArray() ) );
 	}
 
 	@Override
 	public Uni<Void> remove(Object entity) {
-		return uni( () -> delegate.reactiveRemove( entity ) );
+		return uni( delegate.reactiveRemove( entity ) );
 	}
 
 	@Override
 	public Uni<Void> removeAll(Object... entities) {
-		return uni( () -> applyToAll( delegate::reactiveRemove, entities ) );
+		return uni( applyToAll( delegate::reactiveRemove, entities ) );
 	}
 
 	@Override
 	public Uni<Void> removeMultiple(List<?> entities) {
-		return uni( () -> applyToAll( delegate::reactiveRemove, entities.toArray() ) );
+		return uni( applyToAll( delegate::reactiveRemove, entities.toArray() ) );
 	}
 
 	@Override
 	public <T> Uni<T> merge(T entity) {
-		return uni( () -> delegate.reactiveMerge( entity ) );
+		return uni( delegate.reactiveMerge( entity ) );
 	}
 
 	@Override
 	public final Uni<Void> mergeAll(Object... entities) {
-		return uni( () -> applyToAll( delegate::reactiveMerge, entities ) );
+		return uni( applyToAll( delegate::reactiveMerge, entities ) );
 	}
 
 	@Override
 	public Uni<Void> mergeMultiple(List<?> entities) {
-		return uni( () -> applyToAll( delegate::reactiveMerge, entities.toArray() ) );
+		return uni( applyToAll( delegate::reactiveMerge, entities.toArray() ) );
 	}
 
 	@Override
 	public Uni<Void> refresh(Object entity) {
-		return uni( () -> delegate.reactiveRefresh( entity, LockOptions.NONE ) );
+		return uni( delegate.reactiveRefresh( entity, LockOptions.NONE ) );
 	}
 
 	@Override
 	public Uni<Void> refresh(Object entity, LockMode lockMode) {
-		return uni( () -> delegate.reactiveRefresh( entity, lockMode ) );
+		return uni( delegate.reactiveRefresh( entity, lockMode ) );
 	}
 
 	@Override
@@ -323,22 +327,22 @@ public class MutinySessionImpl implements Mutiny.Session {
 
 	//	@Override
 	public Uni<Void> refresh(Object entity, LockOptions lockOptions) {
-		return uni( () -> delegate.reactiveRefresh( entity, lockOptions ) );
+		return uni( delegate.reactiveRefresh( entity, lockOptions ) );
 	}
 
 	@Override
 	public Uni<Void> refreshAll(Object... entities) {
-		return uni( () -> applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entities ) );
+		return uni( applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entities ) );
 	}
 
 	@Override
 	public Uni<Void> refreshMultiple(List<?> entities) {
-		return uni( () -> applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entities.toArray() ) );
+		return uni( applyToAll( e -> delegate.reactiveRefresh( e, LockOptions.NONE ), entities.toArray() ) );
 	}
 
 	@Override
 	public Uni<Void> lock(Object entity, LockMode lockMode) {
-		return uni( () -> delegate.reactiveLock( entity, lockMode ) );
+		return uni( delegate.reactiveLock( entity, lockMode ) );
 	}
 
 	@Override
@@ -348,7 +352,7 @@ public class MutinySessionImpl implements Mutiny.Session {
 
 	//	@Override
 	public Uni<Void> lock(Object entity, LockOptions lockOptions) {
-		return uni( () -> delegate.reactiveLock( entity, lockOptions ) );
+		return uni( delegate.reactiveLock( entity, lockOptions ) );
 	}
 
 	@Override

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/query/spi/ReactiveAbstractSelectionQuery.java
@@ -34,6 +34,7 @@ import org.hibernate.query.sqm.tree.select.SqmSelectStatement;
 import org.hibernate.reactive.engine.impl.ReactiveCallbackImpl;
 import org.hibernate.reactive.logging.impl.Log;
 import org.hibernate.reactive.logging.impl.LoggerFactory;
+import org.hibernate.reactive.session.ReactiveSession;
 import org.hibernate.reactive.query.sqm.internal.AggregatedSelectReactiveQueryPlan;
 import org.hibernate.reactive.query.sqm.internal.ConcreteSqmSelectReactiveQueryPlan;
 import org.hibernate.reactive.query.sqm.spi.ReactiveSelectQueryPlan;
@@ -158,8 +159,13 @@ public class ReactiveAbstractSelectionQuery<R> {
 				return QueryOptions.NONE;
 			}
 		};
-		return buildConcreteSelectQueryPlan( sqmStatement.createCountQuery(), Long.class, getQueryOptions() )
-				.reactiveExecuteQuery( context, new ReactiveSingleResultConsumer<>() );
+		final Supplier<CompletionStage<Long>> operation = () ->
+				buildConcreteSelectQueryPlan( sqmStatement.createCountQuery(), Long.class, getQueryOptions() )
+						.reactiveExecuteQuery( context, new ReactiveSingleResultConsumer<>() );
+		if ( session instanceof ReactiveSession reactiveSession ) {
+			return reactiveSession.serialized( operation );
+		}
+		return operation.get();
 	}
 
 	private R reactiveSingleResult(List<R> list) {
@@ -197,7 +203,7 @@ public class ReactiveAbstractSelectionQuery<R> {
 	public CompletionStage<List<R>> reactiveList() {
 		final var profiles = applyProfiles();
 		return beforeQuery.get()
-				.thenCompose( v -> doReactiveList() )
+				.thenCompose( v -> serializedDoReactiveList() )
 				.handle( (list, error) -> {
 					handleException( error );
 					return list;
@@ -206,6 +212,13 @@ public class ReactiveAbstractSelectionQuery<R> {
 					afterQuery.accept( throwable == null );
 					unapplyProfiles( profiles );
 				} );
+	}
+
+	private CompletionStage<List<R>> serializedDoReactiveList() {
+		if ( session instanceof ReactiveSession reactiveSession ) {
+			return reactiveSession.serialized( this::doReactiveList );
+		}
+		return doReactiveList();
 	}
 
 	private void unapplyProfiles(HashSet<String> profiles) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveQueryProducer.java
@@ -42,6 +42,10 @@ public interface ReactiveQueryProducer extends ReactiveConnectionSupplier {
 
 	<T> CompletionStage<T> reactiveFetch(T association, boolean unproxy);
 
+	default <T> CompletionStage<T> internalReactiveFetch(T association, boolean unproxy) {
+		return reactiveFetch( association, unproxy );
+	}
+
 	CompletionStage<Object> reactiveInternalLoad(String entityName, Object id, boolean eager, boolean nullable);
 
 	<T> EntityGraph<T> createEntityGraph(Class<T> entity);

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/ReactiveSession.java
@@ -7,6 +7,7 @@ package org.hibernate.reactive.session;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
+import java.util.function.Supplier;
 
 import org.hibernate.CacheMode;
 import org.hibernate.Filter;
@@ -90,6 +91,10 @@ public interface ReactiveSession extends ReactiveQueryProducer, ReactiveSharedSe
 
 	<T> CompletionStage<T> reactiveGet(Class<T> entityClass, Object id);
 
+	default <T> CompletionStage<T> internalReactiveGet(Class<T> entityClass, Object id) {
+		return reactiveGet( entityClass, id );
+	}
+
 	<T> CompletionStage<T> reactiveFind(Class<T> entityClass, Object id, LockOptions lockOptions, EntityGraph<T> fetchGraph);
 
 	default <T> CompletionStage<T> reactiveFind(Class<T> entityClass, Object id){
@@ -154,6 +159,8 @@ public interface ReactiveSession extends ReactiveQueryProducer, ReactiveSharedSe
 
 	boolean isDirty();
 	boolean isOpen();
+
+	<T> CompletionStage<T> serialized(Supplier<CompletionStage<T>> operation);
 
 	// Different approach so that we can overload the method in SessionImpl
 	CompletionStage<Void> reactiveClose();

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveSessionImpl.java
@@ -164,6 +164,7 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	private transient final ReactiveActionQueue reactiveActionQueue = new ReactiveActionQueue( this );
 	private ReactiveConnection reactiveConnection;
 	private final Thread associatedWorkThread;
+	private CompletionStage<Void> previousOperation = voidFuture();
 
 	public ReactiveSessionImpl(SessionFactoryImpl delegate, SessionCreationOptions options, ReactiveConnection connection) {
 		super( delegate, options );
@@ -195,6 +196,14 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	private void threadCheck() {
 		InternalStateAssertions.assertCurrentThreadMatches( associatedWorkThread );
+	}
+
+	@Override
+	public <T> CompletionStage<T> serialized(Supplier<CompletionStage<T>> operation) {
+		final CompletionStage<T> result = previousOperation
+				.thenCompose( ignored -> operation.get() );
+		previousOperation = result.handle( (v, e) -> null );
+		return result;
 	}
 
 	@Override
@@ -311,6 +320,15 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 	//Note: when making changes to this method, please also consider
 	//      the similar code in Mutiny.fetch() and Stage.fetch()
 	public <T> CompletionStage<T> reactiveFetch(T association, boolean unproxy) {
+		return serialized( () -> doReactiveFetch( association, unproxy ) );
+	}
+
+	@Override
+	public <T> CompletionStage<T> internalReactiveFetch(T association, boolean unproxy) {
+		return doReactiveFetch( association, unproxy );
+	}
+
+	private <T> CompletionStage<T> doReactiveFetch(T association, boolean unproxy) {
 		checkOpen();
 		if ( association == null ) {
 			return nullFuture();
@@ -362,20 +380,22 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public <E, T> CompletionStage<T> reactiveFetch(E entity, Attribute<E, T> field) {
-		final ReactiveEntityPersister entityPersister = (ReactiveEntityPersister) getEntityPersister( null, entity );
-		LazyAttributeLoadingInterceptor lazyAttributeLoadingInterceptor = entityPersister.getBytecodeEnhancementMetadata()
-				.extractInterceptor( entity );
-		final String attributeName = field.getName();
-		if ( !lazyAttributeLoadingInterceptor.isAttributeLoaded( attributeName ) ) {
-			return ( (CompletionStage<T>) lazyAttributeLoadingInterceptor.fetchAttribute( entity, field.getName() ) )
-					.thenApply( value -> {
-						lazyAttributeLoadingInterceptor.attributeInitialized( attributeName );
-						return value;
-					} );
-		}
-		else {
-			return completedFuture( (T) entityPersister.getPropertyValue( entity, attributeName ) );
-		}
+		return serialized( () -> {
+			final ReactiveEntityPersister entityPersister = (ReactiveEntityPersister) getEntityPersister( null, entity );
+			LazyAttributeLoadingInterceptor lazyAttributeLoadingInterceptor = entityPersister.getBytecodeEnhancementMetadata()
+					.extractInterceptor( entity );
+			final String attributeName = field.getName();
+			if ( !lazyAttributeLoadingInterceptor.isAttributeLoaded( attributeName ) ) {
+				return ((CompletionStage<T>) lazyAttributeLoadingInterceptor.fetchAttribute( entity, field.getName() ))
+						.thenApply( value -> {
+							lazyAttributeLoadingInterceptor.attributeInitialized( attributeName );
+							return value;
+						} );
+			}
+			else {
+				return completedFuture( (T) entityPersister.getPropertyValue( entity, attributeName ) );
+			}
+		} );
 	}
 
 	@Override
@@ -857,14 +877,18 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactivePersist(Object entity) {
-		checkOpen();
-		return firePersist( new PersistEvent( null, entity, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return firePersist( new PersistEvent( null, entity, this ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactivePersist(String entityName, Object entity) {
-		checkOpen();
-		return firePersist( new PersistEvent( entityName, entity, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return firePersist( new PersistEvent( entityName, entity, this ) );
+		} );
 	}
 
 	@Override
@@ -927,8 +951,10 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactiveRemove(Object entity) {
-		checkOpen();
-		return fireRemove( new DeleteEvent( entity, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return fireRemove( new DeleteEvent( entity, this ) );
+		} );
 	}
 
 	@Override
@@ -995,8 +1021,10 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public <T> CompletionStage<T> reactiveMerge(T object) throws HibernateException {
-		checkOpen();
-		return fireMerge( new MergeEvent( null, object, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return fireMerge( new MergeEvent( null, object, this ) );
+		} );
 	}
 
 	@Override
@@ -1057,13 +1085,17 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactiveFlush() {
-		checkOpen();
-		return doFlush();
+		return serialized( () -> {
+			checkOpen();
+			return doFlush();
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveAutoflush() {
-		return getHibernateFlushMode().lessThan( FlushMode.COMMIT ) ? voidFuture() : doFlush();
+		return serialized( () ->
+				getHibernateFlushMode().lessThan( FlushMode.COMMIT ) ? voidFuture() : doFlush()
+		);
 	}
 
 	@Override
@@ -1125,8 +1157,10 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactiveRefresh(Object entity, LockOptions lockOptions) {
-		checkOpen();
-		return fireRefresh( new RefreshEvent( entity, lockOptions, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return fireRefresh( new RefreshEvent( entity, lockOptions, this ) );
+		} );
 	}
 
 	@Override
@@ -1190,8 +1224,10 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactiveLock(Object object, LockOptions lockOptions) {
-		checkOpen();
-		return fireLock( new LockEvent( object, lockOptions, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return fireLock( new LockEvent( object, lockOptions, this ) );
+		} );
 	}
 
 	@Override
@@ -1201,8 +1237,10 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public CompletionStage<Void> reactiveLock(String entityName, Object object, LockOptions lockOptions) {
-		checkOpen();
-		return fireLock( new LockEvent( entityName, object, lockOptions, this ) );
+		return serialized( () -> {
+			checkOpen();
+			return fireLock( new LockEvent( entityName, object, lockOptions, this ) );
+		} );
 	}
 
 	private CompletionStage<Void> fireLock(LockEvent event) {
@@ -1222,6 +1260,15 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public <T> CompletionStage<T> reactiveGet(Class<T> entityClass, Object id) {
+		return serialized( () -> doReactiveGet( entityClass, id ) );
+	}
+
+	@Override
+	public <T> CompletionStage<T> internalReactiveGet(Class<T> entityClass, Object id) {
+		return doReactiveGet( entityClass, id );
+	}
+
+	private <T> CompletionStage<T> doReactiveGet(Class<T> entityClass, Object id) {
 		return reactiveById( entityClass ).load( id );
 	}
 
@@ -1239,25 +1286,27 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 			Object id,
 			LockOptions lockOptions,
 			EntityGraph<T> fetchGraph) {
-		checkOpen();
-		return supplyStage( () -> {
-			if ( fetchGraph != null ) {
-				getLoadQueryInfluencers()
-						.getEffectiveEntityGraph()
-						.applyGraph( (RootGraphImplementor<T>) fetchGraph, GraphSemantic.FETCH );
-			}
-			getLoadQueryInfluencers().setReadOnly( readOnlyHint( null ) );
+		return serialized( () -> {
+			checkOpen();
+			return supplyStage( () -> {
+				if ( fetchGraph != null ) {
+					getLoadQueryInfluencers()
+							.getEffectiveEntityGraph()
+							.applyGraph( (RootGraphImplementor<T>) fetchGraph, GraphSemantic.FETCH );
+				}
+				getLoadQueryInfluencers().setReadOnly( readOnlyHint( null ) );
 
-			return reactiveById( entityClass )
-					.with( determineAppropriateLocalCacheMode( null ) )
-					.with( lockOptions )
-					.load( id );
-		} ).handle( CompletionStages::handle )
-				.thenCompose( handler -> handleReactiveFindException( entityClass, id, lockOptions, handler ) )
-				.whenComplete( (v, e) -> {
-					getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
-					getLoadQueryInfluencers().setReadOnly( null );
-				} );
+				return reactiveById( entityClass )
+						.with( determineAppropriateLocalCacheMode( null ) )
+						.with( lockOptions )
+						.load( id );
+			} ).handle( CompletionStages::handle )
+					.thenCompose( handler -> handleReactiveFindException( entityClass, id, lockOptions, handler ) )
+					.whenComplete( (v, e) -> {
+						getLoadQueryInfluencers().getEffectiveEntityGraph().clear();
+						getLoadQueryInfluencers().setReadOnly( null );
+					} );
+		} );
 	}
 
 	@Override
@@ -1320,16 +1369,18 @@ public class ReactiveSessionImpl extends SessionImpl implements ReactiveSession,
 
 	@Override
 	public <T> CompletionStage<List<T>> reactiveFind(Class<T> entityClass, Object... ids) {
-		return new ReactiveMultiIdentifierLoadAccessImpl<>( entityClass ).multiLoad( ids );
+		return serialized( () -> new ReactiveMultiIdentifierLoadAccessImpl<>( entityClass ).multiLoad( ids ) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> reactiveFind(Class<T> entityClass, Map<String, Object> ids) {
-		final ReactiveEntityPersister persister = entityPersister( entityClass );
-		final Object normalizedIdValues = persister.getNaturalIdMapping().normalizeInput( ids );
-		return new NaturalIdLoadAccessImpl<T>( this, persister, requireEntityPersister( entityClass ) )
-				.resolveNaturalId( normalizedIdValues )
-				.thenCompose( id -> reactiveFind( entityClass, id ) );
+		return serialized( () -> {
+			final ReactiveEntityPersister persister = entityPersister( entityClass );
+			final Object normalizedIdValues = persister.getNaturalIdMapping().normalizeInput( ids );
+			return new NaturalIdLoadAccessImpl<T>( this, persister, requireEntityPersister( entityClass ) )
+					.resolveNaturalId( normalizedIdValues )
+					.thenCompose( id -> reactiveById( entityClass ).load( id ) );
+		} );
 	}
 
 	private <T> ReactiveEntityPersister entityPersister(Class<T> entityClass) {

--- a/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
+++ b/hibernate-reactive-core/src/main/java/org/hibernate/reactive/session/impl/ReactiveStatelessSessionImpl.java
@@ -133,6 +133,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 	private final ReactiveStatelessSessionImpl batchingHelperSession;
 	private final PersistenceContext persistenceContext;
 	private final boolean connectionProvided;
+	private CompletionStage<Void> previousOperation = voidFuture();
 
 	public ReactiveStatelessSessionImpl(SessionFactoryImpl factory, SessionCreationOptions options, ReactiveConnection connection) {
 		super( factory, options );
@@ -186,6 +187,13 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 		// FIXME: We should check the threads like we do in ReactiveSessionImpl
 	}
 
+	private <T> CompletionStage<T> serialized(Supplier<CompletionStage<T>> operation) {
+		final CompletionStage<T> result = previousOperation
+				.thenCompose( ignored -> operation.get() );
+		previousOperation = result.handle( (v, e) -> null );
+		return result;
+	}
+
 	@Override
 	public Dialect getDialect() {
 		return getJdbcServices().getDialect();
@@ -213,39 +221,41 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public <T> CompletionStage<T> reactiveGet(Class<T> entityClass, Object id) {
-		return reactiveGet( entityClass.getName(), id, LockMode.NONE, null );
+		return serialized( () -> doReactiveGet( entityClass.getName(), id, LockMode.NONE, null ) );
 	}
 
 	@Override
 	public <T> CompletionStage<List<T>> reactiveGet(Class<T> entityClass, Object... ids) {
-		checkOpen();
-		for (Object id : ids) {
-			if ( id == null ) {
-				return failedFuture( new IllegalArgumentException( "Null id" ) );
+		return serialized( () -> {
+			checkOpen();
+			for ( Object id : ids ) {
+				if ( id == null ) {
+					return failedFuture( new IllegalArgumentException( "Null id" ) );
+				}
 			}
-		}
 
-		Object[] sids = new Object[ids.length];
-		System.arraycopy( ids, 0, sids, 0, ids.length );
+			Object[] sids = new Object[ids.length];
+			System.arraycopy( ids, 0, sids, 0, ids.length );
 
-		return getEntityPersister( entityClass.getName() )
-				.reactiveMultiLoad( sids, this, StatelessSessionImpl.MULTI_ID_LOAD_OPTIONS )
-				.whenComplete( (list, e) -> {
-					if ( getPersistenceContext().isLoadFinished() ) {
-						getPersistenceContext().clear();
-					}
-				} )
-				.thenApply( list -> (List<T>) list );
+			return getEntityPersister( entityClass.getName() )
+					.reactiveMultiLoad( sids, this, StatelessSessionImpl.MULTI_ID_LOAD_OPTIONS )
+					.whenComplete( (list, e) -> {
+						if ( getPersistenceContext().isLoadFinished() ) {
+							getPersistenceContext().clear();
+						}
+					} )
+					.thenApply( list -> (List<T>) list );
+		} );
 	}
 
 	@Override
 	public <T> CompletionStage<T> reactiveGet(String entityName, Object id) {
-		return reactiveGet( entityName, id, LockMode.NONE, null );
+		return serialized( () -> doReactiveGet( entityName, id, LockMode.NONE, null ) );
 	}
 
 	@Override
 	public <T> CompletionStage<T> reactiveGet(Class<T> entityClass, Object id, LockMode lockMode, EntityGraph<T> fetchGraph) {
-		return reactiveGet( entityClass.getName(), id, lockMode, fetchGraph );
+		return serialized( () -> doReactiveGet( entityClass.getName(), id, lockMode, fetchGraph ) );
 	}
 
 	@Override
@@ -255,6 +265,10 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public <T> CompletionStage<T> reactiveGet(String entityName, Object id, LockMode lockMode, EntityGraph<T> fetchGraph) {
+		return serialized( () -> doReactiveGet( entityName, id, lockMode, fetchGraph ) );
+	}
+
+	private <T> CompletionStage<T> doReactiveGet(String entityName, Object id, LockMode lockMode, EntityGraph<T> fetchGraph) {
 		checkOpen();
 
 		// differs from core, because core doesn't let us pass an EntityGraph
@@ -295,18 +309,20 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public CompletionStage<Void> reactiveInsert(Object entity) {
-		checkOpen();
-		final ReactiveEntityPersister persister = getEntityPersister( null, entity );
-		final Object[] state = persister.getValues( entity );
-		return reactiveInsert( entity, state, persister )
-				.thenCompose( id -> recreateCollections( entity, id, persister ) )
-				.thenAccept( id -> {
-					firePostInsert( entity, id, state, persister );
-					final StatisticsImplementor statistics = getFactory().getStatistics();
-					if ( statistics.isStatisticsEnabled() ) {
-						statistics.insertEntity( persister.getEntityName() );
-					}
-				} );
+		return serialized( () -> {
+			checkOpen();
+			final ReactiveEntityPersister persister = getEntityPersister( null, entity );
+			final Object[] state = persister.getValues( entity );
+			return reactiveInsert( entity, state, persister )
+					.thenCompose( id -> recreateCollections( entity, id, persister ) )
+					.thenAccept( id -> {
+						firePostInsert( entity, id, state, persister );
+						final StatisticsImplementor statistics = getFactory().getStatistics();
+						if ( statistics.isStatisticsEnabled() ) {
+							statistics.insertEntity( persister.getEntityName() );
+						}
+					} );
+		} );
 	}
 
 	private static class Loop {
@@ -453,35 +469,35 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public CompletionStage<Void> reactiveDelete(Object entity) {
-		checkOpen();
-		final ReactiveEntityPersister persister = getEntityPersister( null, entity );
-		final Object id = persister.getIdentifier( entity, this );
-		final Object version = persister.getVersion( entity );
-		if ( firePreDelete( entity, id, persister ) ) {
-			return voidFuture();
-		}
+		return serialized( () -> {
+			checkOpen();
+			final ReactiveEntityPersister persister = getEntityPersister( null, entity );
+			final Object id = persister.getIdentifier( entity, this );
+			final Object version = persister.getVersion( entity );
+			if ( firePreDelete( entity, id, persister ) ) {
+				return voidFuture();
+			}
 
-		getInterceptor().onDelete( entity, id, persister.getPropertyNames(), persister.getPropertyTypes() );
-		return removeCollections( entity, id, persister )
-				.thenCompose( v -> {
-					final Object ck = lockCacheItem( id, version, persister );
-					final EventMonitor eventMonitor = getEventMonitor();
-					final DiagnosticEvent event = eventMonitor.beginEntityDeleteEvent();
-					// try-block
-					return supplyStage( () -> persister.deleteReactive( id, version, entity, this ) )
-							// finally-block
-							.whenComplete( (unused, throwable) -> eventMonitor
-									.completeEntityDeleteEvent( event, id, persister.getEntityName(), throwable != null, this )
-							)
-							.thenAccept( unused -> removeCacheItem( ck, persister ) );
-				} )
-				.thenAccept( v -> {
-					firePostDelete( entity, id, persister );
-					final StatisticsImplementor statistics = getFactory().getStatistics();
-					if ( statistics.isStatisticsEnabled() ) {
-						statistics.deleteEntity( persister.getEntityName() );
-					}
-				} );
+			getInterceptor().onDelete( entity, id, persister.getPropertyNames(), persister.getPropertyTypes() );
+			return removeCollections( entity, id, persister )
+					.thenCompose( v -> {
+						final Object ck = lockCacheItem( id, version, persister );
+						final EventMonitor eventMonitor = getEventMonitor();
+						final DiagnosticEvent event = eventMonitor.beginEntityDeleteEvent();
+						return supplyStage( () -> persister.deleteReactive( id, version, entity, this ) )
+								.whenComplete( (unused, throwable) -> eventMonitor
+										.completeEntityDeleteEvent( event, id, persister.getEntityName(), throwable != null, this )
+								)
+								.thenAccept( unused -> removeCacheItem( ck, persister ) );
+					} )
+					.thenAccept( v -> {
+						firePostDelete( entity, id, persister );
+						final StatisticsImplementor statistics = getFactory().getStatistics();
+						if ( statistics.isStatisticsEnabled() ) {
+							statistics.deleteEntity( persister.getEntityName() );
+						}
+					} );
+		} );
 	}
 
 	private CompletionStage<Void> removeCollections(Object entity, Object id, EntityPersister persister) {
@@ -518,15 +534,17 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public CompletionStage<Void> reactiveUpdate(Object entity) {
-		checkOpen();
-		if ( entity instanceof HibernateProxy proxy ) {
-			final LazyInitializer hibernateLazyInitializer = proxy.getHibernateLazyInitializer();
-			return hibernateLazyInitializer.isUninitialized()
-					? failedFuture( LOG.uninitializedProxyUpdate( entity.getClass() ) )
-					: executeReactiveUpdate( hibernateLazyInitializer.getImplementation() );
-		}
+		return serialized( () -> {
+			checkOpen();
+			if ( entity instanceof HibernateProxy proxy ) {
+				final LazyInitializer hibernateLazyInitializer = proxy.getHibernateLazyInitializer();
+				return hibernateLazyInitializer.isUninitialized()
+						? failedFuture( LOG.uninitializedProxyUpdate( entity.getClass() ) )
+						: executeReactiveUpdate( hibernateLazyInitializer.getImplementation() );
+			}
 
-		return executeReactiveUpdate( entity );
+			return executeReactiveUpdate( entity );
+		} );
 	}
 
 	/**
@@ -607,15 +625,15 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public CompletionStage<Void> reactiveRefresh(Object entity) {
-		return reactiveRefresh( bestGuessEntityName( entity ), entity, LockMode.NONE );
+		return serialized( () -> doReactiveRefresh( bestGuessEntityName( entity ), entity, LockMode.NONE ) );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveRefresh(Object entity, LockMode lockMode) {
-		return reactiveRefresh( bestGuessEntityName( entity ), entity, lockMode );
+		return serialized( () -> doReactiveRefresh( bestGuessEntityName( entity ), entity, lockMode ) );
 	}
 
-	private CompletionStage<Void> reactiveRefresh(String entityName, Object entity, LockMode lockMode) {
+	private CompletionStage<Void> doReactiveRefresh(String entityName, Object entity, LockMode lockMode) {
 		checkOpen();
 		final ReactiveEntityPersister persister = getEntityPersister( entityName, entity );
 		final Object id = persister.getIdentifier( entity, this );
@@ -655,105 +673,118 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 	 */
 	@Override
 	public CompletionStage<Void> reactiveUpsert(Object entity) {
-		checkOpen();
-		final ReactiveEntityPersister persister = getEntityPersister( null, entity );
-		final Object id = idToUpsert( entity, persister );
-		final Object[] state = persister.getValues( entity );
-		if ( firePreUpsert( entity, id, state, persister ) ) {
-			return voidFuture();
-		}
-		getInterceptor().onUpsert( entity, id, state, persister.getPropertyNames(), persister.getPropertyTypes() );
-		final Object oldVersion = versionToUpsert( entity, persister, state );
-		final Object ck = lockCacheItem( id, oldVersion, persister );
-		final EventMonitor eventMonitor = getEventMonitor();
-		final DiagnosticEvent event = eventMonitor.beginEntityUpsertEvent();
-		return supplyStage( () -> persister
-				.mergeReactive( id, state, null, false, null, oldVersion, entity, null, this ) )
-				.whenComplete( (v, throwable) -> eventMonitor
-						.completeEntityUpsertEvent( event, id, persister.getEntityName(), throwable != null, this )
-				)
-				.thenAccept( v -> {
-					removeCacheItem( ck, persister );
-					final StatisticsImplementor statistics = getFactory().getStatistics();
-					if ( statistics.isStatisticsEnabled() ) {
-						statistics.upsertEntity( persister.getEntityName() );
+		return serialized( () -> {
+			checkOpen();
+			final ReactiveEntityPersister persister = getEntityPersister( null, entity );
+			final Object id = idToUpsert( entity, persister );
+			final Object[] state = persister.getValues( entity );
+			if ( firePreUpsert( entity, id, state, persister ) ) {
+				return voidFuture();
+			}
+			getInterceptor().onUpsert( entity, id, state, persister.getPropertyNames(), persister.getPropertyTypes() );
+			final Object oldVersion = versionToUpsert( entity, persister, state );
+			final Object ck = lockCacheItem( id, oldVersion, persister );
+			final EventMonitor eventMonitor = getEventMonitor();
+			final DiagnosticEvent event = eventMonitor.beginEntityUpsertEvent();
+			return supplyStage( () -> persister
+					.mergeReactive( id, state, null, false, null, oldVersion, entity, null, this ) )
+					.whenComplete( (v, throwable) -> eventMonitor
+							.completeEntityUpsertEvent( event, id, persister.getEntityName(), throwable != null, this )
+					)
+					.thenAccept( v -> {
+						removeCacheItem( ck, persister );
+						final StatisticsImplementor statistics = getFactory().getStatistics();
+						if ( statistics.isStatisticsEnabled() ) {
+							statistics.upsertEntity( persister.getEntityName() );
 					}
 				} )
 				.thenCompose( v -> removeAndRecreateCollections( entity, id, persister ) )
 				.thenAccept( v -> firePostUpsert( entity, id, state, persister ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveUpsertAll(int batchSize, Object... entities) {
-		final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
-		batchingHelperSession.setJdbcBatchSize( batchSize );
-		final ReactiveConnection connection = batchingConnection( batchSize );
-		return loop( entities, batchingHelperSession::reactiveUpsert )
-				.thenCompose( v -> connection.executeBatch() )
-				.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		return serialized( () -> {
+			final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
+			batchingHelperSession.setJdbcBatchSize( batchSize );
+			final ReactiveConnection connection = batchingConnection( batchSize );
+			return loop( entities, batchingHelperSession::reactiveUpsert )
+					.thenCompose( v -> connection.executeBatch() )
+					.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveInsertAll(Object... entities) {
-		return loop( entities, batchingHelperSession::reactiveInsert )
-				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() );
+		return serialized( () -> loop( entities, batchingHelperSession::reactiveInsert )
+				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() ) );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveInsertAll(int batchSize, Object... entities) {
-		final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
-		batchingHelperSession.setJdbcBatchSize( batchSize );
-		final ReactiveConnection connection = batchingConnection( batchSize );
-		return loop( entities, batchingHelperSession::reactiveInsert )
-				.thenCompose( v -> connection.executeBatch() )
-				.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		return serialized( () -> {
+			final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
+			batchingHelperSession.setJdbcBatchSize( batchSize );
+			final ReactiveConnection connection = batchingConnection( batchSize );
+			return loop( entities, batchingHelperSession::reactiveInsert )
+					.thenCompose( v -> connection.executeBatch() )
+					.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveUpdateAll(Object... entities) {
-		return loop( entities, batchingHelperSession::reactiveUpdate )
-				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() );
+		return serialized( () -> loop( entities, batchingHelperSession::reactiveUpdate )
+				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() ) );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveUpdateAll(int batchSize, Object... entities) {
-		final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
-		batchingHelperSession.setJdbcBatchSize( batchSize );
-		final ReactiveConnection connection = batchingConnection( batchSize );
-		return loop( entities, batchingHelperSession::reactiveUpdate )
-				.thenCompose( v -> connection.executeBatch() )
-				.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		return serialized( () -> {
+			final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
+			batchingHelperSession.setJdbcBatchSize( batchSize );
+			final ReactiveConnection connection = batchingConnection( batchSize );
+			return loop( entities, batchingHelperSession::reactiveUpdate )
+					.thenCompose( v -> connection.executeBatch() )
+					.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveDeleteAll(Object... entities) {
-		return loop( entities, batchingHelperSession::reactiveDelete )
-				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() );
+		return serialized( () -> loop( entities, batchingHelperSession::reactiveDelete )
+				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() ) );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveDeleteAll(int batchSize, Object... entities) {
-		final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
-		batchingHelperSession.setJdbcBatchSize( batchSize );
-		final ReactiveConnection connection = batchingConnection( batchSize );
-		return loop( entities, batchingHelperSession::reactiveDelete ).thenCompose( v -> connection.executeBatch() )
-				.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		return serialized( () -> {
+			final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
+			batchingHelperSession.setJdbcBatchSize( batchSize );
+			final ReactiveConnection connection = batchingConnection( batchSize );
+			return loop( entities, batchingHelperSession::reactiveDelete )
+					.thenCompose( v -> connection.executeBatch() )
+					.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		} );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveRefreshAll(Object... entities) {
-		return loop( entities, batchingHelperSession::reactiveRefresh )
-				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() );
+		return serialized( () -> loop( entities, batchingHelperSession::reactiveRefresh )
+				.thenCompose( v -> batchingHelperSession.getReactiveConnection().executeBatch() ) );
 	}
 
 	@Override
 	public CompletionStage<Void> reactiveRefreshAll(int batchSize, Object... entities) {
-		final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
-		batchingHelperSession.setJdbcBatchSize( batchSize );
-		final ReactiveConnection connection = batchingConnection( batchSize );
-		return loop( entities, batchingHelperSession::reactiveRefresh )
-				.thenCompose( v -> connection.executeBatch() )
-				.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		return serialized( () -> {
+			final Integer jdbcBatchSize = batchingHelperSession.getJdbcBatchSize();
+			batchingHelperSession.setJdbcBatchSize( batchSize );
+			final ReactiveConnection connection = batchingConnection( batchSize );
+			return loop( entities, batchingHelperSession::reactiveRefresh )
+					.thenCompose( v -> connection.executeBatch() )
+					.whenComplete( (v, throwable) -> batchingHelperSession.setJdbcBatchSize( jdbcBatchSize ) );
+		} );
 	}
 
 	private ReactiveConnection batchingConnection(int batchSize) {
@@ -775,7 +806,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 			throw new SessionException( "proxies cannot be fetched by a stateless session" );
 		}
 		// unless we are still in the process of handling a top-level load
-		return reactiveGet( entityName, id );
+		return doReactiveGet( entityName, id, LockMode.NONE, null );
 	}
 
 	@Override
@@ -785,7 +816,7 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 		// IMPLEMENTATION NOTE: increment/decrement the load count before/after getting the value
 		//                      to ensure that #get does not clear the PersistenceContext.
 		persistenceContext.beforeLoad();
-		return this.reactiveGet( entityName, id )
+		return this.doReactiveGet( entityName, id, LockMode.NONE, null )
 				.whenComplete( (r, e) -> persistenceContext.afterLoad() );
 	}
 
@@ -829,7 +860,19 @@ public class ReactiveStatelessSessionImpl extends StatelessSessionImpl implement
 
 	@Override
 	public <T> CompletionStage<T> reactiveFetch(T association, boolean unproxy) {
+		return serialized( () -> {
+			checkOpen();
+			return doReactiveFetch( association, unproxy );
+		} );
+	}
+
+	@Override
+	public <T> CompletionStage<T> internalReactiveFetch(T association, boolean unproxy) {
 		checkOpen();
+		return doReactiveFetch( association, unproxy );
+	}
+
+	private <T> CompletionStage<T> doReactiveFetch(T association, boolean unproxy) {
 		if ( association == null ) {
 			return nullFuture();
 		}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InternalStateAssertionsTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/InternalStateAssertionsTest.java
@@ -87,9 +87,9 @@ public class InternalStateAssertionsTest extends BaseReactiveTest {
 		ThreadPerCommandExecutor executor = new ThreadPerCommandExecutor();
 
 		test( testContext, assertThrown( IllegalStateException.class, sessionUni
+				.emitOn( executor )
 				.call( session -> session
-						.persist( new Competition( "Cheese Rolling" ) )
-						.runSubscriptionOn( executor ) ) )
+						.persist( new Competition( "Cheese Rolling" ) ) ) )
 				.invoke( InternalStateAssertionsTest::assertException )
 		);
 	}

--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SessionOperationSerializationTest.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/SessionOperationSerializationTest.java
@@ -1,0 +1,504 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ * Copyright Red Hat Inc. and Hibernate Authors
+ */
+package org.hibernate.reactive;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import org.hibernate.Hibernate;
+import org.hibernate.reactive.annotations.EnabledFor;
+
+import org.junit.jupiter.api.Test;
+
+import io.smallrye.mutiny.Uni;
+import io.vertx.junit5.Timeout;
+import io.vertx.junit5.VertxTestContext;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+
+import static java.util.concurrent.TimeUnit.MINUTES;
+import static org.hibernate.reactive.containers.DatabaseConfiguration.DBType.POSTGRESQL;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Timeout(value = 10, timeUnit = MINUTES)
+@EnabledFor(POSTGRESQL)
+public class SessionOperationSerializationTest extends BaseReactiveTest {
+
+	private static final int ENTITY_COUNT = 100;
+
+	@Override
+	protected Collection<Class<?>> annotatedEntities() {
+		return List.of( SimpleEntity.class, Author.class, Book.class );
+	}
+
+	@Test
+	public void testConcurrentPersistWithStages(VertxTestContext context) {
+		test( context, getSessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				s.persist( new SimpleEntity( "entity-" + i ) );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return s.flush()
+					.thenCompose( $ -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity", Long.class
+					).getSingleResult() )
+					.thenAccept( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Test
+	public void testConcurrentPersistWithMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				s.persist( new SimpleEntity( "entity-" + i ) );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return s.flush()
+					.chain( () -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity", Long.class
+					).getSingleResult() )
+					.invoke( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Test
+	public void testAllOfWithStages(VertxTestContext context) {
+		test( context, getSessionFactory().withSession( s -> {
+			CompletableFuture<?>[] futures = new CompletableFuture[ENTITY_COUNT];
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				futures[i] = s.persist( new SimpleEntity( "entity-" + i ) )
+						.toCompletableFuture();
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return CompletableFuture.allOf( futures )
+					.thenCompose( $ -> s.flush() )
+					.thenCompose( $ -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity", Long.class
+					).getSingleResult() )
+					.thenAccept( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Test
+	public void testCombineAllWithMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withSession( s -> {
+			List<Uni<Void>> unis = new ArrayList<>();
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				unis.add( s.persist( new SimpleEntity( "entity-" + i ) ) );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return Uni.combine().all().unis( unis ).discardItems()
+					.call( s::flush )
+					.chain( () -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity", Long.class
+					).getSingleResult() )
+					.invoke( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Test
+	public void testCascadingPersistWithStages(VertxTestContext context) {
+		test( context, getSessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				Author author = new Author( "cascade-stage-" + i );
+				author.addBook( new Book( "cs-book-" + i + "-a" ) );
+				author.addBook( new Book( "cs-book-" + i + "-b" ) );
+				s.persist( author );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return s.flush()
+					.thenCompose( v -> s.createSelectionQuery(
+							"select count(*) from SSAuthor where name like 'cascade-stage-%'", Long.class
+					).getSingleResult() )
+					.thenAccept( count -> assertEquals( ENTITY_COUNT, count.intValue() ) );
+		} ) );
+	}
+
+	@Test
+	public void testCascadingPersistWithMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				Author author = new Author( "cascade-mutiny-" + i );
+				author.addBook( new Book( "cm-book-" + i + "-a" ) );
+				author.addBook( new Book( "cm-book-" + i + "-b" ) );
+				s.persist( author );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+			}
+			return s.flush()
+					.chain( () -> s.createSelectionQuery(
+							"select count(*) from SSAuthor where name like 'cascade-mutiny-%'", Long.class
+					).getSingleResult() )
+					.invoke( count -> assertEquals( ENTITY_COUNT, count.intValue() ) );
+		} ) );
+	}
+
+	@Test
+	public void testFetchLazyCollectionWithStages(VertxTestContext context) {
+		Author author = new Author( "fetch-stage-author" );
+		for ( int i = 0; i < 10; i++ ) {
+			author.addBook( new Book( "fetch-stage-book-" + i ) );
+		}
+		test( context, getSessionFactory()
+				.withSession( s -> s.persist( author ).thenCompose( $ -> s.flush() ) )
+				.thenCompose( $ -> getSessionFactory().withSession( s ->
+						s.find( Author.class, author.id )
+								.thenCompose( found -> {
+									assertNotNull( found );
+									assertFalse( Hibernate.isInitialized( found.books ) );
+									s.fetch( found.books );
+									s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+									return s.flush()
+											.thenAccept( v -> {
+												assertTrue( Hibernate.isInitialized( found.books ) );
+												assertEquals( 10, found.books.size() );
+											} );
+								} )
+				) )
+		);
+	}
+
+	@Test
+	public void testFetchLazyCollectionWithMutiny(VertxTestContext context) {
+		Author author = new Author( "fetch-mutiny-author" );
+		for ( int i = 0; i < 10; i++ ) {
+			author.addBook( new Book( "fetch-mutiny-book-" + i ) );
+		}
+		test( context, getMutinySessionFactory()
+				.withSession( s -> s.persist( author ).call( s::flush ) )
+				.chain( () -> getMutinySessionFactory().withSession( s ->
+						s.find( Author.class, author.id )
+								.chain( found -> {
+									assertNotNull( found );
+									assertFalse( Hibernate.isInitialized( found.books ) );
+									return s.fetch( found.books )
+											.invoke( books -> assertEquals( 10, books.size() ) );
+								} )
+				) )
+		);
+	}
+
+	@Test
+	public void testRemoveWithCascadeStages(VertxTestContext context) {
+		test( context, getSessionFactory()
+				.withSession( s -> {
+					for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+						Author author = new Author( "remove-author-" + i );
+						author.addBook( new Book( "remove-book-" + i + "-a" ) );
+						author.addBook( new Book( "remove-book-" + i + "-b" ) );
+						s.persist( author );
+					}
+					return s.flush();
+				} )
+				.thenCompose( $ -> getSessionFactory().withSession( s ->
+						s.createSelectionQuery( "from SSAuthor", Author.class ).getResultList()
+								.thenCompose( authors -> {
+									for ( Author a : authors ) {
+										s.remove( a );
+										s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+									}
+									return s.flush();
+								} )
+								.thenCompose( $2 -> s.createSelectionQuery(
+										"select count(*) from SSAuthor", Long.class
+								).getSingleResult() )
+								.thenAccept( count -> assertEquals(
+										0L, count,
+										"All authors should be removed"
+								) )
+								.thenCompose( $2 -> s.createSelectionQuery(
+										"select count(*) from SSBook", Long.class
+								).getSingleResult() )
+								.thenAccept( count -> assertEquals(
+										0L, count,
+										"All books should be cascade-removed"
+								) )
+				) )
+		);
+	}
+
+	@Test
+	public void testRemoveWithCascadeMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory()
+				.withSession( s -> {
+					for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+						Author author = new Author( "remove-author-" + i );
+						author.addBook( new Book( "remove-book-" + i + "-a" ) );
+						author.addBook( new Book( "remove-book-" + i + "-b" ) );
+						s.persist( author );
+					}
+					return s.flush();
+				} )
+				.chain( () -> getMutinySessionFactory().withSession( s ->
+						s.createSelectionQuery( "from SSAuthor", Author.class ).getResultList()
+								.chain( authors -> {
+									for ( Author a : authors ) {
+										s.remove( a );
+										s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+									}
+									return s.flush();
+								} )
+								.chain( () -> s.createSelectionQuery(
+										"select count(*) from SSAuthor", Long.class
+								).getSingleResult() )
+								.invoke( count -> assertEquals(
+										0L, count,
+										"All authors should be removed"
+								) )
+								.chain( () -> s.createSelectionQuery(
+										"select count(*) from SSBook", Long.class
+								).getSingleResult() )
+								.invoke( count -> assertEquals(
+										0L, count,
+										"All books should be cascade-removed"
+								) )
+				) )
+		);
+	}
+
+	@Test
+	public void testMergeWithCollectionModificationStages(VertxTestContext context) {
+		Author author = new Author( "merge-author" );
+		author.addBook( new Book( "original-book" ) );
+		test( context, getSessionFactory()
+				.withSession( s -> s.persist( author ).thenCompose( $ -> s.flush() ) )
+				.thenCompose( $ -> getSessionFactory().withSession( s -> {
+					author.name = "updated-author";
+					author.addBook( new Book( "new-book-1" ) );
+					author.addBook( new Book( "new-book-2" ) );
+					s.merge( author );
+					s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+					return s.flush();
+				} ) )
+				.thenCompose( $ -> getSessionFactory().withSession( s ->
+						s.find( Author.class, author.id )
+								.thenCompose( found -> s.fetch( found.books )
+										.thenAccept( books -> {
+											assertEquals( "updated-author", found.name );
+											assertEquals( 3, books.size() );
+										} )
+								)
+				) )
+		);
+	}
+
+	@Test
+	public void testMergeWithCollectionModificationMutiny(VertxTestContext context) {
+		Author author = new Author( "merge-author" );
+		author.addBook( new Book( "original-book" ) );
+		test( context, getMutinySessionFactory()
+				.withSession( s -> s.persist( author ).call( s::flush ) )
+				.chain( () -> getMutinySessionFactory().withSession( s -> {
+					author.name = "updated-author";
+					author.addBook( new Book( "new-book-1" ) );
+					author.addBook( new Book( "new-book-2" ) );
+					s.merge( author );
+					s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+					return s.flush();
+				} ) )
+				.chain( () -> getMutinySessionFactory().withSession( s ->
+						s.find( Author.class, author.id )
+								.chain( found -> s.fetch( found.books )
+										.invoke( books -> {
+											assertEquals( "updated-author", found.name );
+											assertEquals( 3, books.size() );
+										} )
+								)
+				) )
+		);
+	}
+
+	@Test
+	public void testConcurrentQueriesWithStages(VertxTestContext context) {
+		test( context, getSessionFactory()
+				.withSession( s -> {
+					for ( int i = 0; i < 10; i++ ) {
+						s.persist( new SimpleEntity( "query-stage-" + i ) );
+					}
+					return s.flush();
+				} )
+				.thenCompose( $ -> getSessionFactory().withSession( s -> {
+					CompletableFuture<?>[] futures = new CompletableFuture[ENTITY_COUNT];
+					for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+						if ( i % 3 == 0 ) {
+							futures[i] = s.createSelectionQuery(
+									"from SimpleEntity where name like 'query-stage-%'", SimpleEntity.class
+							).getResultList().toCompletableFuture();
+						}
+						else if ( i % 3 == 1 ) {
+							futures[i] = s.createNativeQuery(
+									"select * from simple_entity where name like 'query-stage-%'"
+							).getResultList().toCompletableFuture();
+						}
+						else {
+							futures[i] = s.createSelectionQuery(
+									"select count(*) from SimpleEntity where name like 'query-stage-%'", Long.class
+							).getSingleResult().toCompletableFuture();
+						}
+					}
+					return CompletableFuture.allOf( futures );
+				} ) )
+		);
+	}
+
+	@Test
+	public void testConcurrentQueriesWithMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory()
+				.withSession( s -> {
+					for ( int i = 0; i < 10; i++ ) {
+						s.persist( new SimpleEntity( "query-mutiny-" + i ) );
+					}
+					return s.flush();
+				} )
+				.chain( () -> getMutinySessionFactory().withSession( s -> {
+					List<Uni<?>> unis = new ArrayList<>();
+					for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+						if ( i % 3 == 0 ) {
+							unis.add( s.createSelectionQuery(
+									"from SimpleEntity where name like 'query-mutiny-%'", SimpleEntity.class
+							).getResultList() );
+						}
+						else if ( i % 3 == 1 ) {
+							unis.add( s.createNativeQuery(
+									"select * from simple_entity where name like 'query-mutiny-%'"
+							).getResultList() );
+						}
+						else {
+							unis.add( s.createSelectionQuery(
+									"select count(*) from SimpleEntity where name like 'query-mutiny-%'", Long.class
+							).getSingleResult() );
+						}
+					}
+					return Uni.combine().all().unis( unis ).discardItems();
+				} ) )
+		);
+	}
+
+	@Test
+	public void testMixedPersistAndQueriesWithStages(VertxTestContext context) {
+		test( context, getSessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				s.persist( new SimpleEntity( "mixed-stage-" + i ) );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+				s.createSelectionQuery(
+						"select count(*) from SimpleEntity where name like 'mixed-stage-%'", Long.class
+				).getSingleResult();
+			}
+			return s.flush()
+					.thenCompose( v -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity where name like 'mixed-stage-%'", Long.class
+					).getSingleResult() )
+					.thenAccept( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Test
+	public void testMixedPersistAndQueriesWithMutiny(VertxTestContext context) {
+		test( context, getMutinySessionFactory().withSession( s -> {
+			for ( int i = 0; i < ENTITY_COUNT; i++ ) {
+				s.persist( new SimpleEntity( "mixed-mutiny-" + i ) );
+				s.createNativeQuery( "select pg_sleep(0.001)" ).getResultList();
+				s.createSelectionQuery(
+						"select count(*) from SimpleEntity where name like 'mixed-mutiny-%'", Long.class
+				).getSingleResult();
+			}
+			return s.flush()
+					.chain( () -> s.createSelectionQuery(
+							"select count(*) from SimpleEntity where name like 'mixed-mutiny-%'", Long.class
+					).getSingleResult() )
+					.invoke( count -> assertEquals(
+							(long) ENTITY_COUNT, count,
+							"All persisted entities should be in the database"
+					) );
+		} ) );
+	}
+
+	@Entity(name = "SimpleEntity")
+	@Table(name = "SIMPLE_ENTITY")
+	static class SimpleEntity {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		String name;
+
+		SimpleEntity() {
+		}
+
+		SimpleEntity(String name) {
+			this.name = name;
+		}
+	}
+
+	@Entity(name = "SSAuthor")
+	@Table(name = "SS_AUTHOR")
+	static class Author {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		String name;
+
+		@OneToMany(cascade = CascadeType.ALL, fetch = FetchType.LAZY, mappedBy = "author")
+		List<Book> books = new ArrayList<>();
+
+		Author() {
+		}
+
+		Author(String name) {
+			this.name = name;
+		}
+
+		void addBook(Book book) {
+			books.add( book );
+			book.author = this;
+		}
+	}
+
+	@Entity(name = "SSBook")
+	@Table(name = "SS_BOOK")
+	static class Book {
+		@Id
+		@GeneratedValue
+		Long id;
+
+		String title;
+
+		@ManyToOne(fetch = FetchType.LAZY)
+		Author author;
+
+		Book() {
+		}
+
+		Book(String title) {
+			this.title = title;
+		}
+	}
+}


### PR DESCRIPTION
A first draft for #2494 

This solution is built on top of `main` but I'm wondering if we shouldn't include after or with the upgrade to ORM 8.0

The approach is the one suggested in the issue: operations get concatenated when they get called on the session.

I might need to clean it up a little bit, but it should be ready for a first review.

Thanks