### PR TITLE
[3.4] Update SchemaUpdateCockroachDBTestBase

### DIFF
--- a/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateCockroachDBTestBase.java
+++ b/hibernate-reactive-core/src/test/java/org/hibernate/reactive/schema/SchemaUpdateCockroachDBTestBase.java
@@ -160,10 +160,10 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.setParameter( 1, "asimple" )
 												.getResultList()
 												.thenAccept( list -> Assertions.assertThat( list ).containsExactlyInAnyOrder(
-														"CREATE INDEX i_asimple_avalue_astringvalue ON postgres.public.asimple USING btree (avalue ASC, astringvalue DESC)",
-														"CREATE INDEX i_asimple_avalue_data ON postgres.public.asimple USING btree (avalue DESC, data ASC)",
-														"CREATE UNIQUE INDEX asimple_pkey ON postgres.public.asimple USING btree (id ASC)",
-														"CREATE UNIQUE INDEX u_asimple_astringvalue ON postgres.public.asimple USING btree (astringvalue ASC)"
+														"CREATE INDEX i_asimple_avalue_astringvalue ON public.asimple USING btree (avalue ASC, astringvalue DESC)",
+														"CREATE INDEX i_asimple_avalue_data ON public.asimple USING btree (avalue DESC, data ASC)",
+														"CREATE UNIQUE INDEX asimple_pkey ON public.asimple USING btree (id ASC)",
+														"CREATE UNIQUE INDEX u_asimple_astringvalue ON public.asimple USING btree (astringvalue ASC)"
 												) )
 										)
 										.thenCompose( v -> s.createNativeQuery( indexDefinitionQuery, String.class )
@@ -171,7 +171,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.getSingleResult()
 												.thenAccept( result ->
 																	 assertEquals(
-																			 "CREATE UNIQUE INDEX aother_pkey ON postgres.public.aother USING btree (id1 ASC, id2 ASC)",
+																			 "CREATE UNIQUE INDEX aother_pkey ON public.aother USING btree (id1 ASC, id2 ASC)",
 																			 result
 																	 )
 												)
@@ -181,7 +181,7 @@ public abstract class SchemaUpdateCockroachDBTestBase extends BaseReactiveTest {
 												.getSingleResult()
 												.thenAccept( result ->
 																	 assertEquals(
-																			 "CREATE UNIQUE INDEX aanother_pkey ON postgres.public.aanother USING btree (id ASC)",
+																			 "CREATE UNIQUE INDEX aanother_pkey ON public.aanother USING btree (id ASC)",
 																			 result
 																	 )
 												)


### PR DESCRIPTION
This test checks the queries during schema creation fro CockroachDB. After the upgrade to ORM 7.4.5.Final (from 7.4.4.Final), the queries for the creation of the indexes during schema updates don't add the prefix postgres. (the catalog, I think) to the table name during the creation of the index.

For example, this query

```
CREATE UNIQUE INDEX asimple_pkey ON postgres.public.asimple USING btree (id ASC)
```

becomes in ORM 7.4.5.Final

```
CREATE UNIQUE INDEX asimple_pkey ON public.asimple USING btree (id ASC)
```